### PR TITLE
Remove STOP statements in operators and framework.

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1635,8 +1635,6 @@ subroutine wrf_error_fatal(msg)
 
    character (len=*) :: msg
 
-   write(0,*) 'MPAS_TIMEKEEPING: '//trim(msg)
-
-   stop
+   call mpas_dmpar_global_abort('ERROR: mpas_timekeeping: '//trim(msg))
 
 end subroutine wrf_error_fatal

--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -248,7 +248,7 @@
 
           if(.not.timer_found) then
             print *,' timer_stop :: timer_stop called with timer_name =', timer_name,' when timer has not been started.'
-            stop
+            call mpas_dmpar_global_abort('ERROR: in subroutine mpas_timer_stop()')
           endif
 
           if(current%running) then
@@ -316,7 +316,7 @@
 
           if(present(timer_ptr) .and. (.not.present(total_ptr))) then
             print *,'timer_write :: timer_ptr valid, but total_ptr is not assigned.'
-            stop
+            call mpas_dmpar_global_abort('ERROR: in subroutine mpas_timer_write()')
           else if(present(timer_ptr)) then
             tname = ''
             do i=0,timer_ptr%levels+2
@@ -352,7 +352,7 @@
 
           if(.not.total_found) then
             print *,' timer_write :: no timer named "total time" found.'
-            stop
+            call mpas_dmpar_global_abort('ERROR: in subroutine mpas_timer_write()')
           end if
 
           write(stdoutUnit,'(3x, a10, 24x, a15, a10, a13, a15, a15, a12, a12)') 'timer_name', 'total', 'calls', 'min', 'max', &

--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -204,9 +204,9 @@ module mpas_geometry_utils
       integer, dimension(n) :: indx
 !      integer :: i,j
    
-      if ( (ne<n) .or. (ne<m) ) then
-         write(stdoutUnit,*) ' error in poly_fit_2 inversion ',m,n,ne
-         stop
+      if ( (ne < n) .or. (ne < m) ) then
+         write(stderrUnit,*) ' error in poly_fit_2 inversion ',m,n,ne
+         call mpas_dmpar_global_abort('ERROR: in subroutine poly_fit_2()')
       end if
    
 !      a(1:m,1:n) = a_in(1:n,1:m) 

--- a/src/operators/mpas_matrix_operations.F
+++ b/src/operators/mpas_matrix_operations.F
@@ -423,8 +423,7 @@ contains
 
       ! mrp: find out how to do correct error check.
       if (size(A,1).ne.n.or.size(A,2).ne.m) then
-        write(stderrUnit,*) 'error, mpas_outer_product: size of A must match u and v'
-        stop
+        call mpas_dmpar_global_abort('ERROR: in subroutine mpas_outer_product(), size of A must match u and v')
       endif
 
       do i=1,n

--- a/src/operators/mpas_tensor_operations.F
+++ b/src/operators/mpas_tensor_operations.F
@@ -1374,7 +1374,7 @@ contains
 
      else
        write (stderrUnit,*) 'bad choice of tensor_test_function: ',tensor_test_function
-       stop
+       call mpas_dmpar_global_abort('ERROR: in subroutine mpas_test_tensor()')
      endif
 
      if (computeStrainRate) then

--- a/src/operators/mpas_tracer_advection_helpers.F
+++ b/src/operators/mpas_tracer_advection_helpers.F
@@ -334,7 +334,6 @@ module mpas_tracer_advection_helpers
 
 
       integer, parameter :: polynomial_order = 2
-      logical, parameter :: debug = .false.
       logical, parameter :: least_squares = .true.
       logical :: add_the_cell, do_the_cell
 
@@ -699,8 +698,6 @@ module mpas_tracer_advection_helpers
       deallocate(theta_abs)
       deallocate(angle_2d)
 
-      if (debug) stop
-
 
 !      write(stderrUnit,*) ' check for deriv2 coefficients, iEdge 4 '
 !
@@ -718,7 +715,6 @@ module mpas_tracer_advection_helpers
 !      do j=2,7
 !         write(stderrUnit,*) ' j, icell, coef ',j, cellsOnCell(j-1,iCell),deriv_two(j,2,iEdge)
 !      end do
-!      stop
 
    end subroutine mpas_initialize_deriv_two!}}}
 


### PR DESCRIPTION
To ensure that parallel runs of MPAS cores will properly halt when one MPI task encounters a fatal condition, we need to replace all Fortran STOP statements in the shared operator and framework code with calls to mpas_dmpar_global_abort().
