### PR TITLE
Fix uninitialized pointer bug.

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -387,18 +387,32 @@ module ocn_time_integration_rk4
            call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
            call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
 
-           ! advection of u uses u, while advection of layerThickness and tracers use uTransport.
-           call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-              layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
-              sshCur, highFreqThicknessProvis, rk_substep_weights(rk_step), &
-              vertTransportVelocityTop, err)
+           ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
+           if (associated(highFreqThicknessProvis)) then
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
+                 sshCur, rk_substep_weights(rk_step), &
+                 vertTransportVelocityTop, err, highFreqThicknessProvis)
+           else
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
+                 sshCur, rk_substep_weights(rk_step), &
+                 vertTransportVelocityTop, err)
+           endif
 
            call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1)
 
-           call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-              layerThicknessCur, layerThicknessEdge, uTransport, &
-              sshCur, highFreqThicknessProvis, rk_substep_weights(rk_step), &
-              vertTransportVelocityTop, err)
+           if (associated(highFreqThicknessProvis)) then
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur, layerThicknessEdge, uTransport, &
+                 sshCur, rk_substep_weights(rk_step), &
+                 vertTransportVelocityTop, err, highFreqThicknessProvis)
+           else
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur, layerThicknessEdge, uTransport, &
+                 sshCur, rk_substep_weights(rk_step), &
+                 vertTransportVelocityTop, err)
+           endif
 
            call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -406,9 +406,15 @@ module ocn_time_integration_split
 
            ! compute vertTransportVelocityTop.  Use u (rather than uTransport) for momentum advection.
            ! Use the most recent time level available.
-           call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-              layerThicknessCur, layerThicknessEdge, normalVelocityCur, &
-              sshCur, highFreqThicknessNew, dt, vertTransportVelocityTop, err)
+           if (associated(highFreqThicknessNew)) then
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur, layerThicknessEdge, normalVelocityCur, &
+                 sshCur, dt, vertTransportVelocityTop, err, highFreqThicknessNew)
+            else
+               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                  layerThicknessCur, layerThicknessEdge, normalVelocityCur, &
+                  sshCur, dt, vertTransportVelocityTop, err)
+            endif
 
             call ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, stage1_tend_time)
 
@@ -1158,9 +1164,15 @@ module ocn_time_integration_split
             ! compute vertTransportVelocityTop.  Use uTransport for advection of layerThickness and tracers.
             ! Use time level 1 values of layerThickness and layerThicknessEdge because 
             ! layerThickness has not yet been computed for time level 2.
-            call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-               layerThicknessCur, layerThicknessEdge, uTransport, &
-               sshCur, highFreqThicknessNew, dt, vertTransportVelocityTop, err)
+           if (associated(highFreqThicknessNew)) then
+              call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur, layerThicknessEdge, uTransport, &
+                 sshCur, dt, vertTransportVelocityTop, err, highFreqThicknessNew)
+            else
+               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+                 layerThicknessCur, layerThicknessEdge, uTransport, &
+                 sshCur, dt, vertTransportVelocityTop, err)
+            endif
 
             call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -574,7 +574,7 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdge, &
-     normalVelocity, oldSSH, newHighFreqThickness, dt, vertTransportVelocityTop, err)!{{{
+     normalVelocity, oldSSH, dt, vertTransportVelocityTop, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -600,7 +600,7 @@ contains
       real (kind=RKIND), dimension(:), intent(in) :: &
          oldSSH     !< Input: sea surface height at old time
 
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
          newHighFreqThickness   !< Input: high frequency thickness.  Alters ALE thickness.
 
       real (kind=RKIND), intent(in) :: &
@@ -684,7 +684,11 @@ contains
       !
       ! Compute desired thickness at new time
       !
-      call ocn_ALE_thickness(meshPool, verticalMeshPool, oldSSH, div_hu_btr, newHighFreqThickness, dt, ALE_thickness, err)
+      if (present(newHighFreqThickness)) then
+        call ocn_ALE_thickness(meshPool, verticalMeshPool, oldSSH, div_hu_btr, dt, ALE_thickness, err, newHighFreqThickness)
+      else
+        call ocn_ALE_thickness(meshPool, verticalMeshPool, oldSSH, div_hu_btr, dt, ALE_thickness, err)
+      endif
 
       !
       ! Vertical transport through layer interfaces

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -70,7 +70,7 @@ contains
 !>  (z-tilde), and imposes a minimum layer thickness.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_ALE_thickness(meshPool, verticalMeshPool, oldSSH, div_hu_btr, newHighFreqThickness, dt, ALE_thickness, err)!{{{
+   subroutine ocn_ALE_thickness(meshPool, verticalMeshPool, oldSSH, div_hu_btr, dt, ALE_thickness, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -88,7 +88,7 @@ contains
          oldSSH,   &!< Input: sea surface height at old time
          div_hu_btr !< Input: thickness-weighted barotropic divergence
 
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
          newHighFreqThickness   !< Input: high frequency thickness.  Alters ALE thickness.
 
       real (kind=RKIND), intent(in) :: &


### PR DESCRIPTION
Before, highFreqThicknessNew would be passed into
ocn_vert_transport_velocity_top even when it was an
unitialized pointer.  Change highFreqThicknessNew to be
an optional variable.  Otherwise, the pgi compiler always
errors out on this line in debug mode.
