### PR TITLE
Fixing two bugs in the ocean core. Only affects debug mode.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1104,6 +1104,9 @@
 			<var name="salinitySurfaceValue" array_group="surfaceValues" streams="o" units="PSU" name_in_code="salinitySurfaceValue"
 				description="salinity extrapolated to ocean surface"
 			/>
+			<var name="tracer1SurfaceValue" array_group="surfaceValues" streams="o" units="na"
+				description="Tracer of 1 extrapolated to ocean surface"
+			/>
 		</var_array>
 		<var_array name="surfaceVelocity" type="real" dimensions="nCells Time">
 			<var name="zonalSurfaceVelocity" array_group="vel_zonal" units="m s^{-1}"

--- a/src/core_ocean/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/mpas_ocn_equation_of_state_jm.F
@@ -221,7 +221,7 @@ contains
       refBottomDepth => grid % refBottomDepth % array
 
 !  allocate local T,S tracer field
-      allocate(tracerTS(2,nVertLevels,nCells))
+      allocate(tracerTS(2,nVertLevels,nCells+1))
 
 !  fill tracerTS
       if (displacement_type == 'surfaceDisplaced') then


### PR DESCRIPTION
First, the dimensions of tracerSurfaceValues differs from that of
tracers, so the array notation extrapolation doesn't work in debug mode
can causes an error.

Second, the indices of tracerTS in
src/core_ocean/mpas_ocn_equation_of_state_jm.F differs from a real
tracer (nCells+1) and again doesn't work in debug mode.
