### PR TITLE
adding config_maxMeshDensity

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -167,6 +167,10 @@
 		            description="If false, del2 and del4 coefficients are constant throughout the mesh (equivalent to setting $\rho_m=1$ throughout the mesh).  If true, these coefficients scale as mesh density to the -3/4 power."
 		            possible_values=".true. or .false."
 		/>
+                 <nml_option name="config_maxMeshDensity" type="real" default_value="-1.0" units="unitless"
+                            description="Global maximum of the mesh density"
+                            possible_values="Any positive real number. If set any negative real number, config_maxMeshDensity is computed during the initialization of each simulation."
+                />
 		<nml_option name="config_visc_vorticity_term" type="logical" default_value=".true." units="unitless"
 		            description="{\color{red} TO BE DELETED}"
 		            possible_values=".true. or .false."

--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -62,6 +62,7 @@ module mpas_core
       type (dm_info) :: dminfo
 
       integer :: err, err_tmp
+      real (kind=RKIND) :: maxDensity, maxDensity_global
 
       ! Initialize submodules before initializing blocks.
       call ocn_timestep_init(err)
@@ -147,6 +148,18 @@ module mpas_core
          write (0,*) 'filter_btr_mode has only been tested with'// &
             ' config_vert_coord_movement=fixed.'
          call mpas_dmpar_abort(dminfo)
+      endif
+
+      ! find the maximum value of the meshDensity
+      if (config_maxMeshDensity < 0.0) then
+        maxDensity=-1
+        block => domain % blocklist
+        do while (associated(block))
+          maxDensity = max(maxDensity, maxval(block % mesh % meshDensity % array))
+          block => block % next
+        end do
+        call mpas_dmpar_max_real(domain % dminfo, maxDensity, maxDensity_global)
+        config_maxMeshDensity = maxDensity_global
       endif
 
       !
@@ -1012,9 +1025,9 @@ end subroutine ocn_compute_max_level!}}}
          do iEdge=1,mesh%nEdges
             cell1 = mesh % cellsOnEdge % array(1,iEdge)
             cell2 = mesh % cellsOnEdge % array(2,iEdge)
-            meshScalingDel2(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**(3.0/4.0)  ! goes as dc**3
-            meshScalingDel4(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**(3.0/4.0)  ! goes as dc**3
-            meshScaling(iEdge)     = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**(1.0/4.0)
+            meshScalingDel2(iEdge) = 1.0 / ( ((meshDensity(cell1) + meshDensity(cell2) )/2.0)/config_maxMeshDensity)**(3.0/4.0)  ! goes as dc**3
+            meshScalingDel4(iEdge) = 1.0 / ( ((meshDensity(cell1) + meshDensity(cell2) )/2.0)/config_maxMeshDensity)**(3.0/4.0)  ! goes as dc**3
+            meshScaling(iEdge)     = 1.0 / ( ((meshDensity(cell1) + meshDensity(cell2) )/2.0)/config_maxMeshDensity)**(1.0/4.0)
          end do
       end if
 


### PR DESCRIPTION
This pull request fixes a bug in the ocean model that assumed the maximum mesh density was 1.0.

.......

if config_maxMeshDensity set to number  < 0, value is computed at init

meshDensity is normalized to 1.0 when used to compute scaling for del2, del4 and Leith
