### PR TITLE
Fix for an idealized MPAS-A test case

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -271,8 +271,8 @@ module init_atm_cases
       real (kind=RKIND) :: dlat, hx_1d
       real (kind=RKIND) :: z_edge, z_edge3, d2fdx2_cell1, d2fdx2_cell2
 
-      logical, parameter :: moisture = .true.
-!      logical, parameter :: moisture = .false.
+!      logical, parameter :: moisture = .true.
+      logical, parameter :: moisture = .false.
 
       !
       ! Scale all distances and areas from a unit sphere to one with radius sphere_radius


### PR DESCRIPTION
By default, don't add moisture to the Jablonowski and Williamson test cases in MPAS-A.
