### PR TITLE
Change default linear eos values from POP to Ilicak test cases.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -544,15 +544,15 @@
 		/>
 	</nml_record>
 	<nml_record name="eos_linear" in_defaults="true">
-		<nml_option name="config_eos_linear_alpha" type="real" default_value="2.55e-1" units="kg m^{-3} C^{-1}"
+		<nml_option name="config_eos_linear_alpha" type="real" default_value="0.2" units="kg m^{-3} C^{-1}"
 					description="Linear thermal expansion coefficient"
 					possible_values="any positive real"
 		/>
-		<nml_option name="config_eos_linear_beta" type="real" default_value="7.64e-1" units="kg m^{-3} PSU^{-1}"
+		<nml_option name="config_eos_linear_beta" type="real" default_value="0.8" units="kg m^{-3} PSU^{-1}"
 					description="Linear haline contraction coefficient"
 					possible_values="any positive real"
 		/>
-		<nml_option name="config_eos_linear_Tref" type="real" default_value="19.0" units="C"
+		<nml_option name="config_eos_linear_Tref" type="real" default_value="5.0" units="C"
 					description="Reference temperature"
 					possible_values="any real"
 		/>
@@ -560,7 +560,7 @@
 					description="Reference salinity"
 					possible_values="any real"
 		/>
-		<nml_option name="config_eos_linear_densityref" type="real" default_value="1025.022" units="kg m^{-3}"
+		<nml_option name="config_eos_linear_densityref" type="real" default_value="1000.0" units="kg m^{-3}"
 					description="Reference density, i.e. density when T=Tref and S=Sref"
 					possible_values="any positive real"
 		/>


### PR DESCRIPTION
Linear eos defaults are somewhat arbitrary, but consistency is important amongst test cases.  I would like the defaults to be the values in Ilicak, and our submitted paper with four idealized domains.  Previous values were from POP, but do not appear in any standard test cases.
