### PR TITLE
Add option to use either USGS or MODIFIED_IGBP_MODIS_NOAH land use data in MPAS-Atmosphere.

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -194,6 +194,7 @@
 			<var name="surface_pressure"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
+			<var name="mminlu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -481,6 +482,7 @@
 			<var name="ozmixm"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
+			<var name="mminlu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -830,6 +832,7 @@
 			<var name="ozmixm"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
+			<var name="mminlu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -1156,7 +1159,6 @@
 
         <nml_record name="physics" in_defaults="true">
                 <!-- NAMELIST VARIABLES ADDED FOR INITIALIZATION OF SURFACE CHARACTERISTICS: -->
-                <nml_option name="input_landuse_data"                type="character"     default_value="USGS"       in_defaults="false"/>
                 <nml_option name="input_soil_data"                   type="character"     default_value="STAS"       in_defaults="false"/>
                 <nml_option name="input_soil_temperature_lag"        type="integer"       default_value="140"        in_defaults="false"/>
                 <nml_option name="num_soil_layers"                   type="integer"       default_value="4"          in_defaults="false"/>
@@ -1706,6 +1708,7 @@
                 <!--  greenfrac      :monthly climatological greeness fraction                                      [-] -->
                 <!--  isltyp         :dominant soil category                                                        [-] -->
                 <!--  ivgtyp         :dominant vegetation category                                                  [-] -->
+                <!--  mminlu         :land use classification scheme                                                [-] -->
                 <!--  landmask       :=0 for ocean;=1 for land                                                      [-] -->
                 <!--  sfc_albbck     :background albedo                                                             [-] -->
                 <!--  shdmin         :minimum areal fractional coverage of annual green vegetation                  [-] -->
@@ -1731,6 +1734,7 @@
 
                 <var name="isltyp"      type="integer"  dimensions="nCells"/>
                 <var name="ivgtyp"      type="integer"  dimensions="nCells"/>
+                <var name="mminlu"      type="text"     dimensions=""/>
                 <var name="landmask"    type="integer"  dimensions="nCells"/>
                 <var name="shdmin"      type="real"     dimensions="nCells"/>
                 <var name="shdmax"      type="real"     dimensions="nCells"/>

--- a/src/core_atmosphere/mpas_atm_mpas_core.F
+++ b/src/core_atmosphere/mpas_atm_mpas_core.F
@@ -248,6 +248,7 @@ module mpas_core
       
       real (kind=RKIND), dimension(:,:), pointer :: u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional
       real (kind=RKIND), dimension(:), pointer :: meshScalingDel2, meshScalingDel4
+      character(len=StrKIND), pointer :: mminlu
 
       integer, pointer :: nEdgesSolve
    
@@ -288,9 +289,21 @@ module mpas_core
       call physics_namelist_check(mesh, block % configs)
 
       !proceed with initialization of physics parameterization if moist_physics is set to true:
+      call mpas_pool_get_subpool(block % structs, 'sfc_input', sfc_input)
+
+      ! Before calling physics_init, ensure that mminlu contains the name of the land use dataset
+      call mpas_pool_get_array(sfc_input, 'mminlu', mminlu)
+      if (len_trim(mminlu) == 0) then
+            write(0,*) '****************************************************************'
+            write(0,*) 'No information on land use dataset is available.'
+            write(0,*) 'Assume that we are using ''USGS''.'
+            write(0,*) '****************************************************************'
+            write(mminlu,'(a)') 'USGS'
+      end if
+
+
       if (moist_physics) then
-         !initialization of seom input variables in registry:
-         call mpas_pool_get_subpool(block % structs, 'sfc_input', sfc_input)
+         !initialization of some input variables in registry:
          call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
          call mpas_pool_get_subpool(block % structs, 'atm_input', atm_input)
          call physics_registry_init(mesh, block % configs, sfc_input)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -30,9 +30,7 @@
  logical,parameter:: frpcpn   = .false.
  logical,parameter:: rdlai2d  = .false.
 
-!urban physics: since MPAS does not plan to run the urban physics option, the two options
-!below are defined locally:
- integer,parameter,public:: isurban=1
+!urban physics: MPAS does not plan to run the urban physics option.
  integer,parameter:: sf_urban_physics = 0 !activate urban canopy model (=0: no urban canopy) 
 
  integer,private:: i,j,k,n
@@ -63,6 +61,9 @@
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2014-04-22.
 !>    * Modified sourcecode to use pools.
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2014-05-15.
+!>    * Moved the definition of isurban to subroutine landuse_init_forMPAS in mpas_atmphys_landuse.F.
+!>      isurban is now defined as a function of the input landuse data file.
+!>      Dominikus Heinzeller (IMK) / 2014-07-24.
 
 !>
 !> DOCUMENTATION:
@@ -560,7 +561,7 @@
 
 !local pointers:
  logical,pointer:: config_sfc_albedo
- character(len=StrKIND),pointer:: input_landuse_data
+ character(len=StrKIND),pointer:: mminlu
 
 !---------------------------------------------------------------------------------------------
  write(0,*)
@@ -570,7 +571,7 @@
  write(0,*) '--- isurban = ', isurban
 
  call mpas_pool_get_config(configs,'config_sfc_albedo' ,config_sfc_albedo )
- call mpas_pool_get_config(configs,'input_landuse_data',input_landuse_data)
+ call mpas_pool_get_array(sfc_input,'mminlu',mminlu)
 
 !formats:
  101 format(2i6,8(1x,e15.8))
@@ -609,7 +610,7 @@
                 itimestep = itimestep , frpcpn    = frpcpn       , rdlai2d   = rdlai2d      , &
                 xice_threshold   = xice_threshold     ,                                       &
                 usemonalb        = config_sfc_albedo  ,                                       &
-                mminlu           = input_landuse_data ,                                       &
+                mminlu           = mminlu ,                                                   &
                 num_soil_layers  = num_soils          ,                                       &         
                 num_roof_layers  = num_soils    ,                                             &
                 num_wall_layers  = num_soils    ,                                             &

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -47,6 +47,9 @@
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2013-08-02.
 !>    * throughout the sourcecode, replaced all "var_struct" defined arrays by local pointers.
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2014-04-22.
+!>    * In subroutine physics_init_seaice, assign the sea-ice land use category as a function of
+!>      the land use category input file (MODIS OR USGS).
+!>      Dominikus Heinzeller (IMK) / 2014-07-24.
 
 
  contains
@@ -599,6 +602,8 @@
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o,smcrel
 
  logical, pointer :: config_frac_seaice
+ character(len=StrKIND),pointer:: config_landuse_data
+ integer:: isice_lu
 
 !note that this threshold is also defined in module_physics_vars.F.It is defined here to avoid
 !adding "use module_physics_vars" since this subroutine is only used for the initialization of
@@ -611,6 +616,7 @@
  write(0,*) '--- enter physics_init_seaice:'
 
  call mpas_pool_get_config(configs, 'config_frac_seaice', config_frac_seaice)
+ call mpas_pool_get_config(configs, 'config_landuse_data', config_landuse_data)
 
  call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
  call mpas_pool_get_dimension(dims, 'nSoilLevels', nSoilLevels)
@@ -632,6 +638,18 @@
  call mpas_pool_get_array(input, 'sh2o', sh2o)
  call mpas_pool_get_array(input, 'smcrel', smcrel)
 
+!define the land use category for sea-ice as a function of the land use category input file:
+ sfc_input_select1: select case(trim(config_landuse_data))
+    case('OLD')
+       isice_lu = 11
+    case('USGS')
+       isice_lu = 24
+    case('MODIFIED_IGBP_MODIS_NOAH')
+       isice_lu = 15
+    case default
+       CALL physics_error_fatal ('Invalid Land Use Dataset '//trim(config_landuse_data))
+ end select sfc_input_select1
+ write(0,*) '--- isice_lu   = ',isice_lu
 
 !assign the threshold value for xice as a function of config_frac_seaice:
  if(.not. config_frac_seaice) then
@@ -659,7 +677,7 @@
        num_seaice_changes = num_seaice_changes + 1
        !... sea-ice points are converted to land points:
        if(landmask(iCell) .eq. 0) tmn(iCell) = 271.4_RKIND
-       ivgtyp(iCell) = 24 ! (isice = 24)
+       ivgtyp(iCell) = isice_lu
        isltyp(iCell) = 16
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 1._RKIND

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -23,7 +23,7 @@
  public:: landuse_init_forMPAS
 
 !global variables:
- integer,public:: isice,iswater
+ integer,public:: isice,iswater,isurban
 
  integer,parameter:: frac_seaice      = 0       ! = 1: treats seaice as fractional field.
                                                 ! = 0: ice/no-ice flag. 
@@ -70,7 +70,9 @@
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2013-10-19.
 !>    * Modified sourcecode to use pools.
 !>      Laura D. Fowler (birch.mmm.ucar.edu) / 2014-05-15.
-
+!>    * In subroutine landuse_init_forMPAS, added the definition of isurban as a function of the
+!>      input landuse data file.
+!>      Dominikus Heinzeller (IMK) / 2014-07-24.
 
  contains
 
@@ -93,7 +95,7 @@
                    config_frac_seaice, &
                    config_sfc_albedo
 
- character(len=StrKIND),pointer:: input_landuse_data
+ character(len=StrKIND),pointer:: mminlu
 
  integer,pointer:: nCells
  integer,dimension(:),pointer:: ivgtyp
@@ -126,7 +128,7 @@
  call mpas_pool_get_config(configs,'config_do_restart' ,config_do_restart )
  call mpas_pool_get_config(configs,'config_frac_seaice',config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfc_albedo' ,config_sfc_albedo )
- call mpas_pool_get_config(configs,'input_landuse_data',input_landuse_data)
+ call mpas_pool_get_array(sfc_input,'mminlu',mminlu)
 
  call mpas_pool_get_dimension(mesh,'nCells',nCells)
 
@@ -166,7 +168,7 @@
        read(unit=land_unit,fmt='(a35)') lutype
        read(unit=land_unit,fmt=*) lucats,luseas
 
-       if(lutype .eq. input_landuse_data)then
+       if(lutype .eq. mminlu)then
           write(mess,*) '   landuse type = ' // trim (lutype) // ' found', lucats, &
                         ' categories', luseas, ' seasons'
           call physics_message(mess)
@@ -196,23 +198,28 @@
 !      if(is .lt. luseas) write(0,*)
     enddo
 
-!defines the index iswater and isice as a function of sfc_input_data:
+!defines the index isurban, iswater and, isice as a function of sfc_input_data:
     sfc_input_select: select case(trim(lutype))
        case('OLD')
           iswater = 7
           isice   = 11
+          isurban = 1
        case('USGS')
           iswater = 16
           isice   = 24
+          isurban = 1
        case('MODIFIED_IGBP_MODIS_NOAH')
           iswater = 17
           isice   = 15
+          isurban = 13
        case('SiB')
           iswater = 15
           isice   = 16
+          isurban = 11
        case('LW12')
           iswater = 2
           isice   = 3
+          isurban = 1
        case default
     end select sfc_input_select
  endif
@@ -222,6 +229,7 @@
  DM_BCAST_INTEGER(lucats)
  DM_BCAST_INTEGER(iswater)
  DM_BCAST_INTEGER(isice)
+ DM_BCAST_INTEGER(isurban)
  DM_BCAST_MACRO(albd)
  DM_BCAST_MACRO(slmo)
  DM_BCAST_MACRO(sfem)
@@ -231,6 +239,7 @@
  DM_BCAST_MACRO(scfx)
  write(0,*) '--- isice   =',isice
  write(0,*) '--- iswater =',iswater
+ write(0,*) '--- isurban =',isurban
  if(config_do_restart) then
     write(0,*) '--- config_do_restart =', config_do_restart
     write(0,*) '--- skip the end of landuse_init_forMPAS'

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
@@ -102,7 +102,7 @@
 
 !--------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'input_landuse_data'   ,mminlu          )
+ call mpas_pool_get_array(sfc_input,'mminlu'              ,mminlu          )
  call mpas_pool_get_config(configs,'input_soil_data'      ,mminsl          )
  call mpas_pool_get_config(configs,'config_sfc_snowalbedo',input_sfc_albedo)
  call mpas_pool_get_config(configs,'config_do_restart'    ,restart         )
@@ -258,7 +258,7 @@
           call physics_message(mess)
           lumatch=1
        else
-          call physics_message("skipping over lutype = " // trim ( lutype ))
+          call physics_message('    skipping over lutype = ' // trim ( lutype ))
           do lc = 1, lucats+12
              read(16,*)
           enddo
@@ -307,7 +307,7 @@
     2002 continue
     close (16)
     if(lumatch == 0) &
-       call physics_error_fatal ("land use dataset '"//mminlu//"' not found in vegparm.tbl.")
+       call physics_error_fatal ('land use dataset '''//mminlu//''' not found in VEGPARM.TBL.')
       
  endif ! end dminfo
 

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -72,7 +72,8 @@ module_sf_noahdrv.o: \
 	module_sf_urban.o
 
 module_sf_noahlsm.o: \
-	../mpas_atmphys_constants.o
+	../mpas_atmphys_constants.o \
+	../mpas_atmphys_utilities.o
 
 clean:
 	$(RM) *.f90 *.o *.mod

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
@@ -3,6 +3,7 @@ MODULE module_sf_noahlsm
 #if defined(mpas)
 !MPAS specific (Laura D. Fowler):
 use mpas_atmphys_constants, rhowater => rho_w
+use mpas_atmphys_utilities
 #else
   USE module_model_constants
 #endif
@@ -2347,13 +2348,13 @@ CONTAINS
 ! ----------------------------------------------------------------------
 !
                IF (SOILTYP .gt. SLCATS) THEN
-!                       CALL wrf_error_fatal ( 'Warning: too many input soil types' )
+                        CALL physics_error_fatal ( 'Warning: too many input soil types' )
                END IF
                IF (VEGTYP .gt. LUCATS) THEN
-!                    CALL wrf_error_fatal ( 'Warning: too many input landuse types' )
+                     CALL physics_error_fatal ( 'Warning: too many input landuse types' )
                END IF
                IF (SLOPETYP .gt. SLPCATS) THEN
-!                    CALL wrf_error_fatal ( 'Warning: too many input slope types' )
+                     CALL physics_error_fatal ( 'Warning: too many input slope types' )
                END IF
 
 ! ----------------------------------------------------------------------

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -53,6 +53,7 @@
                 <nml_option name="config_met_prefix"            type="character"     default_value="CFSR"/>
                 <nml_option name="config_sfc_prefix"            type="character"     default_value="SST"/>
                 <nml_option name="config_fg_interval"           type="integer"       default_value="21600"/>
+                <nml_option name="config_landuse_data"          type="character"     default_value="USGS"/>
         </nml_record>
 
         <nml_record name="vertical_grid" in_defaults="true">
@@ -147,6 +148,7 @@
 			<var name="ter"/>
 			<var name="landmask"/>
 			<var name="ivgtyp"/>
+			<var name="mminlu"/>
 			<var name="isltyp"/>
 			<var name="soilcat_bot"/>
 			<var name="snoalb"/>
@@ -269,6 +271,7 @@
 			<var name="ter"/>
 			<var name="landmask"/>
 			<var name="ivgtyp"/>
+			<var name="mminlu"/>
 			<var name="isltyp"/>
 			<var name="soilcat_bot"/>
 			<var name="snoalb"/>
@@ -416,14 +419,15 @@
                 <var name="meshDensity"                  type="real"     dimensions="nCells"/>
 
                 <!-- coefficients for vertical extrapolation to the surface -->
-                <var name="cf1"                          type="real"     dimensions=/>
-                <var name="cf2"                          type="real"     dimensions=/>
-                <var name="cf3"                          type="real"     dimensions=/>
+                <var name="cf1"                          type="real"     dimensions=""/>
+                <var name="cf2"                          type="real"     dimensions=""/>
+                <var name="cf3"                          type="real"     dimensions=""/>
 
                 <!-- static terrestrial fields -->
                 <var name="ter"                                  type="real"     dimensions="nCells"/>
                 <var name="landmask"                             type="integer"  dimensions="nCells"/>
                 <var name="ivgtyp"   name_in_code="lu_index"     type="integer"  dimensions="nCells"/>
+                <var name="mminlu"                               type="text"     dimensions=""/>
                 <var name="isltyp"   name_in_code="soilcat_top"  type="integer"  dimensions="nCells"/>
                 <var name="soilcat_bot"                          type="integer"  dimensions="nCells"/>
                 <var name="snoalb"                               type="real"     dimensions="nCells"/>

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -55,6 +55,8 @@ module init_atm_cases
       logical, pointer :: config_static_interp
       logical, pointer :: config_met_interp
 
+      character(len=StrKIND), pointer :: mminlu
+
       integer, pointer :: nCells
       integer, pointer :: nEdges
       integer, pointer :: nVertLevels
@@ -197,6 +199,21 @@ module init_atm_cases
                call init_atm_static(mesh, block_ptr % dimensions, block_ptr % configs)
                call init_atm_static_orogwd(mesh, block_ptr % dimensions, block_ptr % configs)
             end if
+
+            !
+            ! If at this point the mminlu variable is blank, we assume that the static interp step was
+            !   not run, and that we are working with a static file created before there was a choice
+            !   of land use datasets; in this case, the dataset was almost necessarily USGS
+            !
+            call mpas_pool_get_array(mesh, 'mminlu', mminlu)
+            if (len_trim(mminlu) == 0) then
+                  write(0,*) '****************************************************************'
+                  write(0,*) 'No information on land use dataset is available.'
+                  write(0,*) 'Assume that we are using ''USGS''.'
+                  write(0,*) '****************************************************************'
+                  write(mminlu,'(a)') 'USGS'
+            end if
+
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                    diag, diag_physics, config_init_case, block_ptr % dimensions, block_ptr % configs)
             if (config_met_interp) call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -40,7 +40,11 @@
 
  character(len=StrKIND) :: fname
  character(len=StrKIND), pointer :: config_geog_data_path
+ character(len=StrKIND), pointer :: config_landuse_data
  character(len=StrKIND+1) :: geog_data_path      ! same as config_geog_data_path, but guaranteed to have a trailing slash
+ character(len=StrKIND+1) :: geog_sub_path       ! subdirectory names in config_geog_data_path, with trailing slash
+
+ integer:: isice_lu,iswater_lu,ismax_lu
 
  integer:: nx,ny,nz
  integer:: endian,isigned,istatus,wordsize
@@ -86,6 +90,7 @@
  integer, dimension(:), pointer :: soilcat_top
  integer, dimension(:), pointer :: soilcat_bot
  integer, dimension(:), pointer :: landmask
+ character(len=StrKIND), pointer :: mminlu
 
 !--------------------------------------------------------------------------------------------------
 
@@ -94,6 +99,7 @@
  write(0,*) '--- enter subroutine init_atm_static:'
 
  call mpas_pool_get_config(configs, 'config_geog_data_path', config_geog_data_path)
+ call mpas_pool_get_config(configs, 'config_landuse_data', config_landuse_data)
 
  write(geog_data_path, '(a)') config_geog_data_path
  i = len_trim(geog_data_path)
@@ -134,6 +140,7 @@
 
  call mpas_pool_get_array(mesh, 'ter', ter)
  call mpas_pool_get_array(mesh, 'lu_index', lu_index)
+ call mpas_pool_get_array(mesh, 'mminlu', mminlu)
  call mpas_pool_get_array(mesh, 'soilcat_top', soilcat_top)
  call mpas_pool_get_array(mesh, 'soilcat_bot', soilcat_bot)
  call mpas_pool_get_array(mesh, 'landmask', landmask)
@@ -168,9 +175,9 @@
  kiteAreasOnVertex = kiteAreasOnVertex * sphere_radius**2.0
 
 
- !
- ! Initialize Coriolis parameter field on edges and vertices
- !
+!
+! Initialize Coriolis parameter field on edges and vertices
+!
  do iEdge=1,nEdges
     fEdge(iEdge)  = 2.0 * omega * sin(latEdge(iEdge))
  end do
@@ -179,11 +186,34 @@
  end do
 
 
- !
- ! Compute weights used in advection and deformation calculation
- !
+!
+! Compute weights used in advection and deformation calculation
+!
  call atm_initialize_advection_rk(mesh, nCells, nEdges, maxEdges, on_a_sphere, sphere_radius) 
  call atm_initialize_deformation_weights(mesh, nCells, on_a_sphere, sphere_radius) 
+
+
+!
+! Set land use and soil category parameters for water and ice
+!
+ surface_input_select0: select case(trim(config_landuse_data))
+    case('USGS')
+       isice_lu = 24
+       iswater_lu = 16
+       ismax_lu = 24
+       write(mminlu,'(a)') 'USGS'
+    case('MODIFIED_IGBP_MODIS_NOAH')
+       isice_lu = 15
+       iswater_lu = 17
+       ismax_lu = 20
+       write(mminlu,'(a)') 'MODIFIED_IGBP_MODIS_NOAH'
+    case default
+         write(0,*) '*****************************************************************'
+         write(0,*) 'Invalid land use dataset '''//trim(config_landuse_data)//''' selected for config_landuse_data'
+         write(0,*) '   Possible options are: ''USGS'', ''MODIFIED_IGBP_MODIS_NOAH'''
+         write(0,*) '*****************************************************************'
+         call mpas_dmpar_global_abort('Please correct the namelist.')
+ end select surface_input_select0
 
 
 !
@@ -246,6 +276,18 @@
 !
 ! Interpolate LU_INDEX
 !
+ surface_input_select1: select case(trim(config_landuse_data))
+    case('USGS')
+       geog_sub_path = 'landuse_30s/'
+    case('MODIFIED_IGBP_MODIS_NOAH')
+       geog_sub_path = 'modis_landuse_20class_30s/'
+    case default
+       write(0,*) '*****************************************************************'
+       write(0,*) 'Invalid land use dataset '''//trim(config_landuse_data)//''' selected for config_landuse_data'
+       write(0,*) '   Possible options are: ''USGS'', ''MODIFIED_IGBP_MODIS_NOAH'''
+       write(0,*) '*****************************************************************'
+       call mpas_dmpar_global_abort('Please correct the namelist.')
+ end select surface_input_select1
  nx = 1200
  ny = 1200
  nz = 1
@@ -254,7 +296,7 @@
  wordsize = 1
  scalefactor = 1.0
  allocate(rarray(nx,ny,nz))
- allocate(ncat(24,nCells))
+ allocate(ncat(ismax_lu,nCells))
  ncat(:,:) = 0
  lu_index(:) = 0.0
 
@@ -264,7 +306,7 @@
     do iTileStart = 1,42001,nx
        iTileEnd = iTileStart + nx - 1
        write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
-             'landuse_30s/',iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
+             trim(geog_sub_path),iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
        write(0,*) trim(fname)
 
        call read_geogrid(fname,len_trim(fname),rarray,nx,ny,nz,isigned,endian, &
@@ -274,6 +316,11 @@
        iPoint = 1
        do j=1,ny
        do i=1,nx
+!
+! The MODIS dataset appears to have zeros at the South Pole, possibly other places, too
+!
+if (rarray(i,j,1) == 0) cycle
+
           lat_pt = -89.99583  + (jTileStart + j - 2) * 0.0083333333
           lon_pt = -179.99583 + (iTileStart + i - 2) * 0.0083333333
           lat_pt = lat_pt * PI / 180.0
@@ -291,7 +338,7 @@
 
  do iCell = 1,nCells
     lu_index(iCell) = 1
-    do i = 2,24
+    do i = 2,ismax_lu
        if(ncat(i,iCell) > ncat(lu_index(iCell),iCell)) then
           lu_index(iCell) = i
        end if
@@ -423,19 +470,19 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! KLUDGE TO FIX SOIL TYPE OVER ANTARCTICA
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- where (lu_index == 24) soilcat_top = 16
- where (lu_index == 24) soilcat_bot = 16
+ where (lu_index == isice_lu) soilcat_top = 16
+ where (lu_index == isice_lu) soilcat_bot = 16
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! CORRECT INCONSISTENT SOIL AND LAND USE DATA
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  do iCell = 1,nCells
-    if (lu_index(iCell) == 16 .or. &
+    if (lu_index(iCell) == iswater_lu .or. &
         soilcat_top(iCell) == 14 .or. &
         soilcat_bot(iCell) == 14) then
-        if (lu_index(iCell) /= 16) then
+        if (lu_index(iCell) /= iswater_lu) then
             write(0,*) 'Turning lu_index into water at ', iCell
-            lu_index(iCell) = 16
+            lu_index(iCell) = iswater_lu
         end if
         if (soilcat_top(iCell) /= 14) then
             write(0,*) 'Turning soilcat_top into water at ', iCell
@@ -454,7 +501,7 @@
 !
  landmask(:) = 0
  do iCell=1, nCells
-    if (lu_index(iCell) /= 16) landmask(iCell) = 1
+    if (lu_index(iCell) /= iswater_lu) landmask(iCell) = 1
  end do
  write(0,*) '--- end interpolate LANDMASK'
 


### PR DESCRIPTION
When running the init_atmosphere core, users may select between two land use datasets by
setting the namelist option config_landuse_data to either 'USGS' or 'MODIFIED_IGBP_MODIS_NOAH'.
This choice is stored in the initial condition file in the string variable 'mminlu', from
which it is read by the atmosphere core. Users therefore do not need to specify the land use
dataset when running the atmosphere model.

For backwards compatibility with static and existing initial condition files, the land use dataset
is assumed to be USGS if the 'mminlu' variable is not found or contains no information.

Changes contributed by Dominikus Heinzeller (IMK).
