### PR TITLE
Default option for frazil ice formation changed to be false

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -482,7 +482,7 @@
 					description="Coefficient used to determine transmission of surface fluxes. Fluxes are defined with $e^{z/\gamma}$ where this coefficient is $\gamma$."
 					possible_values="Any real number $\gamma>0.0$ and $\gamma \le 1.0$."
 		/>
-		<nml_option name="config_frazil_ice_formation" type="logical" default_value=".true." units="unitless"
+		<nml_option name="config_frazil_ice_formation" type="logical" default_value=".false." units="unitless"
 					description="Logical flag that determines if the formation of frazil ice is allowed."
 					possible_values=".true. or .false."
 		/>


### PR DESCRIPTION
Fixes crashes for runs with linear EOS
causing thickness to become negative and exponential
in ocn_forcing_build_transmission_array to
return a SIGFPE.

Output from gdb can be used to identify this error:

Reading symbols from /Users/pwolfram/Documents/MPAS-pwolfram_fork/ocean_forward_model...rudone.
(idb) run
Starting program: /Users/pwolfram/Documents/MPAS-pwolfram_fork/ocean_forward_model
task     0 of     1 is running
Program received signal SIGFPE
_exp.L () in /Users/pwolfram/Documents/MPAS-pwolfram_fork/ocean_forward_model
(idb) where
#0  0x0000000100f176fe in _exp.L () in /Users/pwolfram/Documents/MPAS-pwolfram_fork/ocean_forward_model
#1  0x0000000100131513 in OCN_FORCING::ocn_forcing_build_transmission_array (mesh= (...), state= (...), forcing= (...), err=0) at /Users/pwolfram/Documents/MPAS-pwolfram_fork/src/core_ocean/shared/mpas_ocn_forcing.F:222
#2  0x0000000100298e12 in MPAS_CORE::mpas_core_run (domain= (...), output_obj= (...), output_frame=2) at /Users/pwolfram/Documents/MPAS-pwolfram_fork/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F:499
#3  0x0000000100001c40 in MPAS_SUBDRIVER::mpas_run () at /Users/pwolfram/Documents/MPAS-pwolfram_fork/src/driver/mpas_subdriver.F:72
#4  0x00000001000016e1 in mpas () at /Users/pwolfram/Documents/MPAS-pwolfram_fork/src/driver/mpas.F:16
