### PR TITLE
Framework: Fixing missing variables in CESM

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -222,8 +222,9 @@ module mpas_io
                       PIO_rearr_box,             &     ! rearr
                       pio_iosystem)                    ! iosystem
   
-        call pio_seterrorhandling(pio_iosystem, PIO_BCAST_ERROR)
       end if
+
+      call pio_seterrorhandling(pio_iosystem, PIO_BCAST_ERROR)
 
    end subroutine MPAS_io_init
 


### PR DESCRIPTION
Adding logic to allow CESM to not error our when a variable is missing
in the input file.

When running in the CESM without this, any variables that are missing from the input file, but are in the i stream cause the model to fail.
