### PR TITLE
Move direction adjective to end of names.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -949,10 +949,10 @@
 			<var name="temperatureSurfaceValue"/>
 			<var name="salinitySurfaceValue"/>
 			<var name="tracer1SurfaceValue"/>
-			<var name="zonalSurfaceVelocity"/>
-			<var name="meridionalSurfaceVelocity"/>
-			<var name="zonalSSHGradient"/>
-			<var name="meridionalSSHGradient"/>
+			<var name="surfaceVelocityZonal"/>
+			<var name="surfaceVelocityMeridional"/>
+			<var name="SSHGradientZonal"/>
+			<var name="SSHGradientMeridional"/>
 			<var name="xtime"/>
 			<var name="zMid"/>
 			<var name="zTop"/>
@@ -967,8 +967,8 @@
 			<var name="viscosity"/>
 			<var name="divergence"/>
 			<var name="relativeVorticityCell"/>
-			<var name="normalVelocityZonal"/>
-			<var name="normalVelocityMeridional"/>
+			<var name="velocityZonal"/>
+			<var name="velocityMeridional"/>
 			<var name="RiTopOfCell"/>
 			<var name="vertViscTopOfEdge"/>
 			<var name="vertViscTopOfCell"/>
@@ -987,32 +987,32 @@
 			<var name="volumeEdgeGlobal"/>
 			<var name="CFLNumberGlobal"/>
 			<var name="nAverage"/>
-			<var name="avgSsh"/>
-			<var name="varSsh"/>
+			<var name="avgSSH"/>
+			<var name="varSSH"/>
 			<var name="avgNormalVelocity"/>
-			<var name="avgZonalVelocity"/>
-			<var name="avgMeridionalVelocity"/>
+			<var name="avgVelocityZonal"/>
+			<var name="avgVelocityMeridional"/>
 			<var name="avgVertVelocityTop"/>
 			<var name="varNormalVelocity"/>
-			<var name="varZonalVelocity"/>
-			<var name="varMeridionalVelocity"/>
+			<var name="varVelocityZonal"/>
+			<var name="varVelocityMeridional"/>
 			<var name="avgNormalTransportVelocity"/>
-			<var name="avgZonalTransportVelocity"/>
-			<var name="avgMeridionalTransportVelocity"/>
+			<var name="avgTransportVelocityZonal"/>
+			<var name="avgTransportVelocityMeridional"/>
 			<var name="avgVertTransportVelocityTop"/>
 			<var name="avgNormalGMBolusVelocity"/>
-			<var name="avgZonalGMBolusVelocity"/>
-			<var name="avgMeridionalGMBolusVelocity"/>
+			<var name="avgGMBolusVelocityZonal"/>
+			<var name="avgGMBolusVelocityMeridional"/>
 			<var name="avgVertGMBolusVelocityTop"/>
 			<var name="surfaceTemperatureFlux"/>
 			<var name="surfaceSalinityFlux"/>
 			<var name="surfaceTracer1Flux"/>
 			<var name="avgTemperatureSurfaceValue"/>
 			<var name="avgSalinitySurfaceValue"/>
-			<var name="avgZonalSurfaceVelocity"/>
-			<var name="avgMeridionalSurfaceVelocity"/>
-			<var name="avgZonalSSHGradient"/>
-			<var name="avgMeridionalSSHGradient"/>
+			<var name="avgSurfaceVelocityZonal"/>
+			<var name="avgSurfaceVelocityMeridional"/>
+			<var name="avgSSHGradientZonal"/>
+			<var name="avgSSHGradientMeridional"/>
 			<var name="surfaceWindStressMagnitude"/>
 			<var name="surfaceMassFlux"/>
 			<var name="seaSurfacePressure"/>
@@ -1045,21 +1045,21 @@
 			<var name="salineContractionCoeff"/>
 			<var name="relativeSlopeTopOfCell"/>
                         <var name="relativeSlopeTaperingCell"/>
-			<var name="xRelativeSlopeTopOfCell"/>
-			<var name="yRelativeSlopeTopOfCell"/>
-			<var name="zRelativeSlopeTopOfCell"/>
-			<var name="zonalRelativeSlopeTopOfCell"/>
-			<var name="meridionalRelativeSlopeTopOfCell"/>
+			<var name="relativeSlopeTopOfCellX"/>
+			<var name="relativeSlopeTopOfCellY"/>
+			<var name="relativeSlopeTopOfCellZ"/>
+			<var name="relativeSlopeTopOfCellZonal"/>
+			<var name="relativeSlopeTopOfCellMeridional"/>
                         <var name="k33"/>
-			<var name="xGMBolusVelocity"/>
-			<var name="yGMBolusVelocity"/>
-			<var name="zonalGMBolusVelocity"/>
-			<var name="meridionalGMBolusVelocity"/>
+			<var name="GMBolusVelocityX"/>
+			<var name="GMBolusVelocityY"/>
+			<var name="GMBolusVelocityZonal"/>
+			<var name="GMBolusVelocityMeridional"/>
 			<var name="normalGMBolusVelocity"/>
 			<var name="vertGMBolusVelocityTop"/>
 			<var name="gmStreamFuncTopOfEdge"/>
-			<var name="xGMStreamFunc"/>
-			<var name="yGMStreamFunc"/>
+			<var name="GMStreamFuncX"/>
+			<var name="GMStreamFuncY"/>
 		</stream>
 	</streams>
 	<var_struct name="state" time_levs="2">
@@ -1364,7 +1364,7 @@
 		<var name="tendLayerThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}" name_in_code="layerThickness"
 			 description="time tendency of layer thickness"
 		/>
-		<var name="tendSsh" type="real" dimensions="nCells Time" units="m s^{-1}" name_in_code="ssh"
+		<var name="tendSSH" type="real" dimensions="nCells Time" units="m s^{-1}" name_in_code="ssh"
 			 description="time tendency of sea-surface height"
 		/>
 		<var name="tendHighFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}" name_in_code="highFreqThickness"
@@ -1392,20 +1392,20 @@
 			/>
 		</var_array>
 		<var_array name="surfaceVelocity" type="real" dimensions="nCells Time">
-			<var name="zonalSurfaceVelocity" array_group="vel_zonal" units="m s^{-1}"
+			<var name="surfaceVelocityZonal" array_group="vel_zonal" units="m s^{-1}"
 				 description="Zonal surface velocity reconstructed at cell centers"
 				
 			/>
-			<var name="meridionalSurfaceVelocity" array_group="vel_meridional" units="m s^{-1}"
+			<var name="surfaceVelocityMeridional" array_group="vel_meridional" units="m s^{-1}"
 				 description="Meridional surface velocity reconstructed at cell centers"
 				
 			/>
 		</var_array>
 		<var_array name="SSHGradient" type="real" dimensions="nCells Time">
-			<var name="zonalSSHGradient" array_group="ssh_zonal" units="m m^{-1}"
+			<var name="SSHGradientZonal" array_group="ssh_zonal" units="m m^{-1}"
 				 description="Zonal gradient of SSH reconstructed at cell centers"
 			/>
-			<var name="meridionalSSHGradient" array_group="ssh_meridional" units="m m^{-1}"
+			<var name="SSHGradientMeridional" array_group="ssh_meridional" units="m m^{-1}"
 				 description="Meridional gradient of SSH reconstructed at cell centers"
 			/>
 		</var_array>
@@ -1519,34 +1519,34 @@
 			 description="Barotropic thickness flux at each edge, used to advance sea surface height in each subcycle of stage 2 of the split-explicit algorithm."
 		/>
 
-		<var name="normalVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="velocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity in the x-direction (cartesian)"
 		/>
-		<var name="normalVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="velocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity in the y-direction (cartesian)"
 		/>
-		<var name="normalVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="velocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity in the z-direction (cartesian)"
 		/>
-		<var name="normalVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="velocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity in the eastward direction"
 		/>
-		<var name="normalVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="velocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity in the northward direction"
 		/>
-		<var name="xTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="transportVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity used to transport mass and tracers in the x-direction (cartesian)"
 		/>
-		<var name="yTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="transportVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity used to transport mass and tracers in the y-direction (cartesian)"
 		/>
-		<var name="zTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="transportVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity used to transport mass and tracers in the z-direction (cartesian)"
 		/>
-		<var name="zonalTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="transportVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity used to transport mass and tracers in the eastward direction"
 		/>
-		<var name="meridionalTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="transportVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="component of horizontal velocity used to transport mass and tracers in the northward direction"
 		/>
 
@@ -1572,19 +1572,19 @@
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
 		/>
-		<var name="xGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="GMBolusVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, x-direction"
 		/>
-		<var name="yGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="GMBolusVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, y-direction"
 		/>
-		<var name="zGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="GMBolusVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, z-direction"
 		/>
-		<var name="zonalGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, zonal-direction"
 		/>
-		<var name="meridionalGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="GMBolusVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, meridional-direction"
 		/>
 
@@ -1684,19 +1684,19 @@
                 <var name="relativeSlopeTaperingCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="non-dimensional"
                          description="averaging of relativeSlopeTapering function to cell centers"
                 />
-		<var name="xRelativeSlopeTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+		<var name="relativeSlopeTopOfCellX" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
 			 description="Slope of isopycnal surface relative to constant coordinate surface"
 		/>
-		<var name="yRelativeSlopeTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+		<var name="relativeSlopeTopOfCellY" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
 			 description="Slope of isopycnal surface relative to constant coordinate surface"
 		/>
-		<var name="zRelativeSlopeTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+		<var name="relativeSlopeTopOfCellZ" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
 			 description="Slope of isopycnal surface relative to constant coordinate surface"
 		/>
-		<var name="zonalRelativeSlopeTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+		<var name="relativeSlopeTopOfCellZonal" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
 			 description="Slope of isopycnal surface relative to constant coordinate surface"
 		/>
-		<var name="meridionalRelativeSlopeTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+		<var name="relativeSlopeTopOfCellMeridional" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
 			 description="Slope of isopycnal surface relative to constant coordinate surface"
 		/>
 		<var name="k33" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
@@ -1708,19 +1708,19 @@
 		<var name="gmStreamFuncTopOfCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function reconstructed to the cell centers"
 		/>
-		<var name="xGMStreamFunc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
+		<var name="GMStreamFuncX" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 		/>
-		<var name="yGMStreamFunc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
+		<var name="GMStreamFuncY" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 		/>
-		<var name="zGMStreamFunc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
+		<var name="GMStreamFuncZ" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 		/>
-		<var name="zonalGMStreamFunc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
+		<var name="GMStreamFuncZonal" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 		/>
-		<var name="meridionalGMStreamFunc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
+		<var name="GMStreamFuncMeridional" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 		/>
 	</var_struct>
@@ -1728,37 +1728,37 @@
 		<var name="nAverage" type="real" dimensions="Time" units="unitless"
 			 description="number of timesteps in time-averaged variables"
 		/>
-		<var name="avgSsh" type="real" dimensions="nCells Time" units="m"
+		<var name="avgSSH" type="real" dimensions="nCells Time" units="m"
 			 description="time-averaged sea surface height"
 		/>
-		<var name="varSsh" type="real" dimensions="nCells Time" units="m"
+		<var name="varSSH" type="real" dimensions="nCells Time" units="m"
 			 description="variance of sea surface height"
 		/>
 		<var name="avgNormalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="time-averaged velocity, normal to cell edge"
 		/>
-		<var name="avgZonalVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged velocity in the eastward direction"
 		/>
-		<var name="avgMeridionalVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged velocity in the northward direction"
 		/>
 		<var name="varNormalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="variance of velocity, normal to cell edge"
 		/>
-		<var name="varZonalVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="varVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="variance of velocity in the eastward direction"
 		/>
-		<var name="varMeridionalVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="varVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="variance of velocity in the northward direction"
 		/>
 		<var name="avgNormalTransportVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="time-averaged total tracer-transport velocity, normal to cell edge"
 		/>
-		<var name="avgZonalTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgTransportVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged total tracer-transport velocity in the eastward direction"
 		/>
-		<var name="avgMeridionalTransportVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgTransportVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged total tracer-transport velocity in the northward direction"
 		/>
 		<var name="avgVertVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
@@ -1770,10 +1770,10 @@
 		<var name="avgNormalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="time-averaged GM Bolus velocity, normal to cell edge"
 		/>
-		<var name="avgZonalGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgGMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged GM Bolus velocity in the eastward direction"
 		/>
-		<var name="avgMeridionalGMBolusVelocity" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="avgGMBolusVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="time-averaged GM Bolus velocity in the northward direction"
 		/>
 		<var name="avgVertGMBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
@@ -1925,18 +1925,18 @@
 			/>
 		</var_array>
 		<var_array name="avgSurfaceVelocity" type="real" dimensions="nCells Time">
-		<var name="avgZonalSurfaceVelocity" array_group="vel_zonal" units="m s^{-1}"
+		<var name="avgSurfaceVelocityZonal" array_group="vel_zonal" units="m s^{-1}"
 			 description="Time averaged zonal surface velocity"
 		/>
-		<var name="avgMeridionalSurfaceVelocity" array_group="vel_meridional" units="m s^{-1}"
+		<var name="avgSurfaceVelocityMeridional" array_group="vel_meridional" units="m s^{-1}"
 			 description="Time averaged meridional surface velocity"
 		/>
 		</var_array>
 		<var_array name="avgSSHGradient" type="real" dimensions="nCells Time">
-			<var name="avgZonalSSHGradient" array_group="ssh_zonal" units="m m^{-1}"
+			<var name="avgSSHGradientZonal" array_group="ssh_zonal" units="m m^{-1}"
 				 description="Time averaged zonal gradient of SSH"
 			/>
-			<var name="avgMeridionalSSHGradient" array_group="ssh_meridional" units="m m^{-1}"
+			<var name="avgSSHGradientMeridional" array_group="ssh_meridional" units="m m^{-1}"
 				 description="Time averaged meridional gradient of SSH"
 			/>
 		</var_array>

--- a/src/core_ocean/analysis_members/Registry_zonal_mean.xml
+++ b/src/core_ocean/analysis_members/Registry_zonal_mean.xml
@@ -39,8 +39,8 @@
 		<stream name="output" type="output">
 			<var name="binCenterZonalMean"/>
 			<var name="binBoundaryZonalMean"/>
-			<var name="zonalVelocityZonalMean"/>
-			<var name="meridionalVelocityZonalMean"/>
+			<var name="velocityZonalZonalMean"/>
+			<var name="velocityMeridionalZonalMean"/>
 			<var name="tracer1ZonalMean"/>
 		</stream>
 	</streams>
@@ -51,10 +51,10 @@
 		<var name="binBoundaryZonalMean" type="real" dimensions="nZonalMeanBinsP1" units="varies"
 			 description="Coordinate of lower edge of zonal mean bin, either in latitude or y, for plotting."
 		/>
-		<var name="zonalVelocityZonalMean" type="real" dimensions="nVertLevels nZonalMeanBins Time" units="m s^{-1}"
+		<var name="velocityZonalZonalMean" type="real" dimensions="nVertLevels nZonalMeanBins Time" units="m s^{-1}"
 			 description="Zonal mean of component of horizontal velocity in the eastward direction"
 		/>
-		<var name="meridionalVelocityZonalMean" type="real" dimensions="nVertLevels nZonalMeanBins Time" units="m s^{-1}"
+		<var name="velocityMeridionalZonalMean" type="real" dimensions="nVertLevels nZonalMeanBins Time" units="m s^{-1}"
 			 description="Zonal mean of component of horizontal velocity in the northward direction"
 		/>
 		<var_array name="tracersZonalMean" type="real" dimensions="nVertLevels nZonalMeanBins Time">

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -388,8 +388,8 @@ contains
       integer, dimension(:), pointer :: maxLevelCell
 
       real (kind=RKIND), dimension(:), pointer ::  areaCell, binVariable, binBoundaryZonalMean
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityZonal, normalVelocityMeridional
-      real (kind=RKIND), dimension(:,:), pointer :: zonalVelocityZonalMean, meridionalVelocityZonalMean
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonalZonalMean, velocityMeridionalZonalMean
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       real (kind=RKIND), dimension(:,:,:), allocatable :: sumZonalMean, totalSumZonalMean, normZonalMean
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersZonalMean
@@ -441,8 +441,8 @@ contains
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)        
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)    
          call mpas_pool_get_array(statePool, 'tracers', tracers,timeLevel)         
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
 
          ! Bin by latitude on a sphere, by yCell otherwise.
          if (on_a_sphere) then
@@ -470,9 +470,9 @@ contains
                      enddo
 
                      iField = num_tracers+2
-                     sumZonalMean(iField,k,iBin) = sumZonalMean(iField,k,iBin) + normalVelocityZonal(k,iCell)*areaCell(iCell)
+                     sumZonalMean(iField,k,iBin) = sumZonalMean(iField,k,iBin) + velocityZonal(k,iCell)*areaCell(iCell)
                      iField = iField+1
-                     sumZonalMean(iField,k,iBin) = sumZonalMean(iField,k,iBin) + normalVelocityMeridional(k,iCell)*areaCell(iCell)
+                     sumZonalMean(iField,k,iBin) = sumZonalMean(iField,k,iBin) + velocityMeridional(k,iCell)*areaCell(iCell)
 
                   end do
                   exit
@@ -517,8 +517,8 @@ contains
          call mpas_pool_get_dimension(statePool, 'num_tracers', num_tracers)
 
          call mpas_pool_get_array(amZonalMeanPool, 'tracersZonalMean', tracersZonalMean)
-         call mpas_pool_get_array(amZonalMeanPool, 'zonalVelocityZonalMean', zonalVelocityZonalMean)
-         call mpas_pool_get_array(amZonalMeanPool, 'meridionalVelocityZonalMean', meridionalVelocityZonalMean)
+         call mpas_pool_get_array(amZonalMeanPool, 'velocityZonalZonalMean', velocityZonalZonalMean)
+         call mpas_pool_get_array(amZonalMeanPool, 'velocityMeridionalZonalMean', velocityMeridionalZonalMean)
 
          do iBin = 1, nZonalMeanBins
             do k = 1, nVertLevels
@@ -528,9 +528,9 @@ contains
                enddo
 
                iField = num_tracers + 2
-               zonalVelocityZonalMean(k,iBin) = normZonalMean(iField,k,iBin)
+               velocityZonalZonalMean(k,iBin) = normZonalMean(iField,k,iBin)
                iField = iField+1
-               meridionalVelocityZonalMean(k,iBin) = normZonalMean(iField,k,iBin)
+               velocityMeridionalZonalMean(k,iBin) = normZonalMean(iField,k,iBin)
 
             end do
          end do

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
@@ -251,8 +251,8 @@ module mpas_core
       real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd, normalTransportVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalGMBolusVelocity, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityX, normalVelocityY, normalVelocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityZonal, normalVelocityMeridional
+      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:,:), pointer :: derivTwo
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
@@ -290,11 +290,11 @@ module mpas_core
 
       call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityX', normalVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityY', normalVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZ', normalVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -328,11 +328,11 @@ module mpas_core
 
       call mpas_init_reconstruct(meshPool)
       call mpas_reconstruct(meshPool, normalVelocity,        &
-                       normalVelocityX,            &
-                       normalVelocityY,            &
-                       normalVelocityZ,            &
-                       normalVelocityZonal,        &
-                       normalVelocityMeridional    &
+                       velocityX,            &
+                       velocityY,            &
+                       velocityZ,            &
+                       velocityZonal,        &
+                       velocityMeridional    &
                       )
 
       if (config_use_standardGM) then

--- a/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
@@ -411,8 +411,8 @@ print *, 'output alarmTimeStep', alarmTimeStep, ierr
       real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd, normalTransportVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalGMBolusVelocity, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityX, normalVelocityY, normalVelocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityZonal, normalVelocityMeridional
+      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:,:), pointer :: derivTwo
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
@@ -451,11 +451,11 @@ print *, 'output alarmTimeStep', alarmTimeStep, ierr
 
       call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityX', normalVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityY', normalVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZ', normalVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -520,11 +520,11 @@ print *, 'output alarmTimeStep', alarmTimeStep, ierr
       call mpas_init_reconstruct(meshPool)
 
       call mpas_reconstruct(meshPool, normalVelocity,        &
-                       normalVelocityX,            &
-                       normalVelocityY,            &
-                       normalVelocityZ,            &
-                       normalVelocityZonal,        &
-                       normalVelocityMeridional    &
+                       velocityX,            &
+                       velocityY,            &
+                       velocityZ,            &
+                       velocityZonal,        &
+                       velocityMeridional    &
                       )
 
       if (config_use_standardGM) then

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -124,8 +124,8 @@ module ocn_time_integration_rk4
       integer, pointer :: indexSalinity
 
       ! Diagnostics Indices
-      integer, pointer :: indexZonalSurfaceVelocity, indexMeridionalSurfaceVelocity
-      integer, pointer:: indexZonalSSHGradient, indexMeridionalSSHGradient
+      integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+      integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
 
       ! Mesh array pointers
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
@@ -144,8 +144,8 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge
       real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
       real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity, normalGMBolusVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityX, normalVelocityY, normalVelocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityZonal, normalVelocityMeridional
+      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:), pointer :: gradSSH
       real (kind=RKIND), dimension(:,:), pointer :: gradSSHX, gradSSHY, gradSSHZ
       real (kind=RKIND), dimension(:,:), pointer :: gradSSHZonal, gradSSHMeridional
@@ -680,18 +680,18 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
 
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_zonalSurfaceVelocity', indexZonalSurfaceVelocity)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_meridionalSurfaceVelocity', indexMeridionalSurfaceVelocity)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_zonalSSHGradient', indexZonalSSHGradient)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_meridionalSSHGradient', indexMeridionalSSHGradient)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
 
          call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
          call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityX', normalVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityY', normalVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZ', normalVelocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
@@ -729,8 +729,8 @@ module ocn_time_integration_rk4
          ! ------------------------------------------------------------------
 
          call mpas_reconstruct(meshPool,  normalVelocityNew,                 &
-                          normalVelocityX, normalVelocityY, normalVelocityZ, &
-                          normalVelocityZonal, normalVelocityMeridional      &
+                          velocityX, velocityY, velocityZ, &
+                          velocityZonal, velocityMeridional      &
                          )
 
          call mpas_reconstruct(meshPool, gradSSH,         &
@@ -738,11 +738,11 @@ module ocn_time_integration_rk4
                           gradSSHZonal, gradSSHMeridional &
                          )
 
-         surfaceVelocity(indexZonalSurfaceVelocity, :) = normalVelocityZonal(1, :)
-         surfaceVelocity(indexMeridionalSurfaceVelocity, :) = normalVelocityMeridional(1, :)
+         surfaceVelocity(indexSurfaceVelocityZonal, :) = velocityZonal(1, :)
+         surfaceVelocity(indexSurfaceVelocityMeridional, :) = velocityMeridional(1, :)
 
-         SSHGradient(indexZonalSSHGradient, :) = gradSSHZonal(1, :)
-         SSHGradient(indexMeridionalSSHGradient, :) = gradSSHMeridional(1, :)
+         SSHGradient(indexSSHGradientZonal, :) = gradSSHZonal(1, :)
+         SSHGradient(indexSSHGradientMeridional, :) = gradSSHMeridional(1, :)
 
          call ocn_time_average_accumulate(averagePool, statePool, diagnosticsPool, 2)
          call ocn_time_average_coupled_accumulate(diagnosticsPool, forcingPool)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -134,8 +134,8 @@ module ocn_time_integration_split
       ! Dimensions
       integer, pointer :: nCells, nEdges, nVertLevels, num_tracers, startIndex, endIndex
       integer, pointer :: indexTemperature, indexSalinity
-      integer, pointer :: indexZonalSurfaceVelocity, indexMeridionalSurfaceVelocity
-      integer, pointer :: indexZonalSSHGradient, indexMeridionalSSHGradient
+      integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+      integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
 
       ! Mesh array pointers
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, nEdgesOnEdge, nEdgesOnCell
@@ -169,8 +169,8 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), pointer :: barotropicForcing, barotropicThicknessFlux
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalTransportVelocity, normalGMBolusVelocity
       real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityX, normalVelocityY, normalVelocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityZonal, normalVelocityMeridional
+      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:), pointer :: gradSSH
       real (kind=RKIND), dimension(:,:), pointer :: gradSSHX, gradSSHY, gradSSHZ
       real (kind=RKIND), dimension(:,:), pointer :: gradSSHZonal, gradSSHMeridional
@@ -1457,11 +1457,11 @@ module ocn_time_integration_split
 
          call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
          call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityX', normalVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityY', normalVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZ', normalVelocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
          call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
@@ -1472,10 +1472,10 @@ module ocn_time_integration_split
          call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
          call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
 
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_zonalSurfaceVelocity', indexZonalSurfaceVelocity)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_meridionalSurfaceVelocity', indexMeridionalSurfaceVelocity)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_zonalSSHGradient', indexZonalSSHGradient)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_meridionalSSHGradient', indexMeridionalSSHGradient)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
+         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
 
          if (config_prescribe_velocity) then
             normalVelocityNew(:,:) = normalVelocityCur(:,:)
@@ -1493,8 +1493,8 @@ module ocn_time_integration_split
          end if
 
          call mpas_reconstruct(meshPool, normalVelocityNew,                  &
-                          normalVelocityX, normalVelocityY, normalVelocityZ, &
-                          normalVelocityZonal, normalVelocityMeridional      &
+                          velocityX, velocityY, velocityZ, &
+                          velocityZonal, velocityMeridional      &
                          )
 
          call mpas_reconstruct(meshPool, gradSSH,         &
@@ -1502,11 +1502,11 @@ module ocn_time_integration_split
                           gradSSHZonal, gradSSHMeridional &
                          )
 
-         surfaceVelocity(indexZonalSurfaceVelocity, :) = normalVelocityZonal(1, :)
-         surfaceVelocity(indexMeridionalSurfaceVelocity, :) = normalVelocityMeridional(1, :)
+         surfaceVelocity(indexSurfaceVelocityZonal, :) = velocityZonal(1, :)
+         surfaceVelocity(indexSurfaceVelocityMeridional, :) = velocityMeridional(1, :)
 
-         SSHGradient(indexZonalSSHGradient, :) = gradSSHZonal(1, :)
-         SSHGradient(indexMeridionalSSHGradient, :) = gradSSHMeridional(1, :)
+         SSHGradient(indexSSHGradientZonal, :) = gradSSHZonal(1, :)
+         SSHGradient(indexSSHGradientMeridional, :) = gradSSHMeridional(1, :)
 
          call ocn_time_average_accumulate(averagePool, statePool, diagnosticsPool, 2)
          call ocn_time_average_coupled_accumulate(diagnosticsPool, forcingPool)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1156,69 +1156,69 @@ contains
       type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-         normalTransportVelocity, xTransportVelocity, yTransportVelocity, zTransportVelocity, zonalTransportVelocity, meridionalTransportVelocity, &
-         normalGMBolusVelocity, xGMBolusVelocity, yGMBolusVelocity, zGMBolusVelocity, zonalGMBolusVelocity, meridionalGMBolusVelocity, &
-         relativeSlopeTopOfEdge, xRelativeSlopeTopOfCell, yRelativeSlopeTopOfCell, zRelativeSlopeTopOfCell, zonalRelativeSlopeTopOfCell, meridionalRelativeSlopeTopOfCell, &
-         gmStreamFuncTopOfEdge, xGMStreamFunc, yGMStreamFunc, zGMStreamFunc, zonalGMStreamFunc, meridionalGMStreamFunc
+         normalTransportVelocity, transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, transportVelocityMeridional, &
+         normalGMBolusVelocity, GMBolusVelocityX, GMBolusVelocityY, GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, &
+         relativeSlopeTopOfEdge, relativeSlopeTopOfCellX, relativeSlopeTopOfCellY, relativeSlopeTopOfCellZ, relativeSlopeTopOfCellZonal, relativeSlopeTopOfCellMeridional, &
+         gmStreamFuncTopOfEdge, GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional
 
          call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'xTransportVelocity', xTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'yTransportVelocity', yTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'zTransportVelocity', zTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'zonalTransportVelocity', zonalTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'meridionalTransportVelocity', meridionalTransportVelocity)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
 
          call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'xGMBolusVelocity', xGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'yGMBolusVelocity', yGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'zGMBolusVelocity', zGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'zonalGMBolusVelocity', zonalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'meridionalGMBolusVelocity', meridionalGMBolusVelocity)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
 
          call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfEdge', relativeSlopeTopOfEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'xRelativeSlopeTopOfCell', xRelativeSlopeTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'yRelativeSlopeTopOfCell', yRelativeSlopeTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'zRelativeSlopeTopOfCell', zRelativeSlopeTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'zonalRelativeSlopeTopOfCell', zonalRelativeSlopeTopOfCell)
-         call mpas_pool_get_array(diagnosticsPool, 'meridionalRelativeSlopeTopOfCell', meridionalRelativeSlopeTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfCellX', relativeSlopeTopOfCellX)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfCellY', relativeSlopeTopOfCellY)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfCellZ', relativeSlopeTopOfCellZ)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfCellZonal', relativeSlopeTopOfCellZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeSlopeTopOfCellMeridional', relativeSlopeTopOfCellMeridional)
 
          call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'xGMStreamFunc', xGMStreamFunc)
-         call mpas_pool_get_array(diagnosticsPool, 'yGMStreamFunc', yGMStreamFunc)
-         call mpas_pool_get_array(diagnosticsPool, 'zGMStreamFunc', zGMStreamFunc)
-         call mpas_pool_get_array(diagnosticsPool, 'zonalGMStreamFunc', zonalGMStreamFunc)
-         call mpas_pool_get_array(diagnosticsPool, 'meridionalGMStreamFunc', meridionalGMStreamFunc)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
 
          call mpas_reconstruct(meshPool, normalTransportVelocity,          &
-                          xTransportVelocity,            &
-                          yTransportVelocity,            &
-                          zTransportVelocity,            &
-                          zonalTransportVelocity,        &
-                          meridionalTransportVelocity    &
+                          transportVelocityX,            &
+                          transportVelocityY,            &
+                          transportVelocityZ,            &
+                          transportVelocityZonal,        &
+                          transportVelocityMeridional    &
                          )
 
          call mpas_reconstruct(meshPool, normalGMBolusVelocity,          &
-                          xGMBolusVelocity,            &
-                          yGMBolusVelocity,            &
-                          zGMBolusVelocity,            &
-                          zonalGMBolusVelocity,        &
-                          meridionalGMBolusVelocity    &
+                          GMBolusVelocityX,            &
+                          GMBolusVelocityY,            &
+                          GMBolusVelocityZ,            &
+                          GMBolusVelocityZonal,        &
+                          GMBolusVelocityMeridional    &
                          )
 
          call mpas_reconstruct(meshPool, relativeSlopeTopOfEdge,          &
-                         xRelativeSlopeTopOfCell,            &
-                         yRelativeSlopeTopOfCell,            &
-                         zRelativeSlopeTopOfCell,            &
-                         zonalRelativeSlopeTopOfCell,        &
-                         meridionalRelativeSlopeTopOfCell    &
+                         relativeSlopeTopOfCellX,            &
+                         relativeSlopeTopOfCellY,            &
+                         relativeSlopeTopOfCellZ,            &
+                         relativeSlopeTopOfCellZonal,        &
+                         relativeSlopeTopOfCellMeridional    &
                         )
 
          call mpas_reconstruct(meshPool, gmStreamFuncTopOfEdge,          &
-                         xGMStreamFunc,            &
-                         yGMStreamFunc,            &
-                         zGMStreamFunc,            &
-                         zonalGMStreamFunc,        &
-                         meridionalGMStreamFunc    &
+                         GMStreamFuncX,            &
+                         GMStreamFuncY,            &
+                         GMStreamFuncZ,            &
+                         GMStreamFuncZonal,        &
+                         GMStreamFuncMeridional    &
                         )
 
    end subroutine ocn_reconstruct_gm_vectors!}}}

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -41,7 +41,7 @@ module ocn_gm
    private :: tridiagonal_solve
 
    ! Config options
-   real (kind=RKIND), pointer :: config_diapycnal_diff, config_gravWaveSpeed_trunc, config_standardGM_tracer_kappa, config_density0, &
+   real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc, config_standardGM_tracer_kappa, config_density0, &
      config_max_relative_slope, config_Redi_kappa
    logical, pointer :: config_use_standardGM
    logical, pointer :: config_disable_redi_k33
@@ -547,7 +547,6 @@ contains
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_diapycnal_diff',config_diapycnal_diff)
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
       call mpas_pool_get_config(ocnConfigs, 'config_max_relative_slope',config_max_relative_slope)

--- a/src/core_ocean/shared/mpas_ocn_time_average.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average.F
@@ -22,28 +22,28 @@ module ocn_time_average
 
         real (kind=RKIND), dimension(:), pointer :: avgSSH, varSSH
         real (kind=RKIND), dimension(:,:), pointer :: &
-           avgNormalVelocity, avgZonalVelocity, avgMeridionalVelocity, avgVertVelocityTop, &
-           varNormalVelocity, varZonalVelocity, varMeridionalVelocity, &
-           avgNormalTransportVelocity, avgZonalTransportVelocity, avgMeridionalTransportVelocity, avgVertTransportVelocityTop, &
-           avgNormalGMBolusVelocity, avgZonalGMBolusVelocity, avgMeridionalGMBolusVelocity, avgVertGMBolusVelocityTop
+           avgNormalVelocity, avgVelocityZonal, avgVelocityMeridional, avgVertVelocityTop, &
+           varNormalVelocity, varVelocityZonal, varVelocityMeridional, &
+           avgNormalTransportVelocity, avgTransportVelocityZonal, avgTransportVelocityMeridional, avgVertTransportVelocityTop, &
+           avgNormalGMBolusVelocity, avgGMBolusVelocityZonal, avgGMBolusVelocityMeridional, avgVertGMBolusVelocityTop
 
         call mpas_pool_get_array(averagePool, 'nAverage', nAverage)
-        call mpas_pool_get_array(averagePool, 'avgSsh', avgSSH)
-        call mpas_pool_get_array(averagePool, 'varSsh', varSSH)
+        call mpas_pool_get_array(averagePool, 'avgSSH', avgSSH)
+        call mpas_pool_get_array(averagePool, 'varSSH', varSSH)
         call mpas_pool_get_array(averagePool, 'avgNormalVelocity', avgNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalVelocity', avgZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalVelocity', avgMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'avgVelocityZonal', avgVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgVelocityMeridional', avgVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertVelocityTop', avgVertVelocityTop)
         call mpas_pool_get_array(averagePool, 'varNormalVelocity', varNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'varZonalVelocity', varZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'varMeridionalVelocity', varMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'varVelocityZonal', varVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'varVelocityMeridional', varVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgNormalTransportVelocity', avgNormalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalTransportVelocity', avgZonalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalTransportVelocity', avgMeridionalTransportVelocity)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityZonal', avgTransportVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityMeridional', avgTransportVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertTransportVelocityTop', avgVertTransportVelocityTop)
         call mpas_pool_get_array(averagePool, 'avgNormalGMBolusVelocity', avgNormalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalGMBolusVelocity', avgZonalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalGMBolusVelocity', avgMeridionalGMBolusVelocity)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityZonal', avgGMBolusVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityMeridional', avgGMBolusVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertGMBolusVelocityTop', avgVertGMBolusVelocityTop)
 
         nAverage = 0
@@ -51,19 +51,19 @@ module ocn_time_average
         avgSSH = 0.0
         varSSH = 0.0
         avgNormalVelocity = 0.0
-        avgZonalVelocity = 0.0
-        avgMeridionalVelocity = 0.0
+        avgVelocityZonal = 0.0
+        avgVelocityMeridional = 0.0
         avgVertVelocityTop = 0.0
         varNormalVelocity = 0.0
-        varZonalVelocity = 0.0
-        varMeridionalVelocity = 0.0
+        varVelocityZonal = 0.0
+        varVelocityMeridional = 0.0
         avgNormalTransportVelocity = 0.0
-        avgZonalTransportVelocity = 0.0
-        avgMeridionalTransportVelocity = 0.0
+        avgTransportVelocityZonal = 0.0
+        avgTransportVelocityMeridional = 0.0
         avgVertTransportVelocityTop = 0.0
         avgNormalGMBolusVelocity = 0.0
-        avgZonalGMBolusVelocity = 0.0
-        avgMeridionalGMBolusVelocity = 0.0
+        avgGMBolusVelocityZonal = 0.0
+        avgGMBolusVelocityMeridional = 0.0
         avgVertGMBolusVelocityTop = 0.0
 
     end subroutine ocn_time_average_init!}}}
@@ -78,23 +78,23 @@ module ocn_time_average
 
         real (kind=RKIND), dimension(:), pointer :: ssh
         real (kind=RKIND), dimension(:,:), pointer :: &
-           normalVelocityZonal, normalVelocityMeridional, normalVelocity, vertVelocityTop, &
-           zonalTransportVelocity, meridionalTransportVelocity, normalTransportVelocity, vertTransportVelocityTop, &
-           zonalGMBolusVelocity, meridionalGMBolusVelocity, normalGMBolusVelocity, vertGMBolusVelocityTop
+           velocityZonal, velocityMeridional, normalVelocity, vertVelocityTop, &
+           transportVelocityZonal, transportVelocityMeridional, normalTransportVelocity, vertTransportVelocityTop, &
+           GMBolusVelocityZonal, GMBolusVelocityMeridional, normalGMBolusVelocity, vertGMBolusVelocityTop
 
         real (kind=RKIND), dimension(:), pointer :: avgSSH, varSSH
         real (kind=RKIND), dimension(:,:), pointer :: &
-           avgNormalVelocity, avgZonalVelocity, avgMeridionalVelocity, avgVertVelocityTop, &
-           varNormalVelocity, varZonalVelocity, varMeridionalVelocity, &
-           avgNormalTransportVelocity, avgZonalTransportVelocity, avgMeridionalTransportVelocity, avgVertTransportVelocityTop, &
-           avgNormalGMBolusVelocity, avgZonalGMBolusVelocity, avgMeridionalGMBolusVelocity, avgVertGMBolusVelocityTop
+           avgNormalVelocity, avgVelocityZonal, avgVelocityMeridional, avgVertVelocityTop, &
+           varNormalVelocity, varVelocityZonal, varVelocityMeridional, &
+           avgNormalTransportVelocity, avgTransportVelocityZonal, avgTransportVelocityMeridional, avgVertTransportVelocityTop, &
+           avgNormalGMBolusVelocity, avgGMBolusVelocityZonal, avgGMBolusVelocityMeridional, avgVertGMBolusVelocityTop
 
         real (kind=RKIND), dimension(:), pointer :: old_avgSSH, old_varSSH
         real (kind=RKIND), dimension(:,:), pointer :: &
-           old_avgNormalVelocity, old_avgZonalVelocity, old_avgMeridionalVelocity, old_avgVertVelocityTop, &
-           old_varNormalVelocity, old_varZonalVelocity, old_varMeridionalVelocity, &
-           old_avgNormalTransportVelocity, old_avgZonalTransportVelocity, old_avgMeridionalTransportVelocity, old_avgVertTransportVelocityTop, &
-           old_avgNormalGMBolusVelocity, old_avgZonalGMBolusVelocity, old_avgMeridionalGMBolusVelocity, old_avgVertGMBolusVelocityTop
+           old_avgNormalVelocity, old_avgVelocityZonal, old_avgVelocityMeridional, old_avgVertVelocityTop, &
+           old_varNormalVelocity, old_varVelocityZonal, old_varVelocityMeridional, &
+           old_avgNormalTransportVelocity, old_avgTransportVelocityZonal, old_avgTransportVelocityMeridional, old_avgVertTransportVelocityTop, &
+           old_avgNormalGMBolusVelocity, old_avgGMBolusVelocityZonal, old_avgGMBolusVelocityMeridional, old_avgVertGMBolusVelocityTop
 
         integer :: timeLevel
 
@@ -107,53 +107,53 @@ module ocn_time_average
         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
         call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-        call mpas_pool_get_array(diagnosticsPool, 'normalVelocityZonal', normalVelocityZonal)
-        call mpas_pool_get_array(diagnosticsPool, 'normalVelocityMeridional', normalVelocityMeridional)
+        call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+        call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
         call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity ', normalTransportVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'zonalTransportVelocity', zonalTransportVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'meridionalTransportVelocity', meridionalTransportVelocity)
+        call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
+        call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
         call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'zonalGMBolusVelocity', zonalGMBolusVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'meridionalGMBolusVelocity', meridionalGMBolusVelocity)
+        call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
+        call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
         call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
 
         call mpas_pool_get_array(averagePool, 'nAverage', nAverage)
-        call mpas_pool_get_array(averagePool, 'avgSsh', avgSSH)
-        call mpas_pool_get_array(averagePool, 'varSsh', varSSH)
+        call mpas_pool_get_array(averagePool, 'avgSSH', avgSSH)
+        call mpas_pool_get_array(averagePool, 'varSSH', varSSH)
         call mpas_pool_get_array(averagePool, 'avgNormalVelocity', avgNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalVelocity', avgZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalVelocity', avgMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'avgVelocityZonal', avgVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgVelocityMeridional', avgVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertVelocityTop', avgVertVelocityTop)
         call mpas_pool_get_array(averagePool, 'varNormalVelocity', varNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'varZonalVelocity', varZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'varMeridionalVelocity', varMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'varVelocityZonal', varVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'varVelocityMeridional', varVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgNormalTransportVelocity', avgNormalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalTransportVelocity', avgZonalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalTransportVelocity', avgMeridionalTransportVelocity)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityZonal', avgTransportVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityMeridional', avgTransportVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertTransportVelocityTop', avgVertTransportVelocityTop)
         call mpas_pool_get_array(averagePool, 'avgNormalGMBolusVelocity', avgNormalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalGMBolusVelocity', avgZonalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalGMBolusVelocity', avgMeridionalGMBolusVelocity)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityZonal', avgGMBolusVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityMeridional', avgGMBolusVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertGMBolusVelocityTop', avgVertGMBolusVelocityTop)
 
         avgSSH = avgSSH + ssh
         varSSH = varSSH + ssh**2
         avgNormalVelocity = avgNormalVelocity + normalVelocity
-        avgZonalVelocity = avgZonalVelocity + normalVelocityZonal
-        avgMeridionalVelocity = avgMeridionalVelocity + normalVelocityMeridional
+        avgVelocityZonal = avgVelocityZonal + velocityZonal
+        avgVelocityMeridional = avgVelocityMeridional + velocityMeridional
         avgVertVelocityTop = avgVertVelocityTop + vertVelocityTop
         varNormalVelocity = varNormalVelocity + normalVelocity**2
-        varZonalVelocity = varZonalVelocity + normalVelocityZonal**2
-        varMeridionalVelocity = varMeridionalVelocity + normalVelocityMeridional**2
+        varVelocityZonal = varVelocityZonal + velocityZonal**2
+        varVelocityMeridional = varVelocityMeridional + velocityMeridional**2
         avgNormalTransportVelocity = avgNormalTransportVelocity + normalTransportVelocity
-        avgZonalTransportVelocity = avgZonalTransportVelocity + zonalTransportVelocity
-        avgMeridionalTransportVelocity = avgMeridionalTransportVelocity + meridionalTransportVelocity
+        avgTransportVelocityZonal = avgTransportVelocityZonal + transportVelocityZonal
+        avgTransportVelocityMeridional = avgTransportVelocityMeridional + transportVelocityMeridional
         avgVertTransportVelocityTop = avgVertTransportVelocityTop + vertTransportVelocityTop
         avgNormalGMBolusVelocity = avgNormalGMBolusVelocity + normalGMBolusVelocity
-        avgZonalGMBolusVelocity = avgZonalGMBolusVelocity + zonalGMBolusVelocity
-        avgMeridionalGMBolusVelocity = avgMeridionalGMBolusVelocity + meridionalGMBolusVelocity
+        avgGMBolusVelocityZonal = avgGMBolusVelocityZonal + GMBolusVelocityZonal
+        avgGMBolusVelocityMeridional = avgGMBolusVelocityMeridional + GMBolusVelocityMeridional
         avgVertGMBolusVelocityTop = avgVertGMBolusVelocityTop + vertGMBolusVelocityTop
 
         nAverage = nAverage + 1
@@ -166,47 +166,47 @@ module ocn_time_average
 
         real (kind=RKIND), dimension(:), pointer :: avgSSH, varSSH
         real (kind=RKIND), dimension(:,:), pointer :: &
-           avgNormalVelocity, avgZonalVelocity, avgMeridionalVelocity, avgVertVelocityTop, &
-           varNormalVelocity, varZonalVelocity, varMeridionalVelocity, &
-           avgNormalTransportVelocity, avgZonalTransportVelocity, avgMeridionalTransportVelocity, avgVertTransportVelocityTop, &
-           avgNormalGMBolusVelocity, avgZonalGMBolusVelocity, avgMeridionalGMBolusVelocity, avgVertGMBolusVelocityTop
+           avgNormalVelocity, avgVelocityZonal, avgVelocityMeridional, avgVertVelocityTop, &
+           varNormalVelocity, varVelocityZonal, varVelocityMeridional, &
+           avgNormalTransportVelocity, avgTransportVelocityZonal, avgTransportVelocityMeridional, avgVertTransportVelocityTop, &
+           avgNormalGMBolusVelocity, avgGMBolusVelocityZonal, avgGMBolusVelocityMeridional, avgVertGMBolusVelocityTop
 
         call mpas_pool_get_array(averagePool, 'nAverage', nAverage)
-        call mpas_pool_get_array(averagePool, 'avgSsh', avgSSH)
-        call mpas_pool_get_array(averagePool, 'varSsh', varSSH)
+        call mpas_pool_get_array(averagePool, 'avgSSH', avgSSH)
+        call mpas_pool_get_array(averagePool, 'varSSH', varSSH)
         call mpas_pool_get_array(averagePool, 'avgNormalVelocity', avgNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalVelocity', avgZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalVelocity', avgMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'avgVelocityZonal', avgVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgVelocityMeridional', avgVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertVelocityTop', avgVertVelocityTop)
         call mpas_pool_get_array(averagePool, 'varNormalVelocity', varNormalVelocity)
-        call mpas_pool_get_array(averagePool, 'varZonalVelocity', varZonalVelocity)
-        call mpas_pool_get_array(averagePool, 'varMeridionalVelocity', varMeridionalVelocity)
+        call mpas_pool_get_array(averagePool, 'varVelocityZonal', varVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'varVelocityMeridional', varVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgNormalTransportVelocity', avgNormalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalTransportVelocity', avgZonalTransportVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalTransportVelocity', avgMeridionalTransportVelocity)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityZonal', avgTransportVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgTransportVelocityMeridional', avgTransportVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertTransportVelocityTop', avgVertTransportVelocityTop)
         call mpas_pool_get_array(averagePool, 'avgNormalGMBolusVelocity', avgNormalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgZonalGMBolusVelocity', avgZonalGMBolusVelocity)
-        call mpas_pool_get_array(averagePool, 'avgMeridionalGMBolusVelocity', avgMeridionalGMBolusVelocity)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityZonal', avgGMBolusVelocityZonal)
+        call mpas_pool_get_array(averagePool, 'avgGMBolusVelocityMeridional', avgGMBolusVelocityMeridional)
         call mpas_pool_get_array(averagePool, 'avgVertGMBolusVelocityTop', avgVertGMBolusVelocityTop)
 
         if(nAverage > 0) then
           avgSSH = avgSSH / nAverage
           varSSH = varSSH / nAverage
           avgNormalVelocity = avgNormalVelocity / nAverage
-          avgZonalVelocity = avgZonalVelocity / nAverage
-          avgMeridionalVelocity = avgMeridionalVelocity / nAverage
+          avgVelocityZonal = avgVelocityZonal / nAverage
+          avgVelocityMeridional = avgVelocityMeridional / nAverage
           avgVertVelocityTop = avgVertVelocityTop / nAverage
           varNormalVelocity = varNormalVelocity / nAverage
-          varZonalVelocity = varZonalVelocity / nAverage
-          varMeridionalVelocity = varMeridionalVelocity / nAverage
+          varVelocityZonal = varVelocityZonal / nAverage
+          varVelocityMeridional = varVelocityMeridional / nAverage
           avgNormalTransportVelocity = avgNormalTransportVelocity / nAverage
-          avgZonalTransportVelocity = avgZonalTransportVelocity / nAverage
-          avgMeridionalTransportVelocity = avgMeridionalTransportVelocity / nAverage
+          avgTransportVelocityZonal = avgTransportVelocityZonal / nAverage
+          avgTransportVelocityMeridional = avgTransportVelocityMeridional / nAverage
           avgVertTransportVelocityTop = avgVertTransportVelocityTop / nAverage
           avgNormalGMBolusVelocity = avgNormalGMBolusVelocity / nAverage
-          avgZonalGMBolusVelocity = avgZonalGMBolusVelocity / nAverage
-          avgMeridionalGMBolusVelocity = avgMeridionalGMBolusVelocity / nAverage
+          avgGMBolusVelocityZonal = avgGMBolusVelocityZonal / nAverage
+          avgGMBolusVelocityMeridional = avgGMBolusVelocityMeridional / nAverage
           avgVertGMBolusVelocityTop = avgVertGMBolusVelocityTop / nAverage
         end if
     end subroutine ocn_time_average_normalize!}}}

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -80,7 +80,7 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue, avgTracersSurfaceValue
         real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
         real (kind=RKIND), dimension(:,:), pointer :: gradSSHZonal, gradSSHMeridional
-        integer, pointer :: index_temperature, index_zonalSSH, index_meridionalSSH, nAccumulatedCoupled
+        integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled
 
         call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
@@ -92,8 +92,8 @@ module ocn_time_average_coupled
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
 
         call mpas_pool_get_dimension(forcingPool, 'index_temperatureSurfaceValue', index_temperature)
-        call mpas_pool_get_dimension(forcingPool, 'index_avgZonalSSHGradient', index_zonalSSH)
-        call mpas_pool_get_dimension(forcingPool, 'index_avgMeridionalSSHGradient', index_meridionalSSH)
+        call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_SSHzonal)
+        call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_SSHmeridional)
 
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
 
@@ -103,8 +103,8 @@ module ocn_time_average_coupled
 
         avgSurfaceVelocity(:,:)     = ( avgSurfaceVelocity(:,:)     * nAccumulatedCoupled + surfaceVelocity(:,:)     ) / ( nAccumulatedCoupled + 1 )
 
-        avgSSHGradient(index_zonalSSH,:)      = ( avgSSHGradient(index_zonalSSH,:)      * nAccumulatedCoupled + gradSSHZonal(1,:) ) / ( nAccumulatedCoupled + 1 )
-        avgSSHGradient(index_meridionalSSH,:) = ( avgSSHGradient(index_meridionalSSH,:) * nAccumulatedCoupled + gradSSHMeridional(1,:) ) / ( nAccumulatedCoupled + 1 )
+        avgSSHGradient(index_SSHzonal,:)      = ( avgSSHGradient(index_SSHzonal,:)      * nAccumulatedCoupled + gradSSHZonal(1,:) ) / ( nAccumulatedCoupled + 1 )
+        avgSSHGradient(index_SSHmeridional,:) = ( avgSSHGradient(index_SSHmeridional,:) * nAccumulatedCoupled + gradSSHMeridional(1,:) ) / ( nAccumulatedCoupled + 1 )
 
         nAccumulatedCoupled = nAccumulatedCoupled + 1
 


### PR DESCRIPTION
This moves X,Y,Z, Zonal, and Meridional to end of all variable names.

When using tools such as Paraview, variables are shown in alphabetical order. This allows different reconstructions of the same variable to show up next to each other in paraview lists.
