### PR TITLE
Set default namelist values in init_atmosphere and atmosphere Registry.xml files

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -34,22 +34,23 @@
 <!-- **************************************************************************************** -->
 
         <nml_record name="nhyd_model" in_defaults="true">
-                <nml_option name="config_time_integration"           type="character"     default_value="SRK3"/>
-                <nml_option name="config_dt"                         type="real"          default_value="600.0"/>
-                <nml_option name="config_calendar_type"              type="character"     default_value="gregorian"/>
-                <nml_option name="config_start_time"                 type="character"     default_value="0000-01-01_00:00:00"/>
-                <nml_option name="config_stop_time"                  type="character"     default_value="none"/>
-                <nml_option name="config_run_duration"               type="character"     default_value="none"/>
-                <nml_option name="config_horiz_mixing"               type="character"     default_value="2d_smagorinsky"/>
+                <nml_option name="config_time_integration"           type="character"     default_value="SRK3"        in_defaults="false"/>
+                <nml_option name="config_dt"                         type="real"          default_value="450.0"/>
+                <nml_option name="config_calendar_type"              type="character"     default_value="gregorian"   in_defaults="false"/>
+                <nml_option name="config_start_time"                 type="character"     default_value="2010-10-23_00:00:00"/>
+                <nml_option name="config_stop_time"                  type="character"     default_value="none"        in_defaults="false"/>
+                <nml_option name="config_run_duration"               type="character"     default_value="5_00:00:00"/>
+                <nml_option name="config_number_of_sub_steps"        type="integer"       default_value="6"/>
                 <nml_option name="config_h_mom_eddy_visc2"           type="real"          default_value="0.0"/>
                 <nml_option name="config_h_mom_eddy_visc4"           type="real"          default_value="0.0"/>
                 <nml_option name="config_v_mom_eddy_visc2"           type="real"          default_value="0.0"/>
                 <nml_option name="config_h_theta_eddy_visc2"         type="real"          default_value="0.0"/>
                 <nml_option name="config_h_theta_eddy_visc4"         type="real"          default_value="0.0"/>
                 <nml_option name="config_v_theta_eddy_visc2"         type="real"          default_value="0.0"/>
-                <nml_option name="config_visc4_2dsmag"               type="real"          default_value="0.0"/>
-                <nml_option name="config_del4u_div_factor"           type="real"          default_value="1.0"/>
-                <nml_option name="config_number_of_sub_steps"        type="integer"       default_value="6"/>
+                <nml_option name="config_horiz_mixing"               type="character"     default_value="2d_smagorinsky"/>
+                <nml_option name="config_len_disp"                   type="real"          default_value="120000.0"/>
+                <nml_option name="config_visc4_2dsmag"               type="real"          default_value="0.05"/>
+                <nml_option name="config_del4u_div_factor"           type="real"          default_value="1.0"         in_defaults="false"/>
                 <nml_option name="config_w_adv_order"                type="integer"       default_value="3"/>
                 <nml_option name="config_theta_adv_order"            type="integer"       default_value="3"/>
                 <nml_option name="config_scalar_adv_order"           type="integer"       default_value="3"/>
@@ -57,51 +58,50 @@
                 <nml_option name="config_w_vadv_order"               type="integer"       default_value="3"/>
                 <nml_option name="config_theta_vadv_order"           type="integer"       default_value="3"/>
                 <nml_option name="config_scalar_vadv_order"          type="integer"       default_value="3"/>
-                <nml_option name="config_coef_3rd_order"             type="real"          default_value="0.25"/>
                 <nml_option name="config_scalar_advection"           type="logical"       default_value="true"/>
                 <nml_option name="config_positive_definite"          type="logical"       default_value="false"/>
                 <nml_option name="config_monotonic"                  type="logical"       default_value="true"/>
-                <nml_option name="config_mix_full"                   type="logical"       default_value="true"/>
-                <nml_option name="config_len_disp"                   type="real"          default_value="120000.0"/>
+                <nml_option name="config_coef_3rd_order"             type="real"          default_value="0.25"/>
+                <nml_option name="config_mix_full"                   type="logical"       default_value="true"        in_defaults="false"/>
                 <nml_option name="config_epssm"                      type="real"          default_value="0.1"/>
                 <nml_option name="config_smdiv"                      type="real"          default_value="0.1"/>
                 <nml_option name="config_newpx"                      type="logical"       default_value="false"/>
-                <nml_option name="config_apvm_upwinding"             type="real"          default_value="0.5"/>
+                <nml_option name="config_apvm_upwinding"             type="real"          default_value="0.5"         in_defaults="false"/>
                 <nml_option name="config_h_ScaleWithMesh"            type="logical"       default_value="true"/>
-                <nml_option name="config_num_halos"                  type="integer"       default_value="2"/>
+                <nml_option name="config_num_halos"                  type="integer"       default_value="2"           in_defaults="false"/>
         </nml_record>
 
         <nml_record name="damping" in_defaults="true">
                 <nml_option name="config_zd"                         type="real"          default_value="22000.0"/>
-                <nml_option name="config_xnutr"                      type="real"          default_value="0.0"/>
+                <nml_option name="config_xnutr"                      type="real"          default_value="0.2"/>
         </nml_record>
 
         <nml_record name="io" in_defaults="true">
-                <nml_option name="config_input_name"                 type="character"     default_value="init.nc"/>
-                <nml_option name="config_output_name"                type="character"     default_value="output.nc"/>
+                <nml_option name="config_input_name"                 type="character"     default_value="x1.40962.init.nc"/>
+                <nml_option name="config_output_name"                type="character"     default_value="x1.40962.output.nc"/>
                 <nml_option name="config_output_interval"            type="character"     default_value="06:00:00"/>
-                <nml_option name="config_restart_name"               type="character"     default_value="restart.nc"/>
-                <nml_option name="config_restart_interval"           type="character"     default_value="none"/>
-                <nml_option name="config_restart_timestamp_name"     type="character"     default_value="restart_timestamp"/>
-                <nml_option name="config_sfc_update_name"            type="character"     default_value="sfc_update.nc"/>
+                <nml_option name="config_restart_name"               type="character"     default_value="x1.40962.restart.nc"/>
+                <nml_option name="config_restart_interval"           type="character"     default_value="1_00:00:00"/>
+                <nml_option name="config_restart_timestamp_name"     type="character"     default_value="restart_timestamp"  in_defaults="false"/>
+                <nml_option name="config_sfc_update_name"            type="character"     default_value="x1.40962.sfc_update.nc"/>
                 <nml_option name="config_sfc_update_interval"        type="character"     default_value="none"/>
                 <nml_option name="config_hifreq_output_interval"     type="character"     default_value="none"/>
-                <nml_option name="config_frames_per_outfile"         type="integer"       default_value="0"/>
+                <nml_option name="config_frames_per_outfile"         type="integer"       default_value="1"/>
                 <nml_option name="config_pio_num_iotasks"            type="integer"       default_value="0"/>
                 <nml_option name="config_pio_stride"                 type="integer"       default_value="1"/>
-                <nml_option name="config_pio_format"                 type="character"     default_value="pnetcdf"/>
+                <nml_option name="config_pio_format"                 type="character"     default_value="pnetcdf"            in_defaults="false"/>
         </nml_record>
 
         <nml_record name="decomposition" in_defaults="true">
-                <nml_option name="config_block_decomp_file_prefix"   type="character"     default_value="graph.info.part."/>
-                <nml_option name="config_number_of_blocks"           type="integer"       default_value="0"/>
-                <nml_option name="config_explicit_proc_decomp"       type="logical"       default_value="false"/>
-                <nml_option name="config_proc_decomp_file_prefix"    type="character"     default_value="graph.info.part."/>
+                <nml_option name="config_block_decomp_file_prefix"   type="character"     default_value="x1.40962.graph.info.part."/>
+                <nml_option name="config_number_of_blocks"           type="integer"       default_value="0"                  in_defaults="false"/>
+                <nml_option name="config_explicit_proc_decomp"       type="logical"       default_value="false"              in_defaults="false"/>
+                <nml_option name="config_proc_decomp_file_prefix"    type="character"     default_value="graph.info.part."   in_defaults="false"/>
         </nml_record>
 
         <nml_record name="restart" in_defaults="true">
                 <nml_option name="config_do_restart"                 type="logical"       default_value="false"/>
-                <nml_option name="config_do_DAcycling"               type="logical"       default_value="false"/>
+                <nml_option name="config_do_DAcycling"               type="logical"       default_value="false"              in_defaults="false"/>
         </nml_record>
 
 
@@ -1154,50 +1154,50 @@
 
         <nml_record name="physics" in_defaults="true">
                 <!-- NAMELIST VARIABLES ADDED FOR INITIALIZATION OF SURFACE CHARACTERISTICS: -->
-                <nml_option name="input_landuse_data"                type="character"     default_value="USGS"/>
-                <nml_option name="input_soil_data"                   type="character"     default_value="STAS"/>
-                <nml_option name="input_soil_temperature_lag"        type="integer"       default_value="140"/>
-                <nml_option name="num_soil_layers"                   type="integer"       default_value="4"/>
-                <nml_option name="months"                            type="integer"       default_value="12"/>
+                <nml_option name="input_landuse_data"                type="character"     default_value="USGS"       in_defaults="false"/>
+                <nml_option name="input_soil_data"                   type="character"     default_value="STAS"       in_defaults="false"/>
+                <nml_option name="input_soil_temperature_lag"        type="integer"       default_value="140"        in_defaults="false"/>
+                <nml_option name="num_soil_layers"                   type="integer"       default_value="4"          in_defaults="false"/>
+                <nml_option name="months"                            type="integer"       default_value="12"         in_defaults="false"/>
 
                 <!-- ... DIMENSION NEEDED FOR OZONE AND AEROSOLS CONCENTRATIONS IN THE CAM LONGWAVE AND SHORTWAVE -->
                 <!-- ... RADIATION PARAMETERIZATIONS.                                                             -->
-                <nml_option name="noznlev"                           type="integer"       default_value="59"/>
-                <nml_option name="naerlev"                           type="integer"       default_value="29"/>
-                <nml_option name="camdim1"                           type="integer"       default_value="4"/>
+                <nml_option name="noznlev"                           type="integer"       default_value="59"         in_defaults="false"/>
+                <nml_option name="naerlev"                           type="integer"       default_value="29"         in_defaults="false"/>
+                <nml_option name="camdim1"                           type="integer"       default_value="4"          in_defaults="false"/>
 
                 <!-- NAMELIST VARIABLES ADDED FOR PHYSICS CONFIGURATION: -->
                 <nml_option name="config_frac_seaice"                type="logical"       default_value="false"/>
-                <nml_option name="config_sfc_albedo"                 type="logical"       default_value="false"/>
-                <nml_option name="config_sfc_snowalbedo"             type="logical"       default_value="false"/>
+                <nml_option name="config_sfc_albedo"                 type="logical"       default_value="true"/>
+                <nml_option name="config_sfc_snowalbedo"             type="logical"       default_value="true"/>
                 <nml_option name="config_sst_update"                 type="logical"       default_value="false"/>
                 <nml_option name="config_sstdiurn_update"            type="logical"       default_value="false"/>
                 <nml_option name="config_deepsoiltemp_update"        type="logical"       default_value="false"/>
-                <nml_option name="config_o3climatology"              type="logical"       default_value="false"/>
+                <nml_option name="config_o3climatology"              type="logical"       default_value="false"      in_defaults="false"/>
 
                 <nml_option name="config_n_microp"                   type="integer"       default_value="1"/>
 
-                <nml_option name="config_radtlw_interval"            type="character"     default_value="none"/>
-                <nml_option name="config_radtsw_interval"            type="character"     default_value="none"/>
+                <nml_option name="config_radtlw_interval"            type="character"     default_value="00:30:00"/>
+                <nml_option name="config_radtsw_interval"            type="character"     default_value="00:30:00"/>
                 <nml_option name="config_conv_interval"              type="character"     default_value="none"/>
                 <nml_option name="config_pbl_interval"               type="character"     default_value="none"/>
-                <nml_option name="config_camrad_abs_update"          type="character"     default_value="06:00:00"/>
-                <nml_option name="config_greeness_update"            type="character"     default_value="24:00:00"/>
+                <nml_option name="config_camrad_abs_update"          type="character"     default_value="06:00:00"   in_defaults="false"/>
+                <nml_option name="config_greeness_update"            type="character"     default_value="24:00:00"   in_defaults="false"/>
                 <nml_option name="config_bucket_update"              type="character"     default_value="none"/>
 
-                <nml_option name="config_microp_scheme"              type="character"     default_value="off"/>
-                <nml_option name="config_conv_deep_scheme"           type="character"     default_value="off"/>
-                <nml_option name="config_lsm_scheme"                 type="character"     default_value="off"/>
-                <nml_option name="config_pbl_scheme"                 type="character"     default_value="off"/>
+                <nml_option name="config_microp_scheme"              type="character"     default_value="wsm6"/>
+                <nml_option name="config_conv_deep_scheme"           type="character"     default_value="kain_fritsch"/>
+                <nml_option name="config_lsm_scheme"                 type="character"     default_value="noah"/>
+                <nml_option name="config_pbl_scheme"                 type="character"     default_value="ysu"/>
                 <nml_option name="config_gwdo_scheme"                type="character"     default_value="off"/>
-                <nml_option name="config_radt_cld_scheme"            type="character"     default_value="off"/>
-                <nml_option name="config_radt_lw_scheme"             type="character"     default_value="off"/>
-                <nml_option name="config_radt_sw_scheme"             type="character"     default_value="off"/>
-                <nml_option name="config_sfclayer_scheme"            type="character"     default_value="off"/>
+                <nml_option name="config_radt_cld_scheme"            type="character"     default_value="cld_incidence"/>
+                <nml_option name="config_radt_lw_scheme"             type="character"     default_value="rrtmg_lw"/>
+                <nml_option name="config_radt_sw_scheme"             type="character"     default_value="rrtmg_sw"/>
+                <nml_option name="config_sfclayer_scheme"            type="character"     default_value="monin_obukhov"/>
 
-                <nml_option name="config_bucket_radt"                type="real"          default_value="0.0_RKIND"/>
-                <nml_option name="config_bucket_rainc"               type="real"          default_value="0.0_RKIND"/>
-                <nml_option name="config_bucket_rainnc"              type="real"          default_value="0.0_RKIND"/>
+                <nml_option name="config_bucket_radt"                type="real"          default_value="1.0e9"      in_defaults="false"/>
+                <nml_option name="config_bucket_rainc"               type="real"          default_value="100.0"      in_defaults="false"/>
+                <nml_option name="config_bucket_rainnc"              type="real"          default_value="100.0"      in_defaults="false"/>
         </nml_record>
 
         <var_struct name="diag_physics" time_levs="1">

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -32,33 +32,33 @@
 
         <nml_record name="nhyd_model" in_defaults="true">
                 <nml_option name="config_init_case"             type="integer"       default_value="7"/>
-                <nml_option name="config_calendar_type"         type="character"     default_value="gregorian"/>
-                <nml_option name="config_start_time"            type="character"     default_value="none"/>
-                <nml_option name="config_stop_time"             type="character"     default_value="none"/>
+                <nml_option name="config_calendar_type"         type="character"     default_value="gregorian"   in_defaults="false"/>
+                <nml_option name="config_start_time"            type="character"     default_value="2010-10-23_00:00:00"/>
+                <nml_option name="config_stop_time"             type="character"     default_value="2010-10-23_00:00:00"/>
                 <nml_option name="config_theta_adv_order"       type="integer"       default_value="3"/>
-                <nml_option name="config_coef_3rd_order"        type="real"          default_value="0.25"/>
-                <nml_option name="config_num_halos"             type="integer"       default_value="2"/>
+                <nml_option name="config_coef_3rd_order"        type="real"          default_value="0.25"        in_defaults="false"/>
+                <nml_option name="config_num_halos"             type="integer"       default_value="2"           in_defaults="false"/>
         </nml_record>
 
         <nml_record name="dimensions" in_defaults="true">
-                <nml_option name="config_nvertlevels"           type="integer"       default_value="26"/>
+                <nml_option name="config_nvertlevels"           type="integer"       default_value="41"/>
                 <nml_option name="config_nsoillevels"           type="integer"       default_value="4"/>
-                <nml_option name="config_nfglevels"             type="integer"       default_value="27"/>
+                <nml_option name="config_nfglevels"             type="integer"       default_value="38"/>
                 <nml_option name="config_nfgsoillevels"         type="integer"       default_value="4"/>
-                <nml_option name="config_months"                type="integer"       default_value="12"/>
+                <nml_option name="config_months"                type="integer"       default_value="12"      in_defaults="false"/>
         </nml_record>
 
         <nml_record name="data_sources" in_defaults="true">
-                <nml_option name="config_geog_data_path"        type="character"     default_value="/mmm/users/wrfhelp/WPS_GEOG/"/>
-                <nml_option name="config_met_prefix"            type="character"     default_value="FILE"/>
-                <nml_option name="config_sfc_prefix"            type="character"     default_value="FILE"/>
+                <nml_option name="config_geog_data_path"        type="character"     default_value="/glade/p/work/wrfhelp/WPS_GEOG/"/>
+                <nml_option name="config_met_prefix"            type="character"     default_value="CFSR"/>
+                <nml_option name="config_sfc_prefix"            type="character"     default_value="SST"/>
                 <nml_option name="config_fg_interval"           type="integer"       default_value="21600"/>
         </nml_record>
 
         <nml_record name="vertical_grid" in_defaults="true">
-                <nml_option name="config_ztop"                  type="real"          default_value="28000.0"/>
-                <nml_option name="config_nsmterrain"            type="integer"       default_value="2"/>
-                <nml_option name="config_smooth_surfaces"       type="logical"       default_value="false"/>
+                <nml_option name="config_ztop"                  type="real"          default_value="30000.0"/>
+                <nml_option name="config_nsmterrain"            type="integer"       default_value="1"/>
+                <nml_option name="config_smooth_surfaces"       type="logical"       default_value="true"/>
         </nml_record>
 
         <nml_record name="preproc_stages" in_defaults="true">
@@ -70,27 +70,27 @@
         </nml_record>
 
         <nml_record name="io" in_defaults="true">
-                <nml_option name="config_input_name"            type="character"     default_value="grid.nc"/>
-                <nml_option name="config_sfc_update_name"       type="character"     default_value="sfc_update.nc"/>
-                <nml_option name="config_output_name"           type="character"     default_value="init.nc"/>
-                <nml_option name="config_restart_name"          type="character"     default_value="restart.nc"/>
-                <nml_option name="config_restart_timestamp_name" type="character"     default_value="restart_timestamp"/>
-                <nml_option name="config_frames_per_outfile"    type="integer"       default_value="0"/>
+                <nml_option name="config_input_name"            type="character"     default_value="x1.40962.grid.nc"/>
+                <nml_option name="config_sfc_update_name"       type="character"     default_value="x1.40962.sfc_update.nc"/>
+                <nml_option name="config_output_name"           type="character"     default_value="x1.40962.init.nc"/>
+                <nml_option name="config_restart_name"          type="character"     default_value="restart.nc"           in_defaults="false"/>
+                <nml_option name="config_restart_timestamp_name" type="character"     default_value="restart_timestamp"   in_defaults="false"/>
+                <nml_option name="config_frames_per_outfile"    type="integer"       default_value="0"                    in_defaults="false"/>
                 <nml_option name="config_pio_num_iotasks"       type="integer"       default_value="0"/>
                 <nml_option name="config_pio_stride"            type="integer"       default_value="1"/>
         </nml_record>
 
         <nml_record name="decomposition" in_defaults="true">
-                <nml_option name="config_block_decomp_file_prefix"   type="character"     default_value="graph.info.part."/>
-                <nml_option name="config_number_of_blocks"           type="integer"       default_value="0"/>
-                <nml_option name="config_explicit_proc_decomp"       type="logical"       default_value=".false."/>
-                <nml_option name="config_proc_decomp_file_prefix"    type="character"     default_value="graph.info.part."/>
+                <nml_option name="config_block_decomp_file_prefix"   type="character"     default_value="x1.40962.graph.info.part."/>
+                <nml_option name="config_number_of_blocks"           type="integer"       default_value="0"                in_defaults="false"/>
+                <nml_option name="config_explicit_proc_decomp"       type="logical"       default_value=".false."          in_defaults="false"/>
+                <nml_option name="config_proc_decomp_file_prefix"    type="character"     default_value="graph.info.part." in_defaults="false"/>
         </nml_record>
 
         <nml_record name="restart" in_defaults="true">
-                <nml_option name="config_restart_interval"      type="integer"       default_value="0"/>
-                <nml_option name="config_do_restart"            type="logical"       default_value="false"/>
-                <nml_option name="config_restart_time"          type="real"          default_value="172800.0"/>
+                <nml_option name="config_restart_interval"      type="integer"       default_value="0"         in_defaults="false"/>
+                <nml_option name="config_do_restart"            type="logical"       default_value="false"     in_defaults="false"/>
+                <nml_option name="config_restart_time"          type="real"          default_value="172800.0"  in_defaults="false"/>
         </nml_record>
 
 


### PR DESCRIPTION
to reflect options that were previously set in example namelist files; also, use in_defaults="false"
to remove some options from the default namelist files.
