### PR TITLE
Moving the parsing of registry into cores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore Files in the MPAS Direcory
 
 # All pre-processed Fortran files in MPAS specific directories
+src/core_*/Registry_processed.xml
 src/core_*/*.f90
 src/framework/*.f90
 src/driver/*.f90

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,9 +26,12 @@ drver:  $(AUTOCLEAN_DEPS) reg_includes externals frame ops dycore
 	( cd driver; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 endif
 
-reg_includes: $(AUTOCLEAN_DEPS)  
+reg_includes: core_reg $(AUTOCLEAN_DEPS)  
 	( cd registry; $(MAKE) CC="$(SCC)" )
-	( cd inc; $(CPP) $(CPPFLAGS) $(CPPINCLUDES) ../core_$(CORE)/Registry.xml | ../registry/parse )
+	( cd inc; ../registry/parse < ../core_$(CORE)/Registry_processed.xml)
+
+core_reg:
+	(cd core_$(CORE); $(MAKE) core_reg )
 
 frame: $(AUTOCLEAN_DEPS) reg_includes externals
 	( cd framework; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -8,6 +8,9 @@ OBJS = mpas_atm_mpas_core.o \
 
 all: physcore dycore atmcore
 
+core_reg:
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
+
 physcore:
 	( cd physics; $(MAKE) all )
 	( mkdir libphys; cd libphys; ar -x ../physics/libphys.a )
@@ -29,6 +32,7 @@ clean:
 	( cd ../..; rm -f *DATA* )
 	$(RM) -r libphys
 	$(RM) *.o *.mod *.f90 libdycore.a
+	$(RM) Registry_processed.xml
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -20,6 +20,9 @@ all: core_hyd
 core_hyd: $(OBJS)
 	ar -ru libdycore.a $(OBJS)
 
+core_reg:
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
+
 mpas_init_atm_cases.o: \
 	read_geogrid.o \
 	mpas_atm_advection.o \
@@ -60,6 +63,7 @@ mpas_atmphys_initialize_real.o:  \
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
+	$(RM) Registry_processed.xml
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_landice/Makefile
+++ b/src/core_landice/Makefile
@@ -15,6 +15,9 @@ all: core_landice
 core_landice: $(OBJS)
 	ar -ru libdycore.a $(OBJS)
 
+core_reg:
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
+
 mpas_li_mpas_core.o: mpas_li_time_integration.o \
                      mpas_li_setup.o \
                      mpas_li_velocity.o \
@@ -42,6 +45,7 @@ mpas_li_mask.o:
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
+	$(RM) Registry_processed.xml
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -63,6 +63,9 @@ libcvmix:
 core_hyd: $(OBJS)
 	ar -ru libdycore.a $(OBJS) cvmix/*.o
 
+core_reg:
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
+
 mpas_ocn_time_integration.o: mpas_ocn_time_integration_rk4.o mpas_ocn_time_integration_split.o
 
 mpas_ocn_time_integration_rk4.o: mpas_ocn_tendency.o mpas_ocn_diagnostics.o mpas_ocn_time_average_coupled.o mpas_ocn_sea_ice.o
@@ -203,6 +206,7 @@ clean:
 		(cd cvmix; make clean) \
 	fi
 	$(RM) *.o *.mod *.f90 libdycore.a
+	$(RM) Registry_processed.xml
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_sw/Makefile
+++ b/src/core_sw/Makefile
@@ -11,6 +11,9 @@ all: core_sw
 core_sw: $(OBJS)
 	ar -ru libdycore.a $(OBJS)
 
+core_reg:
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
+
 mpas_sw_test_cases.o:
 
 mpas_sw_advection.o:
@@ -23,6 +26,7 @@ mpas_sw_mpas_core.o: mpas_sw_global_diagnostics.o mpas_sw_test_cases.o mpas_sw_t
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
+	$(RM) Registry_processed.xml
 
 .F.o:
 	$(RM) $@ $*.mod


### PR DESCRIPTION
This allows cores to do more complicated parsing of registry. Then the
parse executable parses Registry_processed.xml which is the output from
the core target "core_reg".

This can be used for splitting a core's registry file into multiple sub files.
