### PR TITLE
Adding the default_value attribute to registry.

### DIFF
--- a/src/registry/Registry.xsd
+++ b/src/registry/Registry.xsd
@@ -85,6 +85,8 @@
 									<xs:attribute name="dimensions"  type="xs:string" use="required"/>
 									<!-- The persistence attribute determines if the var_array is persistence or scratch. Valid options are persistent, and scratch. -->
 									<xs:attribute name="persistence"  type="xs:string" use="optional"/>
+									<!-- The default_value attribute determines the default value for the var_array. Reals default to 0.0_RKIND, integers to 0, logicals to .false. and characters to ''-->
+									<xs:attribute name="default_value"  type="xs:string" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 							<!-- This var element defines a variable that does not live within a var_array group. -->
@@ -104,6 +106,8 @@
 									<xs:attribute name="units"  type="xs:string" use="optional"/>
 									<!-- The description attribute provides a brief description of the variable. -->
 									<xs:attribute name="description"  type="xs:string" use="optional"/>
+									<!-- The default_value attribute determines the default value for the var. Reals default to 0.0_RKIND, integers to 0, logicals to .false. and characters to ''-->
+									<xs:attribute name="default_value"  type="xs:string" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>

--- a/src/registry/gen_inc.c
+++ b/src/registry/gen_inc.c
@@ -761,12 +761,7 @@ void gen_field_defs(struct group_list * groups, struct variable * vars, struct d
                   dimlist_ptr = dimlist_ptr->next;
                }
                fortprintf(fd, "))\n");
-               if (var_ptr->vtype == INTEGER)
-                  fortprintf(fd, "      %s %% %s %% array = 0\n", group_ptr->name, var_ptr2->super_array ); /* initialize field to zero */
-               else if (var_ptr->vtype == REAL)
-                  fortprintf(fd, "      %s %% %s %% array = 0.0\n", group_ptr->name, var_ptr2->super_array ); /* initialize field to zero */
-               else if (var_ptr->vtype == CHARACTER)
-                  fortprintf(fd, "      %s %% %s %% array = \'\'\n", group_ptr->name, var_ptr2->super_array ); /* initialize field to zero */
+               fortprintf(fd, "      %s %% %s %% array = %s\n", group_ptr->name, var_ptr2->super_array, var_ptr2->default_value ); /* initialize field */
 			}
 
             fortprintf(fd, "      %s %% %s %% dimSizes(1) = %i\n", group_ptr->name, var_ptr2->super_array, i);
@@ -868,13 +863,7 @@ void gen_field_defs(struct group_list * groups, struct variable * vars, struct d
                   dimlist_ptr = dimlist_ptr->next;
                }
                fortprintf(fd, "))\n");
-               if (var_ptr->vtype == INTEGER)
-                  fortprintf(fd, "      %s %% %s %% array = 0\n", group_ptr->name, var_ptr->name_in_code ); /* initialize field to zero */
-               else if (var_ptr->vtype == REAL)
-                  fortprintf(fd, "      %s %% %s %% array = 0.0\n", group_ptr->name, var_ptr->name_in_code ); /* initialize field to zero */
-               else if (var_ptr->vtype == CHARACTER)
-                  fortprintf(fd, "      %s %% %s %% array = \'\'\n", group_ptr->name, var_ptr->name_in_code ); /* initialize field to zero */
-
+               fortprintf(fd, "      %s %% %s %% array = %s\n", group_ptr->name, var_ptr->name_in_code, var_ptr->default_value ); /* initialize field */
 			  }
                dimlist_ptr = var_ptr->dimlist;
                i = 1;

--- a/src/registry/parse.c
+++ b/src/registry/parse.c
@@ -84,8 +84,8 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 	const char *dimname, *dimunits, *dimdesc, *dimdef;
 	const char *nmlrecname, *nmloptname, *nmlopttype, *nmloptval, *nmloptunits, *nmloptdesc, *nmloptposvals;
 	const char *structname, *structlevs;
-	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence;
-	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams;
+	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrdefaultval;
+	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval;
 	const char *varname_in_code;
 	const char *const_model, *const_core, *const_version;
 
@@ -93,6 +93,7 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 	char *dimension_list;
 	char dimension_buffer[128];
 	char streams_buffer[128];
+	char default_value[1024];
 
 	NEW_NAMELIST(nls_ptr)
 	NEW_DIMENSION(dim_ptr)
@@ -245,6 +246,7 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 			vararrtype = ezxml_attr(var_arr_xml, "type");
 			vararrdims = ezxml_attr(var_arr_xml, "dimensions");
 			vararrpersistence = ezxml_attr(var_arr_xml, "persistence");
+			vararrdefaultval = ezxml_attr(var_arr_xml, "default_value");
 
 			//Parse variables in variable arrays
 			for(var_xml = ezxml_child(var_arr_xml, "var"); var_xml; var_xml = var_xml->next){
@@ -284,12 +286,16 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 
 				if(strncmp(vararrtype, "real", 1024) == 0){
 					var_ptr->vtype = REAL;
+					snprintf(default_value, 1024, "0.0_RKIND");
 				} else if(strncmp(vararrtype, "integer", 1024) == 0){
 					var_ptr->vtype = INTEGER;
+					snprintf(default_value, 1024, "0");
 				} else if(strncmp(vararrtype, "logical", 1024) == 0){
 					var_ptr->vtype = LOGICAL;
+					snprintf(default_value, 1024, ".false.");
 				} else if(strncmp(vararrtype, "text", 1024) == 0){
 					var_ptr->vtype = CHARACTER;
+					snprintf(default_value, 1024, "''");
 				}
 
 				NEW_DIMENSION_LIST(dimlist_ptr)
@@ -337,6 +343,12 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 				} else {
 					snprintf(var_ptr->name_in_code, 1024, "%s", varname_in_code);
 				}
+				
+				if(vararrdefaultval == NULL){
+					snprintf(var_ptr->default_value, 1024, "%s", default_value);
+				} else {
+					snprintf(var_ptr->default_value, 1024, "%s", vararrdefaultval);
+				}
 
 				snprintf(var_ptr->super_array, 1024, "%s", vararrname);
 				snprintf(var_ptr->array_class, 1024, "%s", vararrgroup);
@@ -356,6 +368,7 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 			vardesc = ezxml_attr(var_xml, "description");
 			varstreams = ezxml_attr(var_xml, "streams");
 			varname_in_code = ezxml_attr(var_xml, "name_in_code");
+			vardefaultval = ezxml_attr(var_xml, "default_value");
 
 			if(vlist_cursor == NULL){
 				NEW_VARIABLE_LIST(grouplist_ptr->vlist);
@@ -386,12 +399,16 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 
 			if(strncmp(vartype, "real", 1024) == 0){
 				var_ptr->vtype = REAL;
+				snprintf(default_value, 1024, "0.0_RKIND");
 			} else if(strncmp(vartype, "integer", 1024) == 0){
 				var_ptr->vtype = INTEGER;
+				snprintf(default_value, 1024, "0");
 			} else if(strncmp(vartype, "logical", 1024) == 0){
 				var_ptr->vtype = LOGICAL;
+				snprintf(default_value, 1024, ".false.");
 			} else if(strncmp(vartype, "text", 1024) == 0){
 				var_ptr->vtype = CHARACTER;
+				snprintf(default_value, 1024, "''");
 			}
 
 			NEW_DIMENSION_LIST(dimlist_ptr)
@@ -450,6 +467,12 @@ int parse_reg_xml(FILE * regfile, struct namelist **nls, struct dimension ** dim
 
 			snprintf(var_ptr->super_array, 1024, "-");
 			snprintf(var_ptr->array_class, 1024, "-");
+
+			if(vardefaultval == NULL){
+				snprintf(var_ptr->default_value, 1024, "%s", default_value);
+			} else {
+				snprintf(var_ptr->default_value, 1024, "%s", vardefaultval);
+			}
 
 			NEW_VARIABLE(var_ptr->next);
 			var_ptr2 = var_ptr;

--- a/src/registry/registry_types.h
+++ b/src/registry/registry_types.h
@@ -73,6 +73,7 @@ struct variable {
    char struct_group[1024];
    char super_array[1024];
    char array_class[1024];
+   char default_value[1024];
    int persistence;
    int vtype;
    int ndims;


### PR DESCRIPTION
This allows registry to define the initial value for vars and
var_arrays.

When the attribute is ommited, the previous behavior is reproduced
meaning:

Reals default to 0.0_RKIND
Integers default to 0
Logicals default to .false.
Characters default to '' (empty string)
