### PR TITLE
Modifying namelist character types to not have two layers of quotes.

### DIFF
--- a/namelist.input.ocean
+++ b/namelist.input.ocean
@@ -1,17 +1,17 @@
 &time_management
 	config_do_restart = .false.
-	config_start_time = '0000-01-01_00:00:00'
-	config_stop_time = 'none'
-	config_run_duration = '0_06:00:00'
-	config_calendar_type = '360day'
+	config_start_time = "0000-01-01_00:00:00"
+	config_stop_time = "none"
+	config_run_duration = "0_06:00:00"
+	config_calendar_type = "360day"
 /
 &io
-	config_input_name = 'grid.nc'
-	config_output_name = 'output.nc'
-	config_restart_name = 'restart.nc'
-	config_restart_interval = '0_06:00:00'
-	config_output_interval = '0_06:00:00'
-	config_stats_interval = '0_01:00:00'
+	config_input_name = "grid.nc"
+	config_output_name = "output.nc"
+	config_restart_name = "restart.nc"
+	config_restart_interval = "0_06:00:00"
+	config_output_interval = "0_06:00:00"
+	config_stats_interval = "0_01:00:00"
 	config_write_stats_on_startup = .true.
 	config_write_output_on_startup = .true.
 	config_frames_per_outfile = 1000
@@ -20,20 +20,20 @@
 /
 &time_integration
 	config_dt = 3000.0
-	config_time_integrator = 'split_explicit'
+	config_time_integrator = "split_explicit"
 /
 &grid
 	config_num_halos = 3
-	config_vert_coord_movement = 'uniform_stretching'
-	config_alter_ICs_for_pbcs = 'zlevel_pbcs_off'
+	config_vert_coord_movement = "uniform_stretching"
+	config_alter_ICs_for_pbcs = "zlevel_pbcs_off"
 	config_min_pbc_fraction = 0.10
 	config_check_ssh_consistency = .true.
 /
 &decomposition
-	config_block_decomp_file_prefix = 'graph.info.part.'
+	config_block_decomp_file_prefix = "graph.info.part."
 	config_number_of_blocks = 0
 	config_explicit_proc_decomp = .false.
-	config_proc_decomp_file_prefix = 'graph.info.part.'
+	config_proc_decomp_file_prefix = "graph.info.part."
 /
 &hmix
 	config_hmix_ScaleWithMesh = .false.
@@ -102,7 +102,7 @@
 	config_restoreS_timescale = 90.0
 /
 &advection
-	config_vert_tracer_adv = 'stencil'
+	config_vert_tracer_adv = "stencil"
 	config_vert_tracer_adv_order = 3
 	config_horiz_tracer_adv_order = 3
 	config_coef_3rd_order = 0.25
@@ -112,11 +112,11 @@
 	config_bottom_drag_coeff = 1.0e-3
 /
 &pressure_gradient
-	config_pressure_gradient_type = 'pressure_and_zmid'
+	config_pressure_gradient_type = "pressure_and_zmid"
 	config_density0 = 1014.65
 /
 &eos
-	config_eos_type = 'jm'
+	config_eos_type = "jm"
 /
 &eos_linear
 	config_eos_linear_alpha = 2.55e-1

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -49,45 +49,45 @@
 		            description="Determines if the initial conditions should be read from a restart file, or an input file."
 		            possible_values=".true. or .false."
 		/>
-		<nml_option name="config_start_time" type="character" default_value="'0000-01-01_00:00:00'" units="unitless"
+		<nml_option name="config_start_time" type="character" default_value="0000-01-01_00:00:00" units="unitless"
 		            description="Timestamp describing the initial time of the simulation. If it is set to 'file', the initial time is read from restart_timestamp."
 		            possible_values="'YYYY-MM-DD_HH:MM:SS' or 'file'"
 		/>
-		<nml_option name="config_stop_time" type="character" default_value="'none'" units="unitless"
+		<nml_option name="config_stop_time" type="character" default_value="none" units="unitless"
 		            description="Timestamp descriping the final time of the simulation. If it is set to 'none' the final time is determined from config_start_time and config_run_duration."
 		            possible_values="'YYYY-MM-DD_HH:MM:SS' or 'none'"
 		/>
-		<nml_option name="config_run_duration" type="character" default_value="'0_06:00:00'" units="unitless"
+		<nml_option name="config_run_duration" type="character" default_value="0_06:00:00" units="unitless"
 		            description="Timestamp describing the length of the simulation. If it is set to 'none' the duraction is determined from config_start_time and config_stop_time. config_run_duration overrides inconsistent values of config_stop_time."
 		            possible_values="'DDDD_HH:MM:SS' or 'none'"
 		/>
-		<nml_option name="config_calendar_type" type="character" default_value="'360day'" units="unitless"
+		<nml_option name="config_calendar_type" type="character" default_value="360day" units="unitless"
 		            description="Selection of the type of calendar that should be used in the simulation."
 		            possible_values="'gregorian', 'gregorian_noleap', or '360day'"
 		/>
 	</nml_record>
 	<nml_record name="io">
-		<nml_option name="config_input_name" type="character" default_value="'grid.nc'" units=""
+		<nml_option name="config_input_name" type="character" default_value="grid.nc" units=""
 		            description=""
 		            possible_values=""
 		/>
-		<nml_option name="config_output_name" type="character" default_value="'output.nc'" units=""
+		<nml_option name="config_output_name" type="character" default_value="output.nc" units=""
 		            description=""
 		            possible_values=""
 		/>
-		<nml_option name="config_restart_name" type="character" default_value="'restart.nc'" units=""
+		<nml_option name="config_restart_name" type="character" default_value="restart.nc" units=""
 		            description=""
 		            possible_values=""
 		/>
-		<nml_option name="config_restart_interval" type="character" default_value="'0_06:00:00'" units=""
+		<nml_option name="config_restart_interval" type="character" default_value="0_06:00:00" units=""
 		            description=""
 		            possible_values=""
 		/>
-		<nml_option name="config_output_interval" type="character" default_value="'0_06:00:00'" units=""
+		<nml_option name="config_output_interval" type="character" default_value="0_06:00:00" units=""
 		            description=""
 		            possible_values=""
 		/>
-		<nml_option name="config_stats_interval" type="character" default_value="'0_01:00:00'" units=""
+		<nml_option name="config_stats_interval" type="character" default_value="0_01:00:00" units=""
 		            description=""
 		            possible_values=""
 		/>
@@ -117,7 +117,7 @@
 		            description="Length of model time-step."
 		            possible_values="Any positive real value, but limited by CFL condition."
 		/>
-		<nml_option name="config_time_integrator" type="character" default_value="'split_explicit'" units="unitless"
+		<nml_option name="config_time_integrator" type="character" default_value="split_explicit" units="unitless"
 		            description="Time integration method."
 		            possible_values="'split_explicit', 'RK4', 'unsplit_explicit'"
 		/>
@@ -127,11 +127,11 @@
 		            description="Determines the number of halo cells extending from a blocks owned cells (Called the 0-Halo). The default of 3 is the minimum that can be used with monotonic advection."
 		            possible_values="Any positive interger value."
 		/>
-		<nml_option name="config_vert_coord_movement" type="character" default_value="'uniform_stretching'" units="unitless"
+		<nml_option name="config_vert_coord_movement" type="character" default_value="uniform_stretching" units="unitless"
 		            description="Determines the vertical coordinate movement type. 'uniform_stretching' distrubtes SSH perturbations through all vertical levels, 'fixed' places them all in the top level, 'user_specified' allows the input file to determine the distribution, and 'isopycnal' causes levels to be pure isopycnal."
 		            possible_values="'uniform_stretching', 'fixed', 'user_specified', 'isopycnal'"
 		/>
-		<nml_option name="config_alter_ICs_for_pbcs" type="character" default_value="'zlevel_pbcs_off'" units="unitless"
+		<nml_option name="config_alter_ICs_for_pbcs" type="character" default_value="zlevel_pbcs_off" units="unitless"
 		            description="Determines the method of alteration for partial bottom cells. 'zlevel_pbcs_on' alters the initial conditions for partial bottom cells, 'zlevel_pbcs_off' alters the initial conditions to have full cells everwhere, and 'off' does nothing to the initial conditions."
 		            possible_values="'zlevel_pbcs_on', 'zlevel_pbcs_off', 'off'"
 		/>
@@ -145,7 +145,7 @@
 		/>
 	</nml_record>
 	<nml_record name="decomposition">
-		<nml_option name="config_block_decomp_file_prefix" type="character" default_value="'graph.info.part.'" units="unitless"
+		<nml_option name="config_block_decomp_file_prefix" type="character" default_value="graph.info.part." units="unitless"
 		            description="Defines the prefix for the block decomposition file. Can include a path. The number of blocks is appended to the end of the prefix at run-time."
 					possible_values="Any path/prefix to a block decomposition file."
 		/>
@@ -157,7 +157,7 @@
 		            description="Determines if an explicit processor decomposition should be used. This is only useful if multiple blocks per processor are used."
 		            possible_values=".true. or .false."
 		/>
-		<nml_option name="config_proc_decomp_file_prefix" type="character" default_value="'graph.info.part.'" units="unitless"
+		<nml_option name="config_proc_decomp_file_prefix" type="character" default_value="graph.info.part." units="unitless"
 		            description="Defines the prefix for the processor decomposition file. This file is only read if config_explicit_proc_decomp is .true. The number of processors is appended to the end of the prefix at run-time."
 					possible_values="Any path/prefix to a processor decomposition file."
 		/>
@@ -361,7 +361,7 @@
 		/>
 	</nml_record>
 	<nml_record name="advection">
-		<nml_option name="config_vert_tracer_adv" type="character" default_value="'stencil'" units="unitless"
+		<nml_option name="config_vert_tracer_adv" type="character" default_value="stencil" units="unitless"
 		            description="Method for interpolating tracer values from layer centers to layer edges"
 		            possible_values="'spline' and 'stencil'"
 		/>
@@ -389,7 +389,7 @@
 		/>
 	</nml_record>
 	<nml_record name="pressure_gradient">
-		<nml_option name="config_pressure_gradient_type" type="character" default_value="'pressure_and_zmid'" units="unitless"
+		<nml_option name="config_pressure_gradient_type" type="character" default_value="pressure_and_zmid" units="unitless"
 		            description="Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential."
 		            possible_values="'pressure_and_zmid' or 'MontgomeryPotential'"
 		/>
@@ -399,7 +399,7 @@
 		/>
 	</nml_record>
 	<nml_record name="eos">
-		<nml_option name="config_eos_type" type="character" default_value="'jm'" units="unitless"
+		<nml_option name="config_eos_type" type="character" default_value="jm" units="unitless"
 		            description="Character string to choose EOS formulation"
 		            possible_values="Jackett McDougall EOS = 'jm' and Linear EOS = 'linear'"
 		/>


### PR DESCRIPTION
Previously the default generated versions of namelist files (in
src/framework/mpas_configure.f90) couldn't be used with the model.

This only affects the ocean core.
