### PR TITLE
Fix z-star bug.  

### DIFF
--- a/src/core_ocean/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/mpas_ocn_thick_ale.F
@@ -146,7 +146,7 @@ contains
          newSSH = oldSSH(iCell) - dt*div_hu_btr(iCell)
          thicknessSum = 1e-14  
          do k = 1, kMax
-            SSH_ALE_Thickness(k) = newSSH * vertCoordMovementWeights(k) * restingThickness(k, iCell) * div_hu_btr(iCell)
+            SSH_ALE_Thickness(k) = newSSH * vertCoordMovementWeights(k) * restingThickness(k, iCell)
             thicknessSum = thicknessSum + vertCoordMovementWeights(k) * restingThickness(k, iCell)
          end do
          SSH_ALE_Thickness = SSH_ALE_Thickness / thicknessSum


### PR DESCRIPTION
SSH contribution to h should not be multiplied by the barotropic divergence.
This fixes the z-star problem seen in the cesm coupled runs.
