### PR TITLE
Atmosphere: change checkout_data_files.sh script to use SSH with git,

### DIFF
--- a/src/core_atmos_physics/checkout_data_files.sh
+++ b/src/core_atmos_physics/checkout_data_files.sh
@@ -24,7 +24,7 @@ fi
 which git
 if [ $? == 0 ]; then
    echo "*** trying git to obtain WRF physics tables ***"
-   git clone git://github.com/MPAS-Dev/MPAS-Data.git
+   git clone git@github.com:MPAS-Dev/MPAS-Data.git
    if [ $? == 0 ]; then
       mv MPAS-Data/atmosphere/physics_wrf/files physics_wrf/
       rm -rf MPAS-Data


### PR DESCRIPTION
rather than HTTP, for systems that only permit secure connections.
