### PR TITLE
ALL: Adding new executable path to ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ src/operators/*.f90
 *.a
 
 # Executables
-*.exe
+*_model
 src/registry/parse
 
 # NetCDF Files


### PR DESCRIPTION
Executable changed from *.exe to _model. This change is reflected in the
.gitignore file now.
