### PR TITLE
Modify the computation of meshScalingDel2 and meshScalingDel4

### DIFF
--- a/src/core_atmosphere/mpas_atm_mpas_core.F
+++ b/src/core_atmosphere/mpas_atm_mpas_core.F
@@ -671,8 +671,8 @@ module mpas_core
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            meshScalingDel2(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**0.5
-            meshScalingDel4(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)
+            meshScalingDel2(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**0.25
+            meshScalingDel4(iEdge) = 1.0 / ( (meshDensity(cell1) + meshDensity(cell2) )/2.0)**0.75
          end do
       end if
 


### PR DESCRIPTION
These fields are now inversely proportional to the 0.25 and 0.75 powers of meshDensity, rather than the 0.5 and 1.0 powers, respectively.
