### PR TITLE
Adding a missing use statement.

### DIFF
--- a/src/core_ocean/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/mpas_ocn_equation_of_state_jm.F
@@ -23,6 +23,7 @@ module ocn_equation_of_state_jm
    use mpas_kind_types
    use mpas_grid_types
    use mpas_configure
+   use mpas_dmpar
 
    implicit none
    private


### PR DESCRIPTION
mpas_ocn_equation_of_state_jm was missing a use statement for
mpas_dmpar.
