### PR TITLE
Adding config_restart_timestamp_filename

### DIFF
--- a/namelist.input.ocean
+++ b/namelist.input.ocean
@@ -10,6 +10,7 @@
 	config_output_name = "output.nc"
 	config_restart_name = "restart.nc"
 	config_restart_interval = "0001_00:00:00"
+	config_restart_timestamp_filename = "restart_timestamp"
 	config_output_interval = "0001_00:00:00"
 	config_stats_interval = "0000_01:00:00"
 	config_write_stats_on_startup = .true.

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -82,6 +82,7 @@
                 <nml_option name="config_output_interval"            type="character"     default_value="06:00:00"/>
                 <nml_option name="config_restart_name"               type="character"     default_value="restart.nc"/>
                 <nml_option name="config_restart_interval"           type="character"     default_value="none"/>
+                <nml_option name="config_restart_timestamp_name"     type="character"     default_value="restart_timestamp"/>
                 <nml_option name="config_sfc_update_name"            type="character"     default_value="sfc_update.nc"/>
                 <nml_option name="config_sfc_update_interval"        type="character"     default_value="none"/>
                 <nml_option name="config_hifreq_output_interval"     type="character"     default_value="none"/>

--- a/src/core_atmosphere/mpas_atm_mpas_core.F
+++ b/src/core_atmosphere/mpas_atm_mpas_core.F
@@ -114,7 +114,7 @@ module mpas_core
       integer :: ierr
 
       if(trim(config_start_time) == 'file') then
-         open(22,file='restart_timestamp',form='formatted',status='old')
+         open(22,file=trim(config_restart_timestamp_name),form='formatted',status='old')
          read(22,*) startTimeStamp
          close(22)
       else

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -74,6 +74,7 @@
                 <nml_option name="config_sfc_update_name"       type="character"     default_value="sfc_update.nc"/>
                 <nml_option name="config_output_name"           type="character"     default_value="init.nc"/>
                 <nml_option name="config_restart_name"          type="character"     default_value="restart.nc"/>
+                <nml_option name="config_restart_timestamp_name" type="character"     default_value="restart_timestamp"/>
                 <nml_option name="config_frames_per_outfile"    type="integer"       default_value="0"/>
                 <nml_option name="config_pio_num_iotasks"       type="integer"       default_value="0"/>
                 <nml_option name="config_pio_stride"            type="integer"       default_value="1"/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -76,6 +76,10 @@
 		            description="The template path and name to the restart file for the simulation. A time stamp is prepended to the extension of the file (.nc) both for input and output."
 		            possible_values="path/to/restart.nc"
 		/>
+		<nml_option name="config_restart_timestamp_name" type="character" default_value="restart_timestamp" units="unitless"
+					description="The name of the file timestamps for latest restart files are written to. This file is also read when config_start_time is set to 'file' and config_do_restart is set to .true."
+					possible_values="path/to/restart_timestamp"
+		/>
 		<nml_option name="config_restart_interval" type="character" default_value="0001_00:00:00" units="unitless"
 		            description="Timestamp determining how often a restart file should be written."
 		            possible_values="'DDDD_HH:MM:SS'"

--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -248,7 +248,7 @@ module mpas_core
       integer :: ierr
 
       if(config_start_time == 'file') then
-        open(22,file='restart_timestamp',form='formatted',status='old')
+        open(22,file=config_restart_timestamp_name,form='formatted',status='old')
         read(22,*) restartTimeStamp
         close(22)
         call mpas_set_time(curr_time=startTime, dateTimeString=restartTimeStamp, ierr=ierr)

--- a/src/core_sw/Registry.xml
+++ b/src/core_sw/Registry.xml
@@ -41,6 +41,7 @@
 		<nml_option name="config_input_name"                 type="character"     default_value="grid.nc"/>
 		<nml_option name="config_output_name"                type="character"     default_value="output.nc"/>
 		<nml_option name="config_restart_name"               type="character"     default_value="restart.nc"/>
+		<nml_option name="config_restart_timestamp_name"     type="character"     default_value="restart_timestamp"/>
 		<nml_option name="config_output_interval"            type="character"     default_value="06:00:00"/>
 		<nml_option name="config_frames_per_outfile"         type="integer"       default_value="0"/>
 		<nml_option name="config_pio_num_iotasks"            type="integer"       default_value="0"/>

--- a/src/framework/mpas_io_input.F
+++ b/src/framework/mpas_io_input.F
@@ -107,7 +107,7 @@ module mpas_io_input
       if (config_do_restart) then
         ! this get followed by set is to ensure that the time is in standard format
         if(trim(config_start_time) == 'file') then
-          open(22,file='restart_timestamp',form='formatted',status='old')
+          open(22,file=trim(config_restart_timestamp_name),form='formatted',status='old')
           read(22,*) restartTimeStamp
           close(22)
 

--- a/src/framework/mpas_io_output.F
+++ b/src/framework/mpas_io_output.F
@@ -56,7 +56,7 @@ module mpas_io_output
       else if (trim(stream) == 'RESTART') then
          if(present(outputSuffix)) then
             call mpas_insert_string_suffix(config_restart_name, outputSuffix, tempfilename)
-            open(22,file='restart_timestamp',form='formatted',status='replace')
+            open(22,file=trim(config_restart_timestamp_name),form='formatted',status='replace')
             write(22,*) outputSuffix
             close(22)
          else


### PR DESCRIPTION
This is a namelist parameter that controls the name of the file that restart
timestamps are written to and read from.
