### PR TITLE
Fix an issue with an uninitialized field in one of the I/O structures

### DIFF
--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -14,7 +14,7 @@ module mpas_io_streams
    use mpas_io_units
 
    type field_list_type
-      integer :: field_type
+      integer :: field_type = -999
       logical :: isDecomposed
       integer :: totalDimSize     ! Total size of outer dimension across all blocks for decomposed fields
       logical, dimension(:), pointer :: isAvailable => null() ! Used for reading super-arrays where one or more 


### PR DESCRIPTION
when reading or writing super-arrays. For super-arrays, the first
constituent of the array has its structures properly set up, and the
remaining constituents do nothing. In rare cases, the field_type can end
up with a valid value (although it is uninitialized) on some tasks,
causing those tasks to make collective calls that other tasks don't.

The simplest fix is to just initialize the offending field to a safe
value, but perhaps a more elegant solution can be devised that avoids
adding all super-array constituents to the linked list in a stream.
