### PR TITLE
Call to timer sync is ifdef'd out.

### DIFF
--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -307,9 +307,11 @@
 
           total_found = .false.
 
+#ifdef MPAS_SYNC_TIMERS
           if(associated(domain_info) .and. synced == 0) then
             call mpas_timer_sync()
           endif
+#endif
 
           if(present(timer_ptr) .and. (.not.present(total_ptr))) then
             print *,'timer_write :: timer_ptr valid, but total_ptr is not assigned.'


### PR DESCRIPTION
This is to prevent issues realted to timer sync with hybrid versions of
the code. If it's build with -DMPAS_SYNC_TIMERS then the routine will be
called as it did previously.
