### PR TITLE
adding ifort-gcc compile option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,23 @@ ifort:
 	"USE_PAPI = $(USE_PAPI)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
 
+ifort-gcc:
+	( $(MAKE) all \
+	"FC_PARALLEL = mpif90" \
+	"CC_PARALLEL = mpicc" \
+	"FC_SERIAL = ifort" \
+	"CC_SERIAL = gcc" \
+	"FFLAGS_OPT = -real-size 64 -O3 -convert big_endian -FR" \
+	"CFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT = -O3" \
+	"FFLAGS_DEBUG = -real-size 64 -g -convert big_endian -FR -CU -CB -check all -fpe0 -traceback" \
+	"CFLAGS_DEBUG = -g -traceback" \
+	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
+
 gfortran:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \


### PR DESCRIPTION
compiled with ifort-gcc in optimized and debug mode on OS X, Intel 13.0.2, gcc 4.2.1
