### PR TITLE
Fix a bug in the weighted four-point average interpolation method

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_hinterp.F
+++ b/src/core_init_atmosphere/mpas_init_atm_hinterp.F
@@ -571,7 +571,7 @@ module init_atm_hinterp
             icx = end_x
          end if
 
-         if (yy > real(start_y)-0.5 .and. ifx < start_y) then
+         if (yy > real(start_y)-0.5 .and. ify < start_y) then
             ify = start_y
             icy = start_y
          else if (yy < real(end_y)+0.5 .and. icy > end_y) then

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -317,7 +317,7 @@
        lat = latPoints(i) * DEG_PER_RAD
        lon = lonPoints(i) * DEG_PER_RAD
        call latlon_to_ij(proj, lat, lon, x, y)
-       if(y < 0.5) then
+       if(y <= 0.5) then
           y = 1.0
        elseif(y >= real(field%ny)+0.5) then
           y = real(field % ny)


### PR DESCRIPTION
for MPAS-A initialization.
This affects interpolation near poles of, e.g., seaice.

Also, change an if-test on the y-coordinate of the interpolation location in interp_to_MPAS()
to match the conditions assumed by the interpolation methods.
