### PR TITLE
All/makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,13 @@ else
 	TAU_MESSAGE="TAU Hooks are off."
 endif
 
+ifeq "$(GEN_F90)" "true"
+	GEN_F90_MESSAGE="MPAS generated and was built with intermediate .f90 files."
+else
+	override GEN_F90=false
+	GEN_F90_MESSAGE="MPAS was built with .F files."
+endif
+
 
 ifneq ($(wildcard .mpas_core_*), ) # CHECK FOR BUILT CORE
 
@@ -368,7 +375,8 @@ endif
                  CPPINCLUDES="$(CPPINCLUDES)" \
                  FCINCLUDES="$(FCINCLUDES)" \
                  CORE="$(CORE)"\
-                 AUTOCLEAN="$(AUTOCLEAN)"
+                 AUTOCLEAN="$(AUTOCLEAN)" \
+                 GEN_F90="$(GEN_F90)"
 	@echo "$(CORE)" > .mpas_core_$(CORE)
 	if [ -e src/$(CORE)_model ]; then mv src/$(CORE)_model .; fi
 	@echo ""
@@ -380,6 +388,7 @@ endif
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)
 endif
+	@echo $(GEN_F90_MESSAGE)
 	@echo "*******************************************************************************"
 clean:
 	$(RM) .mpas_core_*
@@ -447,6 +456,7 @@ errmsg:
 	@echo "    USE_PAPI=true - builds version using PAPI for timers. Default is off."
 	@echo "    TAU=true      - builds version using TAU hooks for profiling. Default is off."
 	@echo "    AUTOCLEAN=true    - forces a clean of infrastructure prior to build new core."
+	@echo "    GEN_F90=true  - Generates intermediate .f90 files through CPP, and builds with them."
 	@echo ""
 	@echo "Ensure that NETCDF, PNETCDF, PIO, and PAPI (if USE_PAPI=true) are environment variables"
 	@echo "that point to the absolute paths for the libraries."

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -32,5 +32,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
-	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
+ifeq "$(GEN_F90)" "true"
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I./physics -I./dynamics -I./physics/physics_wrf -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I./physics -I./dynamics -I./physics/physics_wrf -I../external/esmf_time_f90
+endif

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -14,5 +14,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_wrf -I../../external/esmf_time_f90
+endif

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -202,5 +202,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
-	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES)  -DIWORDSIZE=4 -DRWORDSIZE=8 $< > $*.f90
+ifeq "$(GEN_F90)" "true"
+	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) -DIWORDSIZE=4 -DRWORDSIZE=8 $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I./physics_wrf -I../../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) -DIWORDSIZE=4 -DRWORDSIZE=8 $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I./physics_wrf -I../../external/esmf_time_f90
+endif

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -78,5 +78,9 @@ clean:
 	$(RM) *.f90 *.o *.mod
 
 .F.o:
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(COREDEF) $(CPPINCLUDES) -DIWORDSIZE=4 -DRWORDSIZE=8 $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../../framework -I../../../operators -I..
+else
+	$(FC) $(CPPFLAGS) $(COREDEF) -DIWORDSIZE=4 -DRWORDSIZE=8 $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../../framework -I../../../operators -I..
+endif

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -63,8 +63,12 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators  -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators  -I../external/esmf_time_f90
+endif
 
 .c.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(CPPINCLUDES) -c $<

--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -165,5 +165,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90 -I./cvmix/
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90 -I./cvmix/
+endif

--- a/src/core_sw/Makefile
+++ b/src/core_sw/Makefile
@@ -26,5 +26,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90
+endif

--- a/src/driver/Makefile
+++ b/src/driver/Makefile
@@ -14,5 +14,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../core_$(CORE) -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../core_$(CORE) -I../external/esmf_time_f90
+endif

--- a/src/external/esmf_time_f90/Makefile
+++ b/src/external/esmf_time_f90/Makefile
@@ -54,9 +54,13 @@ Test1_WRFU.exe : libesmf_time.a Test1_WRFU.o
 .F90.o :
 	$(RM) $@
 	$(SED_FTN) $*.F90 > $*.b
+ifeq "$(GEN_F90)" "true"
 	$(CPP) -C -P -I. $*.b > $*.f
-	$(RM) $*.b
 	$(FC) -o $@ -c $*.f
+else
+	$(FC) -o $@ -c $*.F90 -I.
+endif
+	$(RM) $*.b
 
 .F90.f :
 	$(RM) $@

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES: .F .o
 
-DEPS := $(wildcard ../core_$(CORE)/*.xml)
+DEPS := $(wildcard ../core_$(CORE)/Registry.xml)
 
 OBJS = mpas_kind_types.o \
        mpas_framework.o \
@@ -67,8 +67,12 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../external/esmf_time_f90
+endif
 
 .c.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(CPPINCLUDES) -c $<

--- a/src/operators/Makefile
+++ b/src/operators/Makefile
@@ -26,5 +26,9 @@ clean:
 
 .F.o:
 	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../external/esmf_time_f90
+endif


### PR DESCRIPTION
These two commits update the makefiles to first off have dependencies on some of the files in src/framework that is the core's Registry.xml file.

This allows the omission of `make clean CORE=...` after updating a registry file for a core that has already been built.

In addition to this modification, these commits allow compilation of the .F files, reducing the number of source files in directories, and removing the requirement for cpp.
