### PR TITLE
Fixing an issue when immutable streams have type='none'

### DIFF
--- a/src/registry/gen_inc.c
+++ b/src/registry/gen_inc.c
@@ -2180,7 +2180,7 @@ int generate_immutable_streams(ezxml_t registry){/*{{{*/
 
 	fortprintf(fd, "subroutine mpas%ssetup_immutable_streams(manager)\n\n", core_string);
 	fortprintf(fd, "   use MPAS_stream_manager, only : MPAS_streamManager_type, MPAS_STREAM_INPUT_OUTPUT, MPAS_STREAM_INPUT, &\n");
-	fortprintf(fd, "                                   MPAS_STREAM_OUTPUT, MPAS_STREAM_PROPERTY_IMMUTABLE, &\n");
+	fortprintf(fd, "                                   MPAS_STREAM_OUTPUT, MPAS_STREAM_NONE, MPAS_STREAM_PROPERTY_IMMUTABLE, &\n");
 	fortprintf(fd, "                                   MPAS_stream_mgr_create_stream, MPAS_stream_mgr_add_field, MPAS_stream_mgr_set_property\n\n");
 	fortprintf(fd, "   implicit none\n\n");
 	fortprintf(fd, "   type (MPAS_streamManager_type), pointer :: manager\n\n");


### PR DESCRIPTION
Previously the MPAS_STREAM_NONE integer was not used in the
setup_immutable_streams subroutine. This caused streams that were
immutable and had a type set to 'none' to not build.
