### PR TITLE
Adding a routine to add immutable streams to mutable streams

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -52,6 +52,7 @@ module mpas_stream_manager
               MPAS_stream_mgr_remove_pkg, &
               MPAS_stream_mgr_add_pool, &
               MPAS_stream_mgr_add_field, &
+              MPAS_stream_mgr_add_stream_fields, &
               MPAS_stream_mgr_remove_field, &
               MPAS_stream_mgr_add_alarm, &
               MPAS_stream_mgr_remove_alarm, &
@@ -755,6 +756,112 @@ module mpas_stream_manager
         end if
 
     end subroutine MPAS_stream_mgr_add_field!}}}
+
+
+    !-----------------------------------------------------------------------
+    !  routine MPAS_stream_mgr_add_stream_fields
+    !
+    !> \brief Add all fields from another stream to the specified stream in an MPAS stream manager.
+    !> \author Michael Duda, Doug Jacobsen
+    !> \date   5 November 2014
+    !> \details
+    !>  Adds all fields from another specified stream into the new specified stream.
+    !>  Both streams need to exist within the same stream manager.
+    !
+    !-----------------------------------------------------------------------
+    subroutine MPAS_stream_mgr_add_stream_fields(manager, streamID, refStreamID, ierr)!{{{
+
+        implicit none
+
+        character (len=*), parameter :: sub = 'MPAS_stream_mgr_add_stream_fields'
+
+        type (MPAS_streamManager_type), intent(inout) :: manager
+        character (len=*), intent(in) :: streamID
+        character (len=*), intent(in) :: refStreamID
+        integer, intent(out), optional :: ierr
+
+        type (MPAS_stream_list_type), pointer :: stream, refStream
+        type (mpas_pool_field_info_type) :: info
+        type (mpas_pool_iterator_type) :: itr
+        integer, pointer :: test_ptr
+        integer :: err_level
+        integer :: err_local
+
+
+        STREAM_DEBUG_WRITE('-- Called MPAS_stream_mgr_add_stream_fields()')
+
+        if (present(ierr)) ierr = MPAS_STREAM_MGR_NOERR
+
+        !
+        ! Check that reference stream exists
+        !
+        if (.not. MPAS_stream_list_query(manager % streams, refStreamID, refStream, ierr=err_local)) then
+            STREAM_ERROR_WRITE('Requested reference stream '//trim(refStreamID)//' does not exist in stream manager')
+            if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+            return
+        end if
+
+        !
+        ! Check that stream exists
+        !
+        if (.not. MPAS_stream_list_query(manager % streams, streamID, stream, ierr=err_local)) then
+            STREAM_ERROR_WRITE('Requested stream '//trim(streamID)//' does not exist in stream manager')
+            if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+            return
+        end if
+
+        !
+        ! Don't modify an immutable stream
+        !
+        if (stream % immutable) then
+            STREAM_ERROR_WRITE('Requested stream '//trim(streamID)//' is immutable.')
+            if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+            return
+        end if
+
+        !
+        ! Loop over all fields in refStream and add them one by one to stream
+        !
+        err_level = mpas_pool_get_error_level()
+        call mpas_pool_set_error_level(MPAS_POOL_SILENT)
+
+        call mpas_pool_begin_iteration(refStream % field_pool)
+        do while (mpas_pool_get_next_member(refStream % field_pool, itr))
+            if ( itr % memberType == MPAS_POOL_CONFIG ) then
+                if ( itr % dataType == MPAS_POOL_INTEGER ) then
+
+                    !
+                    ! Check that field exists
+                    !
+                    info % nDims = -1
+                    call mpas_pool_get_field_info(manager % allFields, itr % memberName, info)
+                    if (info % nDims == -1) then
+                        STREAM_ERROR_WRITE('Requested field '//trim(itr % memberName)//' not available')
+                        if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                        return
+                    end if
+
+                    ! Test that the field does not already exist in stream
+                    nullify(test_ptr)
+                    call mpas_pool_get_config(stream % field_pool, itr % memberName, value=test_ptr)
+
+                    if ( associated(test_ptr) ) then
+                        STREAM_ERROR_WRITE('Requested field '//trim(itr % memberName)//' already in stream '//trim(streamID))
+                        if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                    end if
+
+                    if ( info % isActive ) then
+                        call mpas_pool_add_config(stream % field_pool, itr % memberName, 1)
+                    else
+                        write(stderrUnit, *) ' * Requested field '//trim(itr % memberName)//' is deactivated due to packages, or is a scratch variable.'
+                    end if
+
+                end if
+            end if
+        end do
+        call mpas_pool_set_error_level(err_level)
+
+    end subroutine MPAS_stream_mgr_add_stream_fields!}}}
 
 
     !-----------------------------------------------------------------------
@@ -4543,6 +4650,40 @@ subroutine stream_mgr_add_field_c(manager_c, streamID_c, fieldName_c, ierr_c) bi
     end if
 
 end subroutine stream_mgr_add_field_c !}}}
+
+
+subroutine stream_mgr_add_stream_fields_c(manager_c, streamID_c, refStreamID_c, ierr_c) bind(c) !{{{
+
+    use mpas_c_interfacing, only : mpas_c_to_f_string
+    use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
+    use mpas_stream_manager, only : MPAS_streamManager_type, MPAS_STREAM_MGR_NOERR, MPAS_stream_mgr_add_stream_fields
+    use mpas_kind_types, only : StrKIND
+
+    implicit none
+
+    type (c_ptr) :: manager_c
+    character(kind=c_char) :: streamID_c(*)
+    character(kind=c_char) :: refStreamID_c(*)
+    integer(kind=c_int) :: ierr_c
+
+    type (MPAS_streamManager_type), pointer :: manager
+    character(len=StrKIND) :: streamID, refStreamID
+    integer :: ierr
+
+
+    call c_f_pointer(manager_c, manager)
+    call mpas_c_to_f_string(streamID_c, streamID)
+    call mpas_c_to_f_string(refStreamID_c, refStreamID)
+
+    call MPAS_stream_mgr_add_stream_fields(manager, streamID, refStreamID, ierr)
+
+    if (ierr == MPAS_STREAM_MGR_NOERR) then
+        ierr_c = 0
+    else
+        ierr_c = 1
+    end if
+
+end subroutine stream_mgr_add_stream_fields_c !}}}
 
 
 subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_c, alarmInterval_c, ierr_c) bind(c) !{{{

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -27,6 +27,7 @@
  */
 void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, char *, int *, int *, int *, int *);
 void mpas_stream_mgr_add_field_c(void *, const char *, const char *, int *);
+void mpas_stream_mgr_add_stream_fields_c(void *, const char *, const char *, int *);
 void mpas_stream_mgr_add_pool_c(void *, const char *, const char *, int *);
 void stream_mgr_add_alarm_c(void *, const char *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pkg_c(void *, const char *, const char *, int *);
@@ -1380,6 +1381,16 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		for (substream_xml = ezxml_child(stream_xml, "stream"); substream_xml; substream_xml = ezxml_next(substream_xml)) {
 			streamname_const = ezxml_attr(substream_xml, "name");
+
+			// Immutable streams are added through the add_stream_fields function.
+			// This is because they aren't defined in the XML file, and are instead defined in Regsitry.xml
+			for(streammatch_xml = ezxml_child(streams, "immutable_stream"); streammatch_xml; streammatch_xml = ezxml_next(streammatch_xml)) {
+				compstreamname_const = ezxml_attr(streammatch_xml, "name");
+
+				if (strcmp(streamname_const, compstreamname_const) == 0) {
+					stream_mgr_add_stream_fields_c(manager, streamID, streamname_const, &err);
+				}
+			}
 
 			for(streammatch_xml = ezxml_child(streams, "stream"); streammatch_xml; streammatch_xml = ezxml_next(streammatch_xml)) {
 				compstreamname_const = ezxml_attr(streammatch_xml, "name");


### PR DESCRIPTION
This allows an immutable stream to be added to a mutable stream.
Previously if an immutable stream was added to a mutable stream, it was
simply ignored.

This adds a routine that allows a stream to be added to another stream by iterating over all fields add to the reference stream.
