### PR TITLE
Fixing an issue with non-decomposed fields.

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1250,6 +1250,8 @@ module mpas_io
       integer, dimension(4) :: count4
       integer, dimension(5) :: start5
       integer, dimension(5) :: count5
+      integer, dimension(6) :: start6
+      integer, dimension(6) :: count6
       character (len=StrKIND), dimension(1) :: tempchar
       type (fieldlist_type), pointer :: field_cursor
 
@@ -1323,9 +1325,17 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  realArray1d, pio_ierr)
          else
-            start1(:) = 1
-            count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, realArray1d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start2(1) = 1
+               start2(2) = handle % frame_number
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count2(2) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, realArray1d)
+            else
+               start1(:) = 1
+               count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, realArray1d)
+            end if
          end if
       else if (present(realArray2d)) then
 !         write (0,*) '  value is real2'
@@ -1333,10 +1343,19 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  realArray2d, pio_ierr)
          else
-            start2(:) = 1
-            count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, realArray2d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start3(:) = 1
+               start3(3) = handle % frame_number
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count3(3) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, realArray2d)
+            else
+               start2(:) = 1
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, realArray2d)
+            end if
          end if
       else if (present(realArray3d)) then
 !         write (0,*) '  value is real3'
@@ -1344,11 +1363,21 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  realArray3d, pio_ierr)
          else
-            start3(:) = 1
-            count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, realArray3d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start4(:) = 1
+               start4(4) = handle % frame_number
+               count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count4(4) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, realArray3d)
+            else
+               start3(:) = 1
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, realArray3d)
+            end if
          end if
       else if (present(realArray4d)) then
 !         write (0,*) '  value is real4'
@@ -1356,12 +1385,23 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  realArray4d, pio_ierr)
          else
-            start4(:) = 1
-            count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
-            count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, realArray4d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start5(:) = 1
+               start5(5) = handle % frame_number
+               count5(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count5(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count5(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count5(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               count5(5) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, realArray4d)
+            else
+               start4(:) = 1
+               count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, realArray4d)
+            end if
          end if
       else if (present(realArray5d)) then
 !         write (0,*) '  value is real5'
@@ -1369,13 +1409,25 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                 realArray5d, pio_ierr)
          else
-            start5(:) = 1
-            count5(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count5(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            count5(3) = field_cursor % fieldhandle % dims(3) % dimsize
-            count5(4) = field_cursor % fieldhandle % dims(4) % dimsize
-            count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, realArray5d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start6(:) = 1
+               start6(6) = handle % frame_number
+               count6(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count6(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count6(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count6(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               count6(5) = field_cursor % fieldhandle % dims(5) % dimsize
+               count6(6) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start6, count6, realArray5d)
+            else
+               start5(:) = 1
+               count5(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count5(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count5(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count5(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, realArray5d)
+            end if
          end if
       else if (present(intArray1d)) then
 !         write (0,*) '  value is int1'
@@ -1383,9 +1435,17 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray1d, pio_ierr)
          else
-            start1(:) = 1
-            count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, intArray1d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start2(1) = 1
+               start2(2) = handle % frame_number
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count2(2) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, intArray1d)
+            else
+               start1(:) = 1
+               count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, intArray1d)
+            end if
          end if
       else if (present(intArray2d)) then
 !         write (0,*) '  value is int2'
@@ -1393,10 +1453,19 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray2d, pio_ierr)
          else
-            start2(:) = 1
-            count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, intArray2d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start3(:) = 1
+               start3(3) = handle % frame_number
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count3(3) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, intArray2d)
+            else
+               start2(:) = 1
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, intArray2d)
+            end if
          end if
       else if (present(intArray3d)) then
 !         write (0,*) '  value is int3'
@@ -1404,11 +1473,21 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray3d, pio_ierr)
          else
-            start3(:) = 1
-            count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, intArray3d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start4(:) = 1
+               start4(4) = handle % frame_number
+               count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count4(4) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, intArray3d)
+            else
+               start3(:) = 1
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count3(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, intArray3d)
+            end if
          end if
       else if (present(intArray4d)) then
 !         write (0,*) '  value is int4'
@@ -1416,12 +1495,23 @@ module mpas_io
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray4d, pio_ierr)
          else
-            start4(:) = 1
-            count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
-            count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
-            count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
-            count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
-            pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, intArray4d)
+            if (field_cursor % fieldhandle % has_unlimited_dim) then
+               start5(:) = 1
+               start5(5) = handle % frame_number
+               count5(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count5(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count5(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count5(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               count5(5) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, intArray4d)
+            else
+               start4(:) = 1
+               count4(1) = field_cursor % fieldhandle % dims(1) % dimsize
+               count4(2) = field_cursor % fieldhandle % dims(2) % dimsize
+               count4(3) = field_cursor % fieldhandle % dims(3) % dimsize
+               count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, intArray4d)
+            end if
          end if
       end if
 


### PR DESCRIPTION
Non-decomposed fields that contained an unlimited dimensions (i.e.
Time) previously were read incorrectly when run with multiple
processors.

They would be filled with zeros as PIO would return an incorrect index
error.

I would like @pwolfram to test this with his LPT branch as he was the one who reported the issue to me. But once he verifies it works, @mgduda you can feel free to merge it whenever.
