### PR TITLE
Add check in MPAS-A initialization to prevent static field interpolation...

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_test_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_test_cases.F
@@ -107,6 +107,23 @@ module init_atm_test_cases
          block_ptr => domain % blocklist
          do while (associated(block_ptr))
             if (config_static_interp) then
+
+               !  
+               !  Without a convex mesh partition file, interpolating static fields in parallel 
+               !     will give incorrect results. Since it is very unlikely that typical users
+               !     will have convex partitions, it's safer to just stop if multiple MPI tasks are
+               !     detected when performing the static_interp step.
+               !  
+               if (domain % dminfo % nprocs > 1) then
+                  write(0,*) ' '
+                  write(0,*) '****************************************************************'
+                  write(0,*) 'Error: Interpolation of static fields does not work in parallel.'
+                  write(0,*) 'Please run the static_interp step using only a single MPI task.'
+                  write(0,*) '****************************************************************'
+                  write(0,*) ' '
+                  call mpas_dmpar_abort(domain % dminfo)
+               end if
+
                call init_atm_static(block_ptr % mesh)
                call init_atm_static_orogwd(block_ptr % mesh)
             endif


### PR DESCRIPTION
... from being run in parallel,

since the averaging method that is currently used there can only work in parallel for convex partitionings
of the mesh.
