### PR TITLE
Removing doxygen svn version strings from ocean.

### DIFF
--- a/src/core_ocean/mpas_ocn_constants.F
+++ b/src/core_ocean/mpas_ocn_constants.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean specific constants
 !> \author Doug Jacobsen
 !> \date   04/25/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains constants specific to the ocean model.
 !
@@ -77,7 +76,6 @@ contains
 !> \brief   Initializes the ocean constants
 !> \author  Doug Jacobsen
 !> \date    04/25/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine sets up constants for use in the ocean model.
 !

--- a/src/core_ocean/mpas_ocn_forcing.F
+++ b/src/core_ocean/mpas_ocn_forcing.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean forcing
 !> \author Doug Jacobsen
 !> \date   04/25/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains driver routines for building the forcing arrays.
 !
@@ -71,7 +70,6 @@ contains
 !> \brief   Determines the forcing arrays.
 !> \author  Doug Jacobsen
 !> \date    12/13/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the forcing arrays used later in MPAS.
 !
@@ -135,7 +133,6 @@ contains
 !> \brief   Initializes forcing module
 !> \author  Doug Jacobsen
 !> \date    12/13/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes the forcing modules.
 !
@@ -180,7 +177,6 @@ contains
 !> \brief   Transmission coefficient array for surface forcing.
 !> \author  Doug Jacobsen
 !> \date    10/03/2013
-!> \version SVN:$Id$
 !> \details 
 !>  This subroutine builds the transmission coefficient array for use in
 !>  applying surface fluxes deeper than the surface layer.
@@ -241,7 +237,6 @@ contains
 !> \brief   Transmission coefficient for surface forcing.
 !> \author  Doug Jacobsen
 !> \date    05/03/2013
-!> \version SVN:$Id$
 !> \details 
 !>  This function computes and returns the transmission coefficient for surface
 !>  forcing based on depth. It uses an exponential decay function to determine the

--- a/src/core_ocean/mpas_ocn_forcing_bulk.F
+++ b/src/core_ocean/mpas_ocn_forcing_bulk.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean bulk forcing
 !> \author Doug Jacobsen
 !> \date   04/25/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains routines for building the forcing arrays,
 !>  if bulk forcing is used.
@@ -63,7 +62,6 @@ contains
 !> \brief   Determines the forcing array used for the bulk forcing.
 !> \author  Doug Jacobsen
 !> \date    04/25/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the forcing arrays used later in MPAS.
 !
@@ -191,7 +189,6 @@ contains
 !> \brief   Initializes bulk forcing module
 !> \author  Doug Jacobsen
 !> \date    04/25/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes the bulk forcing module.
 !

--- a/src/core_ocean/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/mpas_ocn_sea_ice.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean sea ice formation module
 !> \author Doug Jacobsen
 !> \date   08/19/2013
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains routines for the formation of sea ice.
 !
@@ -65,7 +64,6 @@ contains
 !> \brief   Performs the formation of Sea Ice within the ocean.
 !> \author  Doug Jacobsen
 !> \date    08/19/2013
-!> \version SVN:$Id$
 !> \details 
 !>   ocn_sea_ice_formation performs the adjustment of tracer values
 !>   and layerThickness based on the formation of frazil ice within the ocean.
@@ -245,7 +243,6 @@ contains
 !> \brief   Computes the freezing temperature of the ocean.
 !> \author  Doug Jacobsen
 !> \date    08/29/2013
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the freezing temperature of the ocean at a given
 !>  salinity value.
@@ -265,7 +262,6 @@ contains
 !> \brief   Initializes ocean sea ice module.
 !> \author  Doug Jacobsen
 !> \date    08/19/2013
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes the ocean sea ice module and variables..
 !

--- a/src/core_ocean/mpas_ocn_thick_surface_flux.F
+++ b/src/core_ocean/mpas_ocn_thick_surface_flux.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean surface fluxes for thickness
 !> \author Doug Jacobsen
 !> \date   12/17/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains the routine for computing 
 !>  tendencies for thickness from surface fluxes
@@ -65,7 +64,6 @@ contains
 !> \brief   Computes tendency term from horizontal advection of thickness
 !> \author  Doug Jacobsen
 !> \date    15 September 2011
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the horizontal advection tendency for
 !>  thicknes based on current state and user choices of forcings.
@@ -154,7 +152,6 @@ contains
 !> \brief   Initializes ocean horizontal thickness surface fluxes
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes quantities related to thickness 
 !>  surface fluxes in the ocean. 

--- a/src/core_ocean/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/mpas_ocn_tracer_short_wave_absorption.F
@@ -5,7 +5,6 @@
 !> \brief MPAS ocean tracer short wave
 !> \author Doug Jacobsen
 !> \date   12/17/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains the routine for computing 
 !>  short wave tendencies
@@ -56,7 +55,6 @@ contains
 !> \brief   Computes tendency term for surface fluxes
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the tendency for tracers based on surface fluxes.
 !
@@ -120,7 +118,6 @@ contains
 !> \brief   Initializes ocean tracer surface flux quantities
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes quantities related to surface fluxes in the ocean.
 !

--- a/src/core_ocean/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -5,7 +5,6 @@
 !> \brief MPAS ocean tracer short wave
 !> \author Doug Jacobsen
 !> \date   12/17/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains the routine for computing 
 !>  short wave tendencies using Jerlov
@@ -70,7 +69,6 @@ contains
 !> \brief   Computes tendency term for surface fluxes
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the tendency for tracers based on surface fluxes.
 !
@@ -172,7 +170,6 @@ contains
 !> \brief   Initializes ocean tracer surface flux quantities
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes quantities related to surface fluxes in the ocean.
 !
@@ -203,7 +200,6 @@ contains
 !> \brief   Initializes short wave absorption fractions
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  Computes fraction of solar short-wave flux penetrating to
 !>  specified depth due to exponential decay in Jerlov water type.

--- a/src/core_ocean/mpas_ocn_tracer_surface_flux.F
+++ b/src/core_ocean/mpas_ocn_tracer_surface_flux.F
@@ -12,7 +12,6 @@
 !> \brief MPAS ocean tracer surface flux
 !> \author Doug Jacobsen
 !> \date   12/17/12
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains the routine for computing 
 !>  surface flux tendencies.  
@@ -64,7 +63,6 @@ contains
 !> \brief   Computes tendency term for surface fluxes
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the tendency for tracers based on surface fluxes.
 !
@@ -157,7 +155,6 @@ contains
 !> \brief   Initializes ocean tracer surface flux quantities
 !> \author  Doug Jacobsen
 !> \date    12/17/12
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes quantities related to surface fluxes in the ocean.
 !

--- a/src/core_ocean/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/mpas_ocn_vmix_cvmix.F
@@ -5,7 +5,6 @@
 !> \brief MPAS ocean vertical mixing interface to CVMix
 !> \author Todd Ringler
 !> \date   04 February 2013
-!> \version SVN:$Id:$
 !> \details
 !>  This module contains the routines for calls into CVMix
 !>
@@ -71,7 +70,6 @@ contains
 !> \brief   Computes mixing coefficients using CVMix
 !> \author  Todd Ringler
 !> \date    04 February 2013
-!> \version SVN:$Id$
 !> \details 
 !>  This routine computes the vertical mixing coefficients for momentum
 !>  and tracers by calling CVMix routines.
@@ -314,7 +312,6 @@ contains
 !> \ get and puts into CVMix
 !> \author  Todd Ringler
 !> \date    04 February 2013
-!> \version SVN:$Id$
 !> \details 
 !>  This routine initializes a variety of quantities related to 
 !>  vertical mixing in the ocean. Parameters are set by calling into CVMix


### PR DESCRIPTION
The ocean core previously had SVN keywords in the version line of
doxygen comments.
