### PR TITLE
Update dependencies in framework.

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES: .F .o
 
-DEPS := $(wildcard ../core_$(CORE)/Registry.xml)
+DEPS := $(shell find ../core_$(CORE)/ -type f -name "*.xml" ! -name "*processed.xml")
 
 OBJS = mpas_kind_types.o \
        mpas_framework.o \


### PR DESCRIPTION
Since cores are allowed to place registry files in subdirectories of
their core directory, update the framework dependency on registry files
to find all registry files that are not named *_processed.xml.
