### PR TITLE
Clean up shared code by removing unused variables

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -24,7 +24,6 @@ module mpas_subdriver
  
       implicit none
 
-      real (kind=RKIND) :: dt
       character(len=StrKIND) :: timeStamp
       integer :: ierr
 

--- a/src/framework/mpas_block_creator.F
+++ b/src/framework/mpas_block_creator.F
@@ -59,7 +59,7 @@ module mpas_block_creator
      type (block_type), pointer :: blockCursor
      type (field1dInteger), pointer :: fieldCursor
  
-     integer :: i, iHalo
+     integer :: i
      integer :: nBlocks
  
      nBlocks = size(blockID)
@@ -147,10 +147,7 @@ module mpas_block_creator
 
      integer, dimension(:), pointer :: sendingHaloLayers
 
-     type (mpas_exchange_list), pointer :: exchListPtr
-
      integer :: nCellsInBlock, maxEdges, nHalos
-     integer :: i, iHalo
 
      nHalos = config_num_halos
 
@@ -285,15 +282,12 @@ module mpas_block_creator
 
      type (field0dInteger), pointer :: offSetCursor, edgeLimitCursor
      type (field1dInteger), pointer :: indexToCellCursor, indexToEdgeCursor, nEdgesCursor, haloCursor, nEdgesSolveCursor
-     type (field2dInteger), pointer :: edgesOnCellCursor, cellsOnEdgeCursor, cellsOnCellCursor
-
-     type (mpas_exchange_list), pointer :: exchListPtr
+     type (field2dInteger), pointer :: edgesOnCellCursor, cellsOnEdgeCursor
 
      integer, dimension(:), pointer :: localEdgeList
      integer, dimension(:), pointer :: sendingHaloLayers
      integer :: nEdgesLocal, nCellsInBlock, maxEdges, edgeDegree, nHalos
      integer :: haloStart
-     integer :: iBlock, i, j, k
 
      ! Setup sendingHaloLayers
      allocate(sendingHaloLayers(1))
@@ -510,10 +504,8 @@ module mpas_block_creator
 
      type (graph), pointer :: blockGraph, blockGraphWithHalo
 
-     type (mpas_exchange_list), pointer :: exchListPtr
-
      integer :: nHalos, nCellsInBlock, nCellsInHalo, maxEdges
-     integer :: iHalo, iBlock, i
+     integer :: iHalo
 
      nHalos = config_num_halos
      dminfo => indexToCellID % block % domain % dminfo
@@ -768,15 +760,15 @@ module mpas_block_creator
      type (field1dInteger), pointer :: haloIndices
 
      type (field0dInteger), pointer :: offSetCursor, edgeLimitCursor
-     type (field1dInteger), pointer :: indexToCellCursor, nEdgesCursor, nCellsSolveCursor, indexToEdgeCursor, nEdgesSolveCursor, haloCursor
+     type (field1dInteger), pointer :: nEdgesCursor, nCellsSolveCursor, indexToEdgeCursor, nEdgesSolveCursor, haloCursor
      type (field2dInteger), pointer :: edgesOnCellCursor, cellsOnEdgeCursor
 
      integer, dimension(:), pointer :: sendingHaloLayers
      integer, dimension(:), pointer :: array1dHolder, localEdgeList
      integer, dimension(:,:), pointer :: array2dHolder
 
-     integer :: iHalo, iBlock, i, j, k
-     integer :: nHalos, nBlocks, nCellsInBlock, nEdgesLocal, haloStart, haloEnd, haloSize
+     integer :: iHalo, iBlock, i, j
+     integer :: nHalos, nBlocks, nCellsInBlock, nEdgesLocal, haloSize
      integer :: maxEdges, edgeDegree
 
      type (hashtable), dimension(:), pointer :: edgeList

--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -74,7 +74,7 @@ module mpas_block_decomp
       integer, dimension(:), allocatable :: local_block_list
       integer, dimension(:,:), allocatable :: sorted_local_cell_list
 
-      integer :: i, j, global_block_id, local_block_id, owning_proc, iunit, istatus
+      integer :: i, global_block_id, local_block_id, owning_proc, iunit, istatus
       integer :: blocks_per_proc
       integer, dimension(:), pointer :: local_nvertices
       character (len=StrKIND) :: filename

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -910,8 +910,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
 
       integer :: i, j, k, kk, iBlock
-      integer :: totalSize, nMesgRecv, nMesgSend, recvNeighbor, sendNeighbor, currentProc, offset
-      integer :: totalSent, totalRecv
+      integer :: totalSize, nMesgRecv, nMesgSend, recvNeighbor, sendNeighbor, currentProc
+      integer :: totalSent
       integer, allocatable, dimension(:) :: numToSend, numToRecv
       integer, allocatable, dimension(:) :: ownedList, ownedListIndex, ownedBlock, neededList, neededListIndex, neededBlock
       integer, allocatable, dimension(:) :: offsetList, ownedLimitList
@@ -1500,7 +1500,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       ! local variables
       !-----------------------------------------------------------------
       type (mpas_multihalo_exchange_list), pointer :: sendListCursor, recvListCursor
-      type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+      type (mpas_exchange_list), pointer :: exchListPtr
       type (mpas_communication_list), pointer :: commListPtr, commListPtr2
       logical :: comm_list_found
       integer :: nAdded, bufferOffset
@@ -1673,13 +1673,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: Halo layers to communicated. Defaults to all.
 
      type (field1dInteger), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i
@@ -1964,13 +1963,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field2dInteger), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j
@@ -2256,13 +2254,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field3dInteger), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j, k
@@ -2555,13 +2552,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field1dReal), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i
@@ -2844,13 +2840,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field2dReal), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j
@@ -3137,13 +3132,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field3dReal), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j, k
@@ -3438,13 +3432,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
 
      type (field4dReal), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j, k, l
@@ -3747,13 +3740,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      integer, dimension(:), pointer, optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all.
 
      type (field5dReal), pointer :: fieldInPtr, fieldOutPtr
-     type (mpas_exchange_list), pointer :: exchListPtr, exchListPtr2
+     type (mpas_exchange_list), pointer :: exchListPtr
      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
      type (dm_info), pointer :: dminfo
 
      logical :: comm_list_found
 
-     integer :: lastPackedIdx, lastUnpackedIdx, nPacked, nUnpacked
      integer :: nAdded, bufferOffset
      integer :: mpi_ierr
      integer :: iHalo, iBuffer, i, j, k, l, m
@@ -4063,13 +4055,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field1DInteger), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 1
         if(field % dimSizes(i) <= 0) then
@@ -4233,13 +4223,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field2DInteger), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 2
         if(field % dimSizes(i) <= 0) then
@@ -4405,13 +4393,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field3DInteger), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j, k
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 3
         if(field % dimSizes(i) <= 0) then
@@ -4583,13 +4569,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field1dReal), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 1
         if(field % dimSizes(i) <= 0) then
@@ -4751,13 +4735,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field2dReal), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 2
         if(field % dimSizes(i) <= 0) then
@@ -4922,13 +4904,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field3dReal), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j, k
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 3
         if(field % dimSizes(i) <= 0) then
@@ -5099,13 +5079,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field4dReal), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j, k, l
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 4
         if(field % dimSizes(i) <= 0) then
@@ -5285,13 +5263,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (dm_info), pointer :: dminfo
       type (field5dReal), pointer :: fieldCursor, fieldCursor2
       type (mpas_exchange_list), pointer :: exchListPtr
-      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr, commListPtr2
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
       integer :: mpi_ierr
       integer :: nHaloLayers, iHalo, i, j, k, l, m
       integer :: bufferOffset, nAdded
       integer, dimension(:), pointer :: haloLayers
-
-      logical :: comm_list_found
 
       do i = 1, 5
         if(field % dimSizes(i) <= 0) then

--- a/src/framework/mpas_hash.F
+++ b/src/framework/mpas_hash.F
@@ -89,7 +89,7 @@ module mpas_hash
      type (hashtable), intent(inout) :: h !< Input/Output: Hashtable
  
      ! Local variables
-     integer :: hashval, i
+     integer :: hashval
      type (hashnode), pointer :: hn 
  
      hashval = mod(key, TABLESIZE) + 1  
@@ -123,7 +123,7 @@ module mpas_hash
       type (hashtable), intent(inout) :: h !< Input/Output: Hashtable
   
       ! Local variables
-      integer :: hashval, i
+      integer :: hashval
       type (hashnode), pointer :: cursor 
   
       mpas_hash_search = .false.

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1379,10 +1379,6 @@ module mpas_io
       integer, intent(out) :: val
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      integer, dimension(1) :: start
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_int0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1399,9 +1395,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       integer, dimension(:), intent(out) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_int1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1420,9 +1413,6 @@ module mpas_io
       integer, dimension(:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_int2d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1439,9 +1429,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       integer, dimension(:,:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_int3d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1460,9 +1447,6 @@ module mpas_io
       integer, dimension(:,:,:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_int4d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1479,10 +1463,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), intent(out) :: val
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      integer, dimension(1) :: start
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1501,9 +1481,6 @@ module mpas_io
       real (kind=RKIND), dimension(:), intent(out) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1520,9 +1497,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), dimension(:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real2d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1541,9 +1515,6 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real3d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1560,9 +1531,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), dimension(:,:,:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real4d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1581,9 +1549,6 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:,:,:), intent(out) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_real5d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1600,9 +1565,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       character (len=*), intent(out) :: val
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_get_var_char0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1765,10 +1727,6 @@ module mpas_io
       integer, intent(in) :: val
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      integer, dimension(1) :: start
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_int0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1785,9 +1743,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       integer, dimension(:), intent(in) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_int1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1806,9 +1761,6 @@ module mpas_io
       integer, dimension(:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_int2d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1825,9 +1777,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       integer, dimension(:,:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_int3d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1846,9 +1795,6 @@ module mpas_io
       integer, dimension(:,:,:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_int4d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1865,10 +1811,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), intent(in) :: val
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      integer, dimension(1) :: start
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1887,9 +1829,6 @@ module mpas_io
       real (kind=RKIND), dimension(:), intent(in) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1906,9 +1845,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), dimension(:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real2d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1927,9 +1863,6 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real3d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1946,9 +1879,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       real (kind=RKIND), dimension(:,:,:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real4d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1967,9 +1897,6 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:,:,:), intent(in) :: array
       integer, intent(out), optional :: ierr
 
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
-
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_real5d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -1986,9 +1913,6 @@ module mpas_io
       character (len=*), intent(in) :: fieldname
       character (len=*), intent(in) :: val
       integer, intent(out), optional :: ierr
-
-      integer :: pio_ierr
-      type (fieldlist_type), pointer :: field_cursor
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_var_char0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR

--- a/src/framework/mpas_sort.F
+++ b/src/framework/mpas_sort.F
@@ -124,7 +124,7 @@ module mpas_sort
       integer, intent(in) :: nArray !< Input: Array size
       integer, dimension(nArray), intent(inout) :: array !< Input/Output: Array to be sorted
 
-      integer :: i, j, top, l, r, pivot, s
+      integer :: i, top, l, r, pivot, s
       integer :: pivot_value
       integer, dimension(1) :: temp
       integer, dimension(1000) :: lstack, rstack
@@ -197,7 +197,7 @@ if (top > 1000) write(stderrUnit,*) 'Error: Quicksort exhausted its stack.'
       integer, intent(in) :: nArray !< Input: Array size
       real (kind=RKIND), dimension(nArray), intent(inout) :: array !< Input/Output: Array to be sorted
 
-      integer :: i, j, top, l, r, pivot, s
+      integer :: i, top, l, r, pivot, s
       real (kind=RKIND) :: pivot_value
       real (kind=RKIND), dimension(1) :: temp
       integer, dimension(1000) :: lstack, rstack
@@ -270,7 +270,7 @@ if (top > 1000) write(stderrUnit,*) 'Error: Quicksort exhausted its stack.'
       integer, intent(in) :: nArray !< Input: Array size
       integer, dimension(2,nArray), intent(inout) :: array !< Input/Output: Array to be sorted
 
-      integer :: i, j, top, l, r, pivot, s
+      integer :: i, top, l, r, pivot, s
       integer :: pivot_value
       integer, dimension(2) :: temp
       integer, dimension(1000) :: lstack, rstack
@@ -343,7 +343,7 @@ if (top > 1000) write(stderrUnit,*) 'Error: Quicksort exhausted its stack.'
       integer, intent(in) :: nArray !< Input: Array size
       real (kind=RKIND), dimension(2,nArray), intent(inout) :: array !< Input/Output: Array to be sorted
 
-      integer :: i, j, top, l, r, pivot, s
+      integer :: i, top, l, r, pivot, s
       real (kind=RKIND) :: pivot_value
       real (kind=RKIND), dimension(2) :: temp
       integer, dimension(1000) :: lstack, rstack

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -537,8 +537,6 @@ module mpas_timekeeping
 
       type (MPAS_Alarm_type), pointer :: alarmPtr
 
-      type (MPAS_TimeInterval_type) :: alarmTimeInterval
-      type (MPAS_Time_type) :: alarmTime
       character (len=StrKIND) :: printString
 
       ierr = 0
@@ -749,7 +747,6 @@ module mpas_timekeeping
       type (MPAS_Time_type) :: previousRingTime
       type (MPAS_Time_type) :: negativeNeighborRingTime
       type (MPAS_Time_type) :: positiveNeighborRingTime
-      type (MPAS_TimeInterval_type) :: ringTimeInterval 
       type (MPAS_Alarm_type), pointer :: alarmPtr
 
       now = mpas_get_clock_time(clock, MPAS_NOW, ierr)
@@ -1007,7 +1004,7 @@ module mpas_timekeeping
       integer, intent(out), optional :: ierr
 
       integer, parameter :: integerMaxDigits = 8
-      integer :: days, hours, minutes, seconds
+!      integer :: days, hours, minutes, seconds
       integer :: numerator, denominator, denominatorPower
       type (MPAS_TimeInterval_type) :: zeroInterval
 

--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -30,9 +30,7 @@ module mpas_geometry_utils
       real (kind=RKIND) :: a, b, c          ! Side lengths of spherical triangle ABC
    
       real (kind=RKIND) :: ABx, ABy, ABz    ! The components of the vector AB
-      real (kind=RKIND) :: mAB              ! The magnitude of AB
       real (kind=RKIND) :: ACx, ACy, ACz    ! The components of the vector AC
-      real (kind=RKIND) :: mAC              ! The magnitude of AC
    
       real (kind=RKIND) :: Dx               ! The i-components of the cross product AB x AC
       real (kind=RKIND) :: Dy               ! The j-components of the cross product AB x AC
@@ -201,9 +199,10 @@ module mpas_geometry_utils
       real (kind=RKIND), dimension(n,m)  :: b
       real (kind=RKIND), dimension(m,m)  :: w,wt,h
       real (kind=RKIND), dimension(n,m)  :: at, ath
-      real (kind=RKIND), dimension(n,n)  :: ata, ata_inv, atha, atha_inv
+!      real (kind=RKIND), dimension(n,n)  :: ata, ata_inv, atha, atha_inv
+      real (kind=RKIND), dimension(n,n)  :: ata, atha, atha_inv
       integer, dimension(n) :: indx
-      integer :: i,j
+!      integer :: i,j
    
       if ( (ne<n) .or. (ne<m) ) then
          write(stdoutUnit,*) ' error in poly_fit_2 inversion ',m,n,ne

--- a/src/operators/mpas_rbf_interpolation.F
+++ b/src/operators/mpas_rbf_interpolation.F
@@ -466,7 +466,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), intent(in) :: alpha !< Input: Characteristic length scale of RBFs
     real(kind=RKIND), dimension(pointCount), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+1, pointCount+1) :: dirichletMatrix
@@ -541,7 +541,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(2,3) :: planeBasisVectors !< Input: Basis vectors for the interpolation plane
     real(kind=RKIND), dimension(pointCount), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+3, pointCount+3) :: dirichletMatrix
@@ -614,7 +614,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), intent(in) :: alpha !< Input: Characteristic length scale for RBFs
     real(kind=RKIND), dimension(pointCount), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+4, pointCount+4) :: dirichletMatrix
@@ -698,7 +698,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(pointCount), intent(out) :: dirichletCoefficients !< Output: Coefficients with Dirichlet BCs
     real(kind=RKIND), dimension(pointCount), intent(out) :: neumannCoefficients !< Output: Coefficients with Neumann BCs
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+1, pointCount+1) :: dirichletMatrix, neumannMatrix
@@ -799,7 +799,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(pointCount), intent(out) :: dirichletCoefficients !< Output: List of Dirichlet coefficients
     real(kind=RKIND), dimension(pointCount), intent(out) :: neumannCoefficients !< Output: List of Neumann coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+3, pointCount+3) :: dirichletMatrix, neumannMatrix
@@ -903,7 +903,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(pointCount), intent(out) :: dirichletCoefficients !< Output: List of Dirichlet coefficients
     real(kind=RKIND), dimension(pointCount), intent(out) :: neumannCoefficients !< Outut: List of Neumann coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+4, pointCount+4) :: dirichletMatrix, neumannMatrix
@@ -997,7 +997,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), intent(in) :: alpha !< Input: Characteristic length scale of RBFs
     real(kind=RKIND), dimension(pointCount, 3), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+3,pointCount+3) :: matrix, matrixCopy
@@ -1088,10 +1088,8 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(2,3) :: planeBasisVectors !< Input: Basis vectors for interpolation plane
     real(kind=RKIND), dimension(pointCount, 3), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
-
-    real(kind=RKIND) :: rSquared, rbfValue, unitVectorDotProduct
 
     real(kind=RKIND), dimension(pointCount,2) :: planarSourcePoints
     real(kind=RKIND), dimension(pointCount,2) :: planarUnitVectors
@@ -1201,7 +1199,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), intent(in) :: alpha !< Input: Characteristic length scale of RBFs
     real(kind=RKIND), dimension(pointCount, 3), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount+3, pointCount+3) :: matrix, matrixCopy
@@ -1299,7 +1297,7 @@ module mpas_rbf_interpolation
     real(kind=RKIND), dimension(2,3), intent(in) :: planeBasisVectors !< Input: Basis vectors for interpolation plane
     real(kind=RKIND), dimension(pointCount, 3), intent(out) :: coefficients !< Output: List of coefficients
 
-    integer :: i, j
+    integer :: i
     integer :: matrixSize
 
     real(kind=RKIND), dimension(pointCount,2) :: planarSourcePoints

--- a/src/operators/mpas_spline_interpolation.F
+++ b/src/operators/mpas_spline_interpolation.F
@@ -201,7 +201,7 @@ subroutine mpas_integrate_cubic_spline(x,y,y2ndDer,n,x1,x2,y_integral)  !{{{
 
 !  local variables:
   
-  integer :: i,j,k
+  integer :: j
   real(kind=RKIND) :: h,h2, A2,B2, F1,F2, eps1
 
   if (x1<x(1).or.x2>x(n).or.x1>x2) then
@@ -291,7 +291,7 @@ subroutine mpas_integrate_cubic_spline(x,y,y2ndDer,n,x1,x2,y_integral)  !{{{
 
 !  local variables:
 
-  integer :: i,j,k
+  integer :: j,k
   real(kind=RKIND) :: h,h2, A2,B2, F1,F2, eps1
 
   y_integral = 0.0

--- a/src/operators/mpas_tensor_operations.F
+++ b/src/operators/mpas_tensor_operations.F
@@ -224,7 +224,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, iCell, nCellsCompute, i,j,k,p,q, nVertLevels
+      integer :: iEdge, iCell, nCellsCompute, i,k,p,q, nVertLevels
 
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -513,9 +513,8 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: i,j,k,p,q
+      integer :: i,j,p,q
 
-      real (kind=RKIND) :: determinant
       real (kind=RKIND), dimension(3) :: zonalUnitVector, meridionalUnitVector, verticalUnitVector
       real (kind=RKIND), dimension(3,3) :: rotationMatrix, strainRateR3_3x3, strainRateLonLat3x3
 
@@ -593,11 +592,10 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: i,j,k,p,q
+      integer :: i,j,p,q
 
-      real (kind=RKIND) :: determinant
       real (kind=RKIND), dimension(3) :: zonalUnitVector, meridionalUnitVector, verticalUnitVector
-      real (kind=RKIND), dimension(3,3) :: rotationMatrix, strainRateR3_3x3, tensorLonLatR3x3, A
+      real (kind=RKIND), dimension(3,3) :: rotationMatrix, strainRateR3_3x3, tensorLonLatR3x3
 
       call mpas_zonal_meridional_vectors(lon, lat, zonalUnitVector, meridionalUnitVector, verticalUnitVector)
 
@@ -667,7 +665,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: i,j,k,p,q
+      integer :: i,j,p,q
 
       real (kind=RKIND), dimension(3) :: zonalUnitVector, meridionalUnitVector, verticalUnitVector
       real (kind=RKIND), dimension(3,3) :: rotationMatrix, strainRateR3_3x3, strainRateLonLat3x3
@@ -743,7 +741,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: i,j,k,p,q
+      integer :: i,j,p,q
 
       real (kind=RKIND), dimension(3) :: zonalUnitVector, meridionalUnitVector, verticalUnitVector
       real (kind=RKIND), dimension(3,3) :: rotationMatrix, strainRateR3_3x3, strainRateLonLat3x3
@@ -840,7 +838,7 @@ contains
       type (block_type), pointer :: block
       type (dm_info), pointer :: dminfo
 
-      integer :: nCells, nCellsSolve, nCellsSolveSum, nCellsGlobal, nEdges, nVertices, nVertLevels, iCell, iEdge, k, i, p, strainRateLonLatRIndex
+      integer :: nCells, nCellsSolve, nCellsSolveSum, nCellsGlobal, nEdges, nVertices, nVertLevels, iCell, iEdge, p, strainRateLonLatRIndex
       integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND) :: xVelocity, yVelocity, cn, cs, r, theta, rot, f, g1, g2, fcos, pi2l, ld, &

--- a/src/operators/mpas_tracer_advection_helpers.F
+++ b/src/operators/mpas_tracer_advection_helpers.F
@@ -106,8 +106,7 @@ module mpas_tracer_advection_helpers
 
       integer, dimension(:), pointer :: cell_indices 
       integer, dimension(:,:), pointer :: sorted_cell_indices
-      integer :: cell1, cell2, iEdge, n, i, j, j_in, iCell, k, nVertLevels
-      logical :: addcell, highOrderAdvection
+      integer :: cell1, cell2, iEdge, n, i, iCell, k, nVertLevels
 
       type (hashtable) :: cell_hash
 
@@ -307,29 +306,26 @@ module mpas_tracer_advection_helpers
 !  local variables
 
       real (kind=RKIND), dimension(2, grid % nEdges) :: thetae
-      real (kind=RKIND), dimension(grid % nEdges) :: xe, ye
+!      real (kind=RKIND), dimension(grid % nEdges) :: xe, ye
       real (kind=RKIND), dimension(grid % nCells) :: theta_abs
 
       real (kind=RKIND), dimension(25) :: xc, yc, zc ! cell center coordinates
       real (kind=RKIND), dimension(25) :: thetav, thetat, dl_sphere
-      real (kind=RKIND) :: xm, ym, zm, dl, xec, yec, zec
-      real (kind=RKIND) :: thetae_tmp, xe_tmp, ye_tmp
+      real (kind=RKIND) :: xec, yec, zec
+      real (kind=RKIND) :: thetae_tmp
       real (kind=RKIND) :: xv1, xv2, yv1, yv2, zv1, zv2
-      integer :: i, j, k, ip1, ip2, m, n, ip1a, ii
+      integer :: i, j, k, ip1, ip2, n
       integer :: iCell, iEdge
       real (kind=RKIND) :: pii
-      real (kind=RKIND) :: x0, y0, x1, y1, x2, y2, x3, y3, x4, y4, x5, y5
-      real (kind=RKIND) :: pdx1, pdx2, pdx3, pdy1, pdy2, pdy3, dx1, dx2, dy1, dy2
-      real (kind=RKIND) :: angv1, angv2, dl1, dl2
-      real (kind=RKIND), dimension(25) :: dxe, dye, x2v, y2v, xp, yp
+!      real (kind=RKIND) :: y1, x2, y2, x3, y3, x4, y4, x5, y5
+      real (kind=RKIND), dimension(25) :: xp, yp
       
       real (kind=RKIND) :: amatrix(25,25), bmatrix(25,25), wmatrix(25,25)
       real (kind=RKIND) :: length_scale
-      integer :: ma,na, cell_add, mw, nn
+      integer :: ma,na, cell_add, mw
       integer, dimension(25) :: cell_list
 
 
-      integer :: cell1, cell2
       integer, parameter :: polynomial_order = 2
       logical, parameter :: debug = .false.
       logical, parameter :: least_squares = .true.
@@ -337,7 +333,7 @@ module mpas_tracer_advection_helpers
 
       logical, parameter :: reset_poly = .true.
 
-      real (kind=RKIND) :: rcell, cos2t, costsint, sin2t
+      real (kind=RKIND) :: cos2t, costsint, sin2t
       real (kind=RKIND), dimension(grid%maxEdges) :: angle_2d
 
 !---    

--- a/src/operators/mpas_tracer_advection_mono.F
+++ b/src/operators/mpas_tracer_advection_mono.F
@@ -79,8 +79,7 @@ module mpas_tracer_advection_mono
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, highOrderAdvectionMask, edgeSignOnCell, edgesOnCell
 
       real (kind=RKIND) :: flux_upwind, tracer_min_new, tracer_max_new, tracer_upwind_new, scale_factor
-      real (kind=RKIND) :: flux, tracer_weight, invDvEdge, invAreaCell1, invAreaCell2
-      real (kind=RKIND) :: cur_max, cur_min, new_max, new_min
+      real (kind=RKIND) :: flux, tracer_weight, invAreaCell1, invAreaCell2
       real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell, verticalDivergenceFactor
       real (kind=RKIND), dimension(:,:), pointer :: tracer_cur, tracer_new, upwind_tendency, inv_h_new, tracer_max, tracer_min

--- a/src/operators/mpas_tracer_advection_std.F
+++ b/src/operators/mpas_tracer_advection_std.F
@@ -78,7 +78,7 @@ module mpas_tracer_advection_std
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, highOrderAdvectionMask, edgeSignOnCell, edgesOnCell
 
-      real (kind=RKIND) :: flux, tracer_weight, invDvEdge, invAreaCell1, invAreaCell2
+      real (kind=RKIND) :: tracer_weight, invAreaCell1
       real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell, verticalDivergenceFactor
       real (kind=RKIND), dimension(:,:), pointer :: tracer_cur, high_order_horiz_flux, high_order_vert_flux

--- a/src/operators/mpas_vector_operations.F
+++ b/src/operators/mpas_vector_operations.F
@@ -556,7 +556,7 @@ contains
 
     integer :: nCells, nEdges
     integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgesOnCell
-    integer :: iEdge, iCell, cell1, cell2, vertex1, vertex2
+    integer :: iEdge, iCell, cell1, cell2
     real(kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell, xEdge, yEdge, zEdge
     real(kind=RKIND), dimension(:,:), pointer :: localVerticalUnitVectors, edgeNormalVectors
     real(kind=RKIND), dimension(:,:,:), pointer :: cellTangentPlane


### PR DESCRIPTION
This pull request removes unused variables reported by the gfortran -Wall flag from many shared modules. There are still some unused variables that have not been removed from modules, as these modules may in fact use these variables in code that is contained in include files (i.e., code included by #include directives), which are apparently not properly accounted for by the gfortran compiler.

In the atmosphere core, I'm getting bit-identical results with these variables removed, but it seems at least possible that the code could produce different results at the level of machine precision with other compilers or optimization. This could happen, e.g., if the removed variables caused a shift in alignment of other variables, which could in turn affect how variables are computed with vector instructions (SSE, AVX).
