### PR TITLE
Remove 'pause' statements from MPAS-A code.

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
@@ -2,6 +2,13 @@ MODULE module_sf_bem
 ! -----------------------------------------------------------------------
 !  Variables and constants used in the BEM module
 ! -----------------------------------------------------------------------
+
+#ifdef mpas
+ USE mpas_dmpar, only : mpas_dmpar_global_abort
+#define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
+#else
+#define FATAL_ERROR(M) write(0,*) M ; stop
+#endif
          
         real emins		!emissivity of the internal walls
         parameter (emins=0.9) 
@@ -2220,7 +2227,7 @@ MODULE module_sf_bem
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     pause 'singular matrix in gaussjbem'
+                     FATAL_ERROR('singular matrix in gaussjbem')
                   endif
                enddo
             endif
@@ -2241,7 +2248,7 @@ MODULE module_sf_bem
           
          endif
          
-         if(a(icol,icol).eq.0)pause 'singular matrix in gaussjbem'
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussjbem')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
@@ -1,5 +1,12 @@
 MODULE module_sf_bep
 
+#ifdef mpas
+ USE mpas_dmpar, only : mpas_dmpar_global_abort
+#define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
+#else 
+#define FATAL_ERROR(M) write(0,*) M ; stop
+#endif
+
 !USE module_model_constants
  USE module_sf_urban
 
@@ -2143,7 +2150,7 @@ MODULE module_sf_bep
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     pause 'singular matrix in gaussj'
+                     FATAL_ERROR('singular matrix in gaussj')
                   endif
                enddo
             endif
@@ -2164,7 +2171,7 @@ MODULE module_sf_bep
           
          endif
          
-         if(a(icol,icol).eq.0)pause 'singular matrix in gaussj'
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
@@ -1,5 +1,12 @@
 MODULE module_sf_bep_bem
 
+#ifdef mpas
+ USE mpas_dmpar, only : mpas_dmpar_global_abort
+#define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
+#else 
+#define FATAL_ERROR(M) write(0,*) M ; stop
+#endif
+
 !USE module_model_constants
  USE module_sf_urban
  USE module_sf_bem
@@ -2938,7 +2945,7 @@ MODULE module_sf_bep_bem
                         icol=k
                      endif
                   elseif(ipiv(k).gt.1)then
-                     pause 'singular matrix in gaussj'
+                     FATAL_ERROR('singular matrix in gaussj')
                   endif
                enddo
             endif
@@ -2959,7 +2966,7 @@ MODULE module_sf_bep_bem
           
          endif
          
-         if(a(icol,icol).eq.0)pause 'singular matrix in gaussj'
+         if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
          
          pivinv=1./a(icol,icol)
          a(icol,icol)=1


### PR DESCRIPTION
In cases where 'pause' was used, we just call mpas_dmpar_global_abort() instead.
