### PR TITLE
ocean: Enable reading of seaSurfacePressure

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -786,6 +786,7 @@
 			<var name="salinityRestore"/>
 			<var name="restingThickness"/>
 			<var name="surfaceWindStress"/>
+			<var name="seaSurfacePressure"/>
 		</stream>
 		<stream name="restart" type="restart">
 			<var name="temperature"/>


### PR DESCRIPTION
The variable seaSurfacePressure was not being read in from input files.
This commit adds that variable to the input stream.
