### PR TITLE
ALL: Core build changes cause error in Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ src/registry/parse
 # Ignore WRF Physics Files
 *.TBL
 *.DBL
+
+# Ignore MPAS core build files.
+.mpas_core_*

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,43 +8,61 @@ endif
 
 else
 
+ifeq "$(AUTOCLEAN)" "true"
+AUTOCLEAN_DEPS=clean_shared
+else
+AUTOCLEAN_DEPS=
+endif
+
 all: mpas
 
-mpas: reg_includes externals frame ops dycore drver
+mpas: $(AUTOCLEAN_DEPS) reg_includes externals frame ops dycore drver
 	$(LINKER) $(LDFLAGS) -o $(CORE)_model driver/*.o -L. -ldycore -lops -lframework $(LIBS) -I./external/esmf_time_f90 -L./external/esmf_time_f90 -lesmf_time
 
-externals: reg_includes
+externals: $(AUTOCLEAN_DEPS) reg_includes
 	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" )
 
-drver:  reg_includes externals frame ops dycore
+drver:  $(AUTOCLEAN_DEPS) reg_includes externals frame ops dycore
 	( cd driver; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 endif
 
-reg_includes: 
+reg_includes: $(AUTOCLEAN_DEPS)  
 	( cd registry; $(MAKE) CC="$(SCC)" )
 	( cd inc; $(CPP) ../core_$(CORE)/Registry.xml | ../registry/parse > Registry.processed)
 
-frame: reg_includes externals
+frame: $(AUTOCLEAN_DEPS) reg_includes externals
 	( cd framework; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 	ln -sf framework/libframework.a libframework.a
 
-ops: reg_includes externals frame
+ops: $(AUTOCLEAN_DEPS) reg_includes externals frame
 	( cd operators; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 	ln -sf operators/libops.a libops.a
 
-dycore: reg_includes externals frame ops
+dycore: $(AUTOCLEAN_DEPS) reg_includes externals frame ops
 	( cd core_$(CORE); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 	ln -sf core_$(CORE)/libdycore.a libdycore.a
 
 
-clean:
+clean: clean_shared clean_core
+
+clean_core:
+	if [ -d core_$(CORE) ] ; then \
+	   ( cd core_$(CORE); $(MAKE) clean ) \
+	fi;
+
+clean_shared:
+ifeq "$(AUTOCLEAN)" "true"
+	@echo ""
+	@echo "*********************************************************************************************"
+	@echo "The MPAS infrastructure is currently built for a core different from $(CORE)."
+	@echo "The infrastructure will be cleaned and re-built for the $(CORE) core."
+	@echo "*********************************************************************************************"
+	@echo ""
+endif
 	$(RM) libframework.a libops.a libdycore.a lib$(CORE).a *.o
 	( cd registry; $(MAKE) clean )
 	( cd external; $(MAKE) clean )
 	( cd framework; $(MAKE) clean )
 	( cd operators; $(MAKE) clean )
 	( cd inc; rm -f *.inc Registry.processed )
-	if [ -d core_$(CORE) ] ; then \
-	   ( cd core_$(CORE); $(MAKE) clean ) \
-	fi;
 	( cd driver; $(MAKE) clean )


### PR DESCRIPTION
The makefile now throws an error message telling users to `make clean`
the previously build core.

This only happens if a core was previously built that is different than
the core attempting to be built, and the build system hasn't been
cleaned.

Longer term solution would be to allow MPAS to build multiple cores.
