### PR TITLE
Fixing a bug in the initialization of core_ocean.

### DIFF
--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -64,6 +64,8 @@ module mpas_core
       integer :: err, err_tmp
       real (kind=RKIND) :: maxDensity, maxDensity_global
 
+      dminfo = domain % dminfo
+
       ! Initialize submodules before initializing blocks.
       call ocn_timestep_init(err)
 


### PR DESCRIPTION
dminfo was used, but not initialized. After this commit it is
initialized to domain % dminfo.
