### PR TITLE
Fixing up CESM/MPAS Calendar issues

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -40,7 +40,7 @@ module mpas_framework
 !>  This routine initializes the MPAS framework. It calls routines related to initializing different parts of MPAS, that are housed within the framework.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_framework_init(dminfo, domain, mpi_comm, nml_filename, io_system, stdoutUnit, stderrUnit)!{{{
+   subroutine mpas_framework_init(dminfo, domain, mpi_comm, nml_filename, io_system, calendar, stdoutUnit, stderrUnit)!{{{
 
       implicit none
 
@@ -50,6 +50,7 @@ module mpas_framework
 
       character (len=*), optional :: nml_filename
       type (iosystem_desc_t), optional, pointer :: io_system
+      character(len=*), intent(in), optional :: calendar
 
       integer, intent(in), optional :: stdoutUnit, stderrUnit
 
@@ -64,7 +65,11 @@ module mpas_framework
 
       call mpas_allocate_domain(domain, dminfo)
       
-      call mpas_timekeeping_init(config_calendar_type)
+      if(present(calendar)) then
+        call mpas_timekeeping_init(calendar)
+      else
+        call mpas_timekeeping_init(config_calendar_type)
+      end if
 
       pio_num_iotasks = config_pio_num_iotasks
       pio_stride = config_pio_stride

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -124,9 +124,7 @@ module mpas_timekeeping
 
       character (len=*), intent(in) :: calendar 
 
-#ifdef MPAS_CESM
-      TheCalendar = defaultCal % Type % caltype - 1
-#else
+#ifndef MPAS_CESM
       if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
          call ESMF_Initialize(defaultCalendar=ESMF_CAL_GREGORIAN)
@@ -136,6 +134,14 @@ module mpas_timekeeping
       else if (trim(calendar) == '360day') then
          TheCalendar = MPAS_360DAY
          call ESMF_Initialize(defaultCalendar=ESMF_CAL_360DAY)
+      else
+         write(stderrUnit,*) 'ERROR: mpas_timekeeping_init: Invalid calendar type'
+      end if
+#else
+      if (trim(calendar) == 'gregorian') then
+         TheCalendar = MPAS_GREGORIAN
+      else if (trim(calendar) == 'gregorian_noleap') then
+         TheCalendar = MPAS_GREGORIAN_NOLEAP
       else
          write(stderrUnit,*) 'ERROR: mpas_timekeeping_init: Invalid calendar type'
       end if


### PR DESCRIPTION
Trying to makesure MPAS and CESM calendars are the same. CESM provides a
noleap, and a gregorian calendar, but not a 360day. While MPAS provides
all three.

For CESM runs, MPAS gets the calendar from CESM.
