### PR TITLE
Adding removal of *.i to clean targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ src/registry/parse
 
 # Ignore all namelist files.
 namelist.*
+
+# Intermediate files that may be produced by Intel compilers
+*.i
+*.i90

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -33,6 +33,9 @@ clean:
 	$(RM) -r libphys
 	$(RM) *.o *.mod *.f90 libdycore.a
 	$(RM) Registry_processed.xml
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -11,6 +11,9 @@ mpas_atm_advection.o:
 
 clean:
 	$(RM) *.o *.mod *.f90
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -199,6 +199,9 @@ mpas_atmphys_update.o: \
 clean:
 	$(RM) *.o *.mod *.f90 libphys.a
 	( cd physics_wrf; make clean )
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -76,6 +76,9 @@ module_sf_noahlsm.o: \
 
 clean:
 	$(RM) *.f90 *.o *.mod
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 ifeq "$(GEN_F90)" "true"

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -64,6 +64,9 @@ mpas_atmphys_initialize_real.o:  \
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
 	$(RM) Registry_processed.xml
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_landice/Makefile
+++ b/src/core_landice/Makefile
@@ -46,6 +46,9 @@ mpas_li_mask.o:
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
 	$(RM) Registry_processed.xml
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -207,6 +207,9 @@ clean:
 	fi
 	$(RM) *.o *.mod *.f90 libdycore.a
 	$(RM) Registry_processed.xml
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_sw/Makefile
+++ b/src/core_sw/Makefile
@@ -27,6 +27,9 @@ mpas_sw_mpas_core.o: mpas_sw_global_diagnostics.o mpas_sw_test_cases.o mpas_sw_t
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
 	$(RM) Registry_processed.xml
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/driver/Makefile
+++ b/src/driver/Makefile
@@ -11,6 +11,9 @@ mpas.o: mpas_subdriver.o
 
 clean:
 	$(RM) *.o *.mod *.f90
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -76,6 +76,9 @@ mpas_io_units.o:
 
 clean:
 	$(RM) *.o *.mod *.f90 libframework.a
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/operators/Makefile
+++ b/src/operators/Makefile
@@ -29,6 +29,9 @@ mpas_geometry_utils.o:
 
 clean:
 	$(RM) *.o *.mod *.f90 libops.a
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/registry/Makefile
+++ b/src/registry/Makefile
@@ -12,6 +12,9 @@ parse: $(OBJS)
 
 clean:
 	$(RM) *.o ezxml/*.o parse
+	@# Certain systems with intel compilers generate *.i files
+	@# This removes them during the clean process
+	$(RM) *.i
 
 .c.o:
 	$(CC) -c $<


### PR DESCRIPTION
This is for specific versions of intel of specific operating systems.
Some versions create *.i files which are not removed during the clean
process presently.
