### PR TITLE
OCEAN: Fixing tracer loop in split explicit.

### DIFF
--- a/src/core_ocean/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mpas_ocn_time_integration_split.F
@@ -85,7 +85,7 @@ module ocn_time_integration_split
       type (dm_info) :: dminfo
       integer :: iCell, i,k,j, iEdge, cell1, cell2, split_explicit_step, split, &
                  eoe, oldBtrSubcycleTime, newBtrSubcycleTime, uPerpTime, BtrCorIter, &
-                 n_bcl_iter(config_n_ts_iter), stage1_tend_time
+                 n_bcl_iter(config_n_ts_iter), stage1_tend_time, startIndex, endIndex
       type (block_type), pointer :: block
       real (kind=RKIND) :: normalThicknessFluxSum, thicknessSum, flux, sshEdge, hEdge1, &
                  CoriolisTerm, uCorr, temp, temp_h, coef, barotropicThicknessFlux_coeff, sshCell1, sshCell2
@@ -810,6 +810,10 @@ module ocn_time_integration_split
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             if (split_explicit_step < config_n_ts_iter) then
 
+               ! Get indices for dynamic tracers (Includes T&S).
+               startIndex = block % state % time_levs(1) % state % dynamics_start
+               endIndex = block % state % time_levs(1) % state % dynamics_end
+
                ! Only need T & S for earlier iterations,
                ! then all the tracers needed the last time through.
                do iCell=1,block % mesh % nCells
@@ -827,7 +831,7 @@ module ocn_time_integration_split
                        block % state % time_levs(1) % state % layerThickness % array(k,iCell) &
                        + temp_h)
 
-                     do i=1,2
+                     do i=startIndex, endIndex
                         ! This is Phi at n+1
                         temp = (  &
                            block % state % time_levs(1) % state % tracers % array(i,k,iCell) &


### PR DESCRIPTION
In split explicit, there was a loop intended to be over temperature and
salinity. The indicies for temperature and salinity were hard coded to
be 1 and 2, rather than using the start and end indices for the
array_group that temperature and salinity are part of.

This commit changes the explicit indicies to the start/end indices.

Fixes #4
