### PR TITLE
Cleaning up surface fluxes.

### DIFF
--- a/src/core_ocean/mpas_ocn_forcing_restoring.F
+++ b/src/core_ocean/mpas_ocn_forcing_restoring.F
@@ -67,7 +67,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_forcing_restoring_build_arrays(mesh, indexT, indexS, indexTFlux, indexSFlux, tracers, temperatureRestoring, salinityRestoring, surfaceFluxes, err)!{{{
+   subroutine ocn_forcing_restoring_build_arrays(mesh, indexT, indexS, indexTFlux, indexSFlux, tracers, temperatureRestoring, salinityRestoring, surfaceTracerFluxes, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -97,7 +97,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-        surfaceFluxes !< Input: tracer quantities
+        surfaceTracerFluxes !< Input: tracer quantities
 
       !-----------------------------------------------------------------
       !
@@ -126,8 +126,8 @@ contains
 
       k = 1  ! restoring only in top layer
       do iCell=1,nCellsSolve
-        surfaceFluxes(indexTFlux, iCell) = - temperatureLengthScale * (tracers(indexT, k, iCell) - temperatureRestoring(iCell)) * invTemp
-        surfaceFluxes(indexSFlux, iCell) = - salinityLengthScale * (tracers(indexS, k, iCell) - salinityRestoring(iCell)) * invSalinity
+        surfaceTracerFluxes(indexTFlux, iCell) = - temperatureLengthScale * (tracers(indexT, k, iCell) - temperatureRestoring(iCell)) * invTemp
+        surfaceTracerFluxes(indexSFlux, iCell) = - salinityLengthScale * (tracers(indexS, k, iCell) - salinityRestoring(iCell)) * invSalinity
       enddo
 
    !--------------------------------------------------------------------

--- a/src/core_ocean/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mpas_ocn_mpas_core.F
@@ -36,6 +36,7 @@ module mpas_core
    use ocn_thick_hadv
    use ocn_thick_vadv
    use ocn_thick_ale
+   use ocn_thick_surface_flux
 
    use ocn_vel_pressure_grad
    use ocn_vel_vadv
@@ -44,6 +45,7 @@ module mpas_core
    use ocn_vel_coriolis
 
    use ocn_tracer_hmix
+   use ocn_tracer_surface_flux
    use ocn_tracer_short_wave_absorption
    use ocn_gm
 
@@ -111,9 +113,12 @@ module mpas_core
 
       call ocn_thick_hadv_init(err_tmp)
       err = ior(err, err_tmp)
-
       call ocn_thick_vadv_init(err_tmp)
       err = ior(err, err_tmp)
+      call ocn_thick_surface_flux_init(err_tmp)
+      err = ior(err, err_tmp)
+      call ocn_thick_ale_init(err_tmp)
+      err = ior(err,err_tmp)
 
       call ocn_vel_coriolis_init(err_tmp)
       err = ior(err, err_tmp)
@@ -128,6 +133,12 @@ module mpas_core
 
       call ocn_tracer_hmix_init(err_tmp)
       err = ior(err, err_tmp)
+      call ocn_tracer_surface_flux_init(err_tmp)
+      err = ior(err, err_tmp)
+      call ocn_tracer_advection_init(err_tmp)
+      err = ior(err,err_tmp)
+      call ocn_tracer_short_wave_absorption_init(err_tmp)
+      err = ior(err,err_tmp)
 
       call ocn_vmix_init(domain,err_tmp)
       err = ior(err, err_tmp)
@@ -139,17 +150,10 @@ module mpas_core
       err = ior(err,err_tmp)
       call ocn_diagnostics_init(err_tmp)
       err = ior(err,err_tmp)
-      call ocn_thick_ale_init(err_tmp)
-      err = ior(err,err_tmp)
 
       call ocn_forcing_init(err_tmp)
       err = ior(err,err_tmp)
 
-      call ocn_tracer_advection_init(err_tmp)
-      err = ior(err,err_tmp)
-
-      call ocn_tracer_short_wave_absorption_init(err_tmp)
-      err = ior(err,err_tmp)
 
       call ocn_global_diagnostics_init(dminfo,err_tmp)
       err = ior(err, err_tmp)

--- a/src/core_ocean/mpas_ocn_thick_surface_flux.F
+++ b/src/core_ocean/mpas_ocn_thick_surface_flux.F
@@ -51,7 +51,7 @@ module ocn_thick_surface_flux
    !
    !--------------------------------------------------------------------
 
-   logical :: surfaceFluxOn
+   logical :: surfaceMassFluxOn
 
 
 !***********************************************************************
@@ -123,7 +123,7 @@ contains
 
       err = 0
 
-      if (.not. surfaceFluxOn) return
+      if (.not. surfaceMassFluxOn) return
 
       maxLevelCell => mesh % maxLevelCell % array
       cellMask => mesh % cellMask % array
@@ -175,14 +175,14 @@ contains
 
       err = 0
 
-      surfaceFluxOn = .true.
+      surfaceMassFluxOn = .true.
 
       if (config_disable_thick_sflux) then
-         surfaceFluxOn = .false.
+         surfaceMassFluxOn = .false.
       end if
 
       if (config_forcing_type == trim('off')) then
-         surfaceFluxOn = .false.
+         surfaceMassFluxOn = .false.
       end if
 
 

--- a/src/core_ocean/mpas_ocn_tracer_surface_flux.F
+++ b/src/core_ocean/mpas_ocn_tracer_surface_flux.F
@@ -51,7 +51,7 @@ module ocn_tracer_surface_flux
    !
    !--------------------------------------------------------------------
 
-   logical :: surfaceFluxOn
+   logical :: surfaceTracerFluxOn
 
 !***********************************************************************
 
@@ -120,7 +120,7 @@ contains
 
       err = 0
 
-      if (.not. surfaceFluxOn) return
+      if (.not. surfaceTracerFluxOn) return
 
       nCells = mesh % nCells
       nVertLevels = mesh % nVertLevels
@@ -171,14 +171,14 @@ contains
 
       err = 0
 
-      surfaceFluxOn = .true.
+      surfaceTracerFluxOn = .true.
 
       if (config_disable_tr_sflux) then
-         surfaceFluxOn = .false.
+         surfaceTracerFluxOn = .false.
       end if
 
       if (config_forcing_type == trim('off')) then
-         surfaceFluxOn = .false.
+         surfaceTracerFluxOn = .false.
       end if
 
    end subroutine ocn_tracer_surface_flux_init!}}}


### PR DESCRIPTION
Renaming surfaceFluxes arrays to surface{Mass,Tracer}Flux.
Adding calls to init routines for surface{Mass,Tracer}Flux arrays.
Cleaning up calls to init routines, to be grouped by module type.

This should fix the application of restoring.
