### PR TITLE
Ocean/tracer surface values

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1007,10 +1007,10 @@
 	</var_struct>
 	<var_struct name="diagnostics" time_levs="0">
                 <var_array name="tracersSurfaceValue" type="real" dimensions="nCells Time">
-                        <var name="temperatureSurfaceValue" array_group="surfaceVales" units="C" name_in_code="temperatureSurfaceValue"
+                        <var name="temperatureSurfaceValue" array_group="surfaceValues" streams="o" units="degrees Celsius" name_in_code="temperatureSurfaceValue"
                              description="potential temperature extrapolated to ocean surface"
                         />
-                        <var name="salinitySurfaceValue" array_group="surfaceVales" units="C" name_in_code="salinitySurfaceValue"
+                        <var name="salinitySurfaceValue" array_group="surfaceValues" streams="o" units="PSU" name_in_code="salinitySurfaceValue"
                              description="salinity extrapolated to ocean surface"
                         />
                 </var_array>

--- a/src/core_ocean/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/mpas_ocn_diagnostics.F
@@ -78,13 +78,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, s, grid, scratch)!{{{
+   subroutine ocn_diagnostic_solve(dt, s, grid, diagnostics, scratch)!{{{
 
       implicit none
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (state_type), intent(inout) :: s !< Input/Output: State information
       type (mesh_type), intent(in) :: grid !< Input: Grid information
+      type (diagnostics_type), intent(inout) :: diagnostics  !< Input/Output: diagnostic fields derived from State
       type (scratch_type), intent(inout) :: scratch !< Input: scratch variables
 
       integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j
@@ -115,6 +116,8 @@ contains
         vorticityGradientNormalComponent, vorticityGradientTangentialComponent
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers, deriv_two
       character :: c1*6
+
+      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue ! => diagnostics % tracersSurfaceValue % array
 
       layerThickness => s % layerThickness % array
       normalVelocity => s % normalVelocity % array
@@ -178,6 +181,8 @@ contains
       edgeSignOnVertex => grid % edgeSignOnVertex % array
       edgeSignOnCell => grid % edgeSignOnCell % array
 
+      tracersSurfaceValue  => diagnostics % tracersSurfaceValue % array(:,:)
+
       !
       ! Compute height on cell edges at velocity locations
       !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
@@ -203,6 +208,12 @@ contains
       layerThickness(:,nCells+1) = -1e34
       tracers(s % index_temperature,:,nCells+1) = -1e34
       tracers(s % index_salinity,:,nCells+1) = -1e34
+
+      !
+      ! extrapolate tracer values to ocean surface
+      ! this eventually be a modelled process
+      ! at present, just copy k=1 tracer values onto surface values
+      tracersSurfaceValue(:,:) = tracers(:,1,:)
 
       circulation(:,:) = 0.0
       relativeVorticity(:,:) = 0.0

--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -343,7 +343,7 @@ module mpas_core
       call ocn_time_average_init(block % state % time_levs(1) % state)
    
       call mpas_timer_start("diagnostic solve", .false., initDiagSolveTimer)
-      call ocn_diagnostic_solve(dt,  block % state % time_levs(1) % state, mesh, block % scratch)
+      call ocn_diagnostic_solve(dt,  block % state % time_levs(1) % state, mesh, block % diagnostics, block % scratch)
       call mpas_timer_stop("diagnostic solve", initDiagSolveTimer)
 
       ! Compute velocity transport, used in advection terms of layerThickness and tracer tendency

--- a/src/core_ocean/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mpas_ocn_time_integration_rk4.F
@@ -211,7 +211,7 @@ module ocn_time_integration_rk4
                  block % provis_state % layerThickness % array(:,:) = block % state % time_levs(1) % state % layerThickness % array(:,:)
               end if
 
-              call ocn_diagnostic_solve(dt, block % provis_state, block % mesh, block % scratch)
+              call ocn_diagnostic_solve(dt, block % provis_state, block % mesh, block % diagnostics, block % scratch)
 
               ! Compute velocity transport, used in advection terms of layerThickness and tracer tendency
               block % provis_state % uTransport % array(:,:) &
@@ -279,7 +279,7 @@ module ocn_time_integration_rk4
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows. 
-        call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % scratch)
+        call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % diagnostics, block % scratch)
 
         call ocn_vmix_implicit(dt, block % mesh, block % diagnostics, block % state % time_levs(2) % state, err)
         block => block % next
@@ -306,7 +306,7 @@ module ocn_time_integration_rk4
             block % state % time_levs(2) % state % layerThickness % array(:,:) = block % state % time_levs(1) % state % layerThickness % array(:,:)
          end if
 
-         call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % scratch)
+         call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % diagnostics, block % scratch)
 
          ! Compute velocity transport, used in advection terms of layerThickness and tracer tendency
             block % state % time_levs(2) % state % uTransport % array(:,:) &

--- a/src/core_ocean/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mpas_ocn_time_integration_split.F
@@ -873,7 +873,7 @@ module ocn_time_integration_split
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH 
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % scratch)
+               call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % diagnostics, block % scratch)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !
@@ -942,7 +942,7 @@ module ocn_time_integration_split
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % scratch)
+        call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % diagnostics, block % scratch)
 
         call ocn_vmix_implicit(dt, block % mesh, block % diagnostics, block % state % time_levs(2) % state, err)
 
@@ -971,7 +971,7 @@ module ocn_time_integration_split
             block % state % time_levs(2) % state % layerThickness % array(:,:) = block % state % time_levs(1) % state % layerThickness % array(:,:)
          end if
 
-         call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % scratch)
+         call ocn_diagnostic_solve(dt, block % state % time_levs(2) % state, block % mesh, block % diagnostics, block % scratch)
 
          ! Compute velocity transport, used in advection terms of layerThickness and tracer tendency
             block % state % time_levs(2) % state % uTransport % array(:,:) &


### PR DESCRIPTION
adding an array for tracer values extrapolated to the surface. at present, this array is filled with k=1 values from tracers, but it will eventually be "modeled" to provide an improved estimate of SST, SSS and surface values for biogeochemical constituents.

in the process, the "diagnostics" type is passed into ocn_diagnostic_solve to facilitate the movement of arrays from state into diagnostics.
