### PR TITLE
Causing makefile to pass CPP flags to CPP

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ endif
 
 reg_includes: $(AUTOCLEAN_DEPS)  
 	( cd registry; $(MAKE) CC="$(SCC)" )
-	( cd inc; $(CPP) ../core_$(CORE)/Registry.xml | ../registry/parse > Registry.processed)
+	( cd inc; $(CPP) $(CPPFLAGS) $(CPPINCLUDES) ../core_$(CORE)/Registry.xml | ../registry/parse > Registry.processed)
 
 frame: $(AUTOCLEAN_DEPS) reg_includes externals
 	( cd framework; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 


### PR DESCRIPTION
This affects Registry. The CPP of Registry doesn't currently pass
$(CPPFLAGS) or $(CPPINCLUDES), so sections of Registry.xml aren't
appropriately ifdef'd out.
