### PR TITLE
Add C++ Makefile support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ bluegene:
 	"CXX_PARALLEL = mpixlcxx_r" \
 	"FC_SERIAL = bgxlf95_r" \
 	"CC_SERIAL = bgxlc_r" \
-	"CXX_SERIAL = bgxlcxx_r" \
+	"CXX_SERIAL = bgxlc++_r" \
 	"FFLAGS_OPT = -O2 -g -qrealsize=8" \
 	"CFLAGS_OPT = -O2 -g" \
 	"CXXFLAGS_OPT = -O2 -g" \


### PR DESCRIPTION
Adding C++ compiler support in the root Makefile.  I've added CXX_PARALLEL, CXX_SERIAL, CXXFLAGS_DEBUG, and CXXFLAGS_OPT variables for each target.  These flags are applied later in the Makefile and are then available to subsequent Makefiles in a standard way.  I've only tested the "gfortran" target, but made educated guesses for the other targets.

This pull request also removes a target that is no longer needed and adds a new target.
