### PR TITLE
Updating registry to properly handle logicals.

### DIFF
--- a/src/registry/parse.c
+++ b/src/registry/parse.c
@@ -575,9 +575,9 @@ int parse_reg_xml(ezxml_t registry, struct namelist **nls, struct dimension ** d
 					nls_ptr->defval.ival = atoi(nmloptval);
 					break;
 				case LOGICAL:
-					if(strncmp(nmloptval, "true", 1024) ==0){
+					if(strncmp(nmloptval, "true", 1024) == 0 || strncmp(nmloptval, ".true.", 1024) == 0){
 						nls_ptr->defval.lval = 1;
-					} else if (strncmp(nmloptval, "false", 1024) == 0){
+					} else if (strncmp(nmloptval, "false", 1024) == 0 || strncmp(nmloptval, ".false.", 1024) == 0){
 						nls_ptr->defval.lval = 0;
 					}
 					break;


### PR DESCRIPTION
Previously the test to see if a logical's default value was true or
false was incorrect if the default value was specified using Fortran
syntax (i.e. .false. and .true.), but was correct if they were specified
as true and false.

Registry has been updated to properly handle both cases.
