### PR TITLE
Fix broken surface updates in MPAS-Atmosphere.

### DIFF
--- a/src/core_atmosphere/mpas_atm_mpas_core.F
+++ b/src/core_atmosphere/mpas_atm_mpas_core.F
@@ -20,6 +20,7 @@ module mpas_core
    integer, parameter :: sfcAlarmID = 3 
    integer, parameter :: hifreqAlarmID = 4
 
+
    contains
 
 
@@ -105,6 +106,7 @@ module mpas_core
          sfc_update_obj % stream = STREAM_SFC
 
          call mpas_io_input_init(sfc_update_obj, domain % dminfo)
+         call mpas_add_input_fields(domain, sfc_update_obj)
 
          !     
          ! We need to decide which time slice to read from the surface file - read the most recent time slice that falls before or on the start time


### PR DESCRIPTION
Before the implementation of pools, the subroutine mpas_io_input_init() was
responsible for both creating a stream and adding the fields that belonged to
the stream. With the implementation of pools, the code to add fields to a stream
was moved to a separate subroutine, mpas_add_input_fields(), and the new
subroutine call was not added for the surface update stream in MPAS-Atmosphere.

Now, in mpas_atm_mpas_core.F, we add the call

```
      call mpas_add_input_fields(domain, sfc_update_obj)
```

immediately after the call to

```
      call mpas_io_input_init(sfc_update_obj, domain % dminfo)
```

.
