### PR TITLE
Update the MPAS-A checkout_data_files.sh script

### DIFF
--- a/src/core_atmosphere/physics/checkout_data_files.sh
+++ b/src/core_atmosphere/physics/checkout_data_files.sh
@@ -4,26 +4,35 @@
 # File: checkout_data_files.sh
 #
 # The purpose of this script is to obtain lookup tables used by the WRF physics
-#   packages. At present, the only method for acquiring these tables is through
+#   packages.  At present, the only method for acquiring these tables is through
 #   the MPAS-Dev github repository using either git, svn, or curl.
 #
 # If none of the methods used in this script are successful in acquiring the 
 #   tables, please attempt to manually download the files from the MPAS-Data 
-#   repository at www.github.com/MPAS-Dev/MPAS-Data/. All *.TBL and *.DBL files
-#   should be copied into a subdirectory named 
-#   src/core_atmosphere/physics/physics_wrf/files before continuing the build
-#   process.
+#   repository at https://github.com/MPAS-Dev/MPAS-Data/.  All *.TBL and *DATA* 
+#   files, as well as the VERSION file, should be copied into a subdirectory 
+#   named src/core_atmosphere/physics/physics_wrf/files before continuing 
+#   the build process.
 #
 # If all else fails, please contact the MPAS-A developers 
 #   via "mpas-atmosphere-help@googlegroups.com".
 #
 ################################################################################
 
-if [ -s physics_wrf/files/CAM_ABS_DATA.DBL ]; then
-   echo "*** WRF physics tables appear to already exist; no need to obtain them again ***"
-   exit 0
+if [ -s physics_wrf/files/VERSION ]; then
+   vers=`cat physics_wrf/files/VERSION`
+   if [ "$vers" = "2.0" ]; then
+      echo "*** WRF physics tables appear to already exist; no need to obtain them again ***"
+      exit 0
+   else
+      echo "*** WRF physics tables appear to be out of date; downloading the latest version ***"
+   fi
 fi
 
+
+if [ ! -d physics_wrf/files ]; then
+   mkdir -p physics_wrf/files
+fi
 
 #
 # Try using 'git'
@@ -33,7 +42,7 @@ if [ $? -eq 0 ]; then
    echo "*** trying git to obtain WRF physics tables ***"
    git clone git://github.com/MPAS-Dev/MPAS-Data.git
    if [ $? -eq 0 ]; then
-      mv MPAS-Data/atmosphere/physics_wrf/files physics_wrf/
+      mv MPAS-Data/atmosphere/physics_wrf/files/* physics_wrf/files
       rm -rf MPAS-Data
       exit 0
    else
@@ -52,7 +61,7 @@ if [ $? -eq 0 ]; then
    echo "*** trying svn to obtain WRF physics tables ***"
    svn checkout --non-interactive --trust-server-cert https://github.com/MPAS-Dev/MPAS-Data.git
    if [ $? -eq 0 ]; then
-      mv MPAS-Data.git/trunk/atmosphere/physics_wrf/files physics_wrf/
+      mv MPAS-Data.git/trunk/atmosphere/physics_wrf/files/* physics_wrf/files
       rm -rf MPAS-Data.git
       exit 0
    else
@@ -74,7 +83,7 @@ if [ $? -eq 0 ]; then
       which unzip
       if [ $? -eq 0 ]; then
          unzip master.zip
-         mv MPAS-Data-master/atmosphere/physics_wrf/files physics_wrf/
+         mv MPAS-Data-master/atmosphere/physics_wrf/files/* physics_wrf/files
          rm -rf master.zip MPAS-Data-master
          exit 0
       else


### PR DESCRIPTION
The updated script will re-checkout the WRF physics tables if the user doesn't have "version 2.0" of the datasets. This is necessary to ensure that users have single-precision tables for WRF physics.
