### PR TITLE
Atmosphere: remove unnecessary rename of 'cp' in mpas_atmphys_constants....

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_constants.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_constants.F
@@ -7,7 +7,7 @@
 !
 !=============================================================================================
  module mpas_atmphys_constants
- use mpas_constants, cp => cp, R_d => rgas, g => gravity
+ use mpas_constants, R_d => rgas, g => gravity
 
  implicit none
  public


### PR DESCRIPTION
...F.
