### PR TITLE
Replace STOP statements in MPAS-Atmosphere code.

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_advection.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_advection.F
@@ -62,7 +62,6 @@ module atm_advection
       real (kind=RKIND), dimension(maxEdges) :: angle_2d
 
       integer, parameter :: polynomial_order = 2
-      logical, parameter :: debug = .false.
       logical, parameter :: least_squares = .true.
       logical, parameter :: reset_poly = .true.
 
@@ -389,8 +388,6 @@ module atm_advection
  
       end do ! end of loop over cells
 
-      if (debug) stop
-
 !      write(0,*) ' check for deriv2 coefficients, iEdge 4 '
 !
 !      iEdge = 4
@@ -407,7 +404,6 @@ module atm_advection
 !      do j=2,7
 !         write(0,*) ' j, icell, coef ',j,grid % CellsOnCell % array(j-1,iCell),deriv_two(j,2,iEdge)
 !      end do
-!      stop
 
    end subroutine atm_initialize_advection_rk
 
@@ -600,9 +596,9 @@ module atm_advection
 !      real (kind=RKIND), dimension(n,n)  :: ata_inv
       integer, dimension(n) :: indx
    
-      if ( (ne<n) .or. (ne<m) ) then
-         write(6,*) ' error in poly_fit_2 inversion ',m,n,ne
-         stop
+      if ( (ne < n) .or. (ne < m) ) then
+         write(stderrUnit,*) ' error in poly_fit_2 inversion ',m,n,ne
+         call mpas_dmpar_global_abort('ERROR: in poly_fit_2 inversion')
       end if
    
       a(1:m,1:n) = a_in(1:m,1:n)

--- a/src/core_atmosphere/physics/mpas_atmphys_interface_nhyd.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface_nhyd.F
@@ -303,7 +303,7 @@
           write(0,201) j,i,k,dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
              rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)
        enddo
-!      stop
+!      call mpas_dmpar_global_abort('ERROR: pressure increasing with height')
     endif
  enddo
  enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_utilities.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_utilities.F
@@ -56,7 +56,7 @@ write(0,*) trim(str)
  write(0,*)
  write(0,*) ( '------------------------------ FATAL CALLED ------------------------------')
  write(0,*) trim(str)
- stop ' MPAS core_physics abort'
+ call mpas_dmpar_global_abort('ERROR: MPAS core_physics abort')
  
  end subroutine physics_error_fatal
 

--- a/src/core_init_atmosphere/mpas_init_atm_llxy.F
+++ b/src/core_init_atmosphere/mpas_init_atm_llxy.F
@@ -2227,8 +2227,7 @@ MODULE init_atm_llxy
 
       CHARACTER (LEN=*), INTENT(IN) :: mesg
 
-      WRITE(0,*) trim(mesg)
-      STOP
+      CALL mpas_dmpar_global_abort(trim(mesg))
 
    END SUBROUTINE llxy_error_fatal
   


### PR DESCRIPTION
To ensure that parallel runs of MPAS-Atmosphere will properly halt when one MPI task encounters a fatal condition, we need to replace all Fortran STOP statements calls to mpas_dmpar_global_abort(). However, to prevent WRF physics from diverging too much from the WRF repository, no code in the physics_wrf has been modified, even though stop statements exist in that code.
