### PR TITLE
OCEAN: Removal/Cleanup of variables

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -684,21 +684,6 @@
 		<var name="normalVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" streams="o" units="m s^{-1}"
 		     description="component of horizontal velocity in the northward"
 		/>
-		<var name="normalVelocityForcingReconstructX" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
-		     description="wind stress in the x-direction (cartesian)"
-		/>
-		<var name="normalVelocityForcingReconstructY" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
-		     description="wind stress in the y-direction (cartesian)"
-		/>
-		<var name="normalVelocityForcingReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
-		     description="wind stress in the z-direction (cartesian)"
-		/>
-		<var name="normalVelocityForcingReconstructZonal" type="real" dimensions="nVertLevels nCells Time" streams="o" units="N m^{-2}"
-		     description="wind stress in the eastward direction"
-		/>
-		<var name="normalVelocityForcingReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" streams="o" units="N m^{-2}"
-		     description="wind stress in the northward direction"
-		/>
 		<var name="montgomeryPotential" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-2}"
 		     description="Montgomery potential, may be used as the pressure for isopycnal coordinates."
 		/>
@@ -1023,7 +1008,7 @@
 		     description="Pressure defined at the sea surface."
 		/>
 	</var_struct>
-	<var_struct name="tend" time_levs="1">
+	<var_struct name="tend" time_levs="0">
 		<var_array name="tracers" type="real" dimensions="nVertLevels nCells Time">
 			<var name="tend_temperature" array_group="dynamics" units="K s^{-1}" name_in_code="temperature"
 			     description="time tendency of potential temperature"
@@ -1042,7 +1027,7 @@
 		     description="time tendency of sea-surface height"
 		/>
 	</var_struct>
-	<var_struct name="diagnostics" time_levs="1">
+	<var_struct name="diagnostics" time_levs="0">
 		<var name="RiTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="nondimensional"
 		     description="gradient Richardson number defined at the center (horizontally) and top (vertically)"
 		/>
@@ -1055,5 +1040,28 @@
 		<var name="vertDiffTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 		     description="vertical diffusion defined at the edge (horizontally) and top (vertically)"
 		/>
+        <var name="windStressZonal" type="real" dimensions="nCells Time" streams="o" units="N m^{-2}"
+             description="reconstructed surface wind stress in the eastward direction."
+        />
+        <var name="windStressMeridional" type="real" dimensions="nCells Time" streams="o" units="N m^{-2}"
+             description="reconstructed surface wind stress in the northward direction."
+        />
 	</var_struct>
+    <var_struct name="scratch" time_levs="0">
+        <var name="normalVelocityForcingX" persistence="scratch" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+		     description="reconstructed wind stress in the x-direction (cartesian)"
+		/>
+		<var name="normalVelocityForcingY" persistence="scratch" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+		     description="reconstructed wind stress in the y-direction (cartesian)"
+		/>
+		<var name="normalVelocityForcingZ" persistence="scratch" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+		     description="reconstructed wind stress in the z-direction (cartesian)"
+		/>
+		<var name="normalVelocityForcingZonal" persistence="scratch" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+		     description="reconstructed wind stress in the eastward direction"
+		/>
+		<var name="normalVelocityForcingMeridional" persistence="scratch" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+		     description="reconstructed wind stress in the northward direction"
+		/>
+    </var_struct>
 </registry>

--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -287,14 +287,6 @@ module mpas_core
                        block % state % time_levs(1) % state % normalVelocityMeridional % array    &
                       )
 
-      call mpas_reconstruct(mesh, mesh % normalVelocityForcing % array,                  &
-                       block % state % time_levs(1) % state % normalVelocityForcingReconstructX % array,            &
-                       block % state % time_levs(1) % state % normalVelocityForcingReconstructY % array,            &
-                       block % state % time_levs(1) % state % normalVelocityForcingReconstructZ % array,            &
-                       block % state % time_levs(1) % state % normalVelocityForcingReconstructZonal % array,        &
-                       block % state % time_levs(1) % state % normalVelocityForcingReconstructMeridional % array    &
-                      )
-
       ! initialize velocities and tracers on land to be zero.
 
       block % mesh % areaCell % array(block % mesh % nCells+1) = -1.0e34
@@ -435,6 +427,7 @@ module mpas_core
    
       use mpas_grid_types
       use mpas_io_output
+      use mpas_vector_reconstruction
    
       implicit none
    
@@ -446,9 +439,32 @@ module mpas_core
       integer :: eoe
       type (block_type), pointer :: block_ptr
    
+      ! Compute output diagnostics
       block_ptr => domain % blocklist
       do while (associated(block_ptr))
          call ocn_compute_output_diagnostics(block_ptr % state % time_levs(1) % state, block_ptr % mesh)
+
+         call mpas_allocate_scratch_field(block_ptr % scratch % normalVelocityForcingX, .true.)
+         call mpas_allocate_scratch_field(block_ptr % scratch % normalVelocityForcingY, .true.)
+         call mpas_allocate_scratch_field(block_ptr % scratch % normalVelocityForcingZ, .true.)
+         call mpas_allocate_scratch_field(block_ptr % scratch % normalVelocityForcingZonal, .true.)
+         call mpas_allocate_scratch_field(block_ptr % scratch % normalVelocityForcingMeridional, .true.)
+
+         call mpas_reconstruct(block_ptr % mesh, block_ptr % mesh % normalVelocityForcing % array, &
+                               block_ptr % scratch % normalVelocityForcingX % array, &
+                               block_ptr % scratch % normalVelocityForcingY % array, &
+                               block_ptr % scratch % normalVelocityForcingZ % array, &
+                               block_ptr % scratch % normalVelocityForcingZonal % array, &
+                               block_ptr % scratch % normalVelocityForcingMeridional % array)
+
+         block_ptr % diagnostics % windStressZonal % array = block_ptr % scratch % normalVelocityForcingZonal % array(1,:)
+         block_ptr % diagnostics % windStressMeridional % array = block_ptr % scratch % normalVelocityForcingMeridional % array(1,:)
+         call mpas_deallocate_scratch_field(block_ptr % scratch % normalVelocityForcingX, .true.)
+         call mpas_deallocate_scratch_field(block_ptr % scratch % normalVelocityForcingY, .true.)
+         call mpas_deallocate_scratch_field(block_ptr % scratch % normalVelocityForcingZ, .true.)
+         call mpas_deallocate_scratch_field(block_ptr % scratch % normalVelocityForcingZonal, .true.)
+         call mpas_deallocate_scratch_field(block_ptr % scratch % normalVelocityForcingMeridional, .true.)
+
          block_ptr => block_ptr % next
       end do
    

--- a/src/core_ocean/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mpas_ocn_time_integration_rk4.F
@@ -312,14 +312,6 @@ module ocn_time_integration_rk4
                           block % state % time_levs(2) % state % normalVelocityMeridional % array    &
                          )
 
-         call mpas_reconstruct(block % mesh, block % mesh % normalVelocityForcing % array,          &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructX % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructY % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructZ % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructZonal % array,        &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructMeridional % array    &
-                         )
-
          call ocn_time_average_accumulate(block % state % time_levs(2) % state, block % state % time_levs(1) % state)
 
          block => block % next

--- a/src/core_ocean/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mpas_ocn_time_integration_split.F
@@ -975,14 +975,6 @@ module ocn_time_integration_split
                           block % state % time_levs(2) % state % normalVelocityMeridional % array    &
                          )
 
-         call mpas_reconstruct(block % mesh, block % mesh % normalVelocityForcing % array,          &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructX % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructY % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructZ % array,            &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructZonal % array,        &
-                          block % state % time_levs(2) % state % normalVelocityForcingReconstructMeridional % array    &
-                         )
-
          call ocn_time_average_accumulate(block % state % time_levs(2) % state, block % state % time_levs(1) % state)
 
          block => block % next


### PR DESCRIPTION
The ocean/variable_cleanup branch includes the following changes:

Removal of the following variables:
hZLevel
tracer1
vh

Creating of a scratch var_struct in registry with no time levels.
Setting time_levs on diagnostics and tend to be 0.

Moving the reconstructed forcing fields into the scratch structure, and only allocating them right before a call to mpas_reconstruct. Then deallocating them after they are done being used.

Also, moving the mpas_reconstruct calls for the forcing fields from each time integration routine to mpas_ocn_mpas_core.F when a frame is being written to an output file. 

Only the surface forcing fields are written out to windStressZonal and windStressMeridional. These fields are defined in the diagnostics structure.
