### PR TITLE
Removing expensive timers in ocean core

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -550,8 +550,6 @@ subroutine tridiagonal_solve(a,b,c,r,x,n)!{{{
    real (KIND=RKIND) :: m
    integer i
 
-   call mpas_timer_start("tridiagonal_solve")
- 
    ! Use work variables for b and r
    bTemp(1) = b(1)
    rTemp(1) = r(1)
@@ -568,8 +566,6 @@ subroutine tridiagonal_solve(a,b,c,r,x,n)!{{{
    do i = n-1, 1, -1
       x(i) = (rTemp(i) - c(i)*x(i+1))/bTemp(i)
    end do
-
-   call mpas_timer_stop("tridiagonal_solve")
  
 end subroutine tridiagonal_solve!}}}
 
@@ -596,8 +592,6 @@ subroutine tridiagonal_solve_mult(a,b,c,r,x,n,nDim,nSystems)!{{{
    real (KIND=RKIND), dimension(nSystems,n) :: rTemp
    real (KIND=RKIND) :: m
    integer i,j
-
-   call mpas_timer_start("tridiagonal_solve_mult")
  
    ! Use work variables for b and r
    bTemp(1) = b(1)
@@ -624,8 +618,6 @@ subroutine tridiagonal_solve_mult(a,b,c,r,x,n,nDim,nSystems)!{{{
       end do
    end do
  
-   call mpas_timer_stop("tridiagonal_solve_mult")
-
 end subroutine tridiagonal_solve_mult!}}}
 
 !***********************************************************************


### PR DESCRIPTION
Within the ocean core, we had timers that wrapped the tridiagonal
solvers. These solvers are called once per column, per timestep at a
minimum.

Calling the timers this much made the actually timer performance
significantly impact the overall model performance.

This issue was reported through our SUPER interactions.
