### PR TITLE
Initialize dx and dy for Gaussian projections when reading intermediate-...

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_read_met.F
+++ b/src/core_init_atmosphere/mpas_init_atm_read_met.F
@@ -346,6 +346,8 @@ module init_atm_read_met
                                                     fg_data % deltalat, &
                                                     fg_data % deltalon, &
                                                     fg_data % earth_radius
+            fg_data % dx = 0.0
+            fg_data % dy = 0.0
 
          ! Polar stereographic
          else if (fg_data % iproj == 5) then


### PR DESCRIPTION
If left uninitialized, a floating point error may occur when we attempt to convert these distances, which are not defined for Gaussian projections, from kilometers to meters.
