### PR TITLE
in Registry we have:

### DIFF
--- a/src/core_ocean/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/mpas_ocn_equation_of_state_linear.F
@@ -112,7 +112,7 @@ contains
       if (present(thermalExpansionCoeff)) then
          do iCell=1,nCells
             do k=1,maxLevelCell(iCell)
-               thermalExpansionCoeff(k,iCell) = -config_eos_linear_alpha/density(k,iCell)
+               thermalExpansionCoeff(k,iCell) = config_eos_linear_alpha/density(k,iCell)
             end do
          end do
       endif


### PR DESCRIPTION
in Registry we have:

<nml_option name="config_eos_linear_alpha" type="real" default_value="2.55e-1" units="kg m^{-3} C^{-1}"
                                        description="Linear thermal expansion coefficient"
                                        possible_values="any positive real"

so config_eos_linear_alpha == thermalExpansionCoeff

but in mpas_ocn_equation_of_state_linear.F we had

thermalExpansionCoeff(k,iCell) = -config_eos_linear_alpha/density(k,iCell)

this commit fixes this error. the correct specification is:

thermalExpansionCoeff(k,iCell) =  config_eos_linear_alpha/density(k,iCell)

(note the removal of the negative sign)
