### PR TITLE
Added line private :: mpas_insert_string_suffix at the top of the module...

### DIFF
--- a/src/framework/mpas_io_output.F
+++ b/src/framework/mpas_io_output.F
@@ -19,6 +19,7 @@ module mpas_io_output
       type (MPAS_Stream_type) :: io_stream
    end type io_output_object
 
+   private :: mpas_insert_string_suffix
 
    contains
 


### PR DESCRIPTION
... to correct compilation error when using gfortran.
