### PR TITLE
Add openmpi target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,23 @@ gfortran:
 	"USE_PAPI = $(USE_PAPI)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
 
+gfortran-openmpi:
+	( $(MAKE) all \
+	"FC_PARALLEL = openmpif90" \
+	"CC_PARALLEL = openmpicc" \
+	"FC_SERIAL = gfortran" \
+	"CC_SERIAL = gcc" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fdefault-real-8 -fconvert=big-endian -ffree-form" \
+	"CFLAGS_OPT = -O3 -m64" \
+	"LDFLAGS_OPT = -O3 -m64" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fdefault-real-8 -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"CFLAGS_DEBUG = -g -m64" \
+	"LDFLAGS_DEBUG = -g -m64" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
+
 g95:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \


### PR DESCRIPTION
When using macports to install mpi on mac, mpi is referred to as openmpi. This target allows for use of macports installed openmpi during build process. The only differences relative to the existing gfortran target are the calls to, e.g. openmpif90 rather than mpif90. 
