### PR TITLE
Fixing an issue related to duplicating var_arrays

### DIFF
--- a/src/framework/duplicate_field_array.inc
+++ b/src/framework/duplicate_field_array.inc
@@ -37,6 +37,10 @@
             dst_cursor % block => src_cursor % block
             dst_cursor % fieldName = src_cursor % fieldName
             dst_cursor % isVarArray = src_cursor % isVarArray
+            if ( associated( src_cursor % constituentNames ) ) then
+               allocate(dst_cursor % constituentNames(size(src_cursor % constituentNames, dim=1)))
+               dst_cursor % constituentNames(:) = src_cursor % constituentNames(:)
+            end if
             dst_cursor % isPersistent = src_cursor % isPersistent
             dst_cursor % isActive = src_cursor % isActive
             dst_cursor % hasTimeDimension = src_cursor % hasTimeDimension


### PR DESCRIPTION
When duplicating a field, if that field is a var_array, previously the
constituentNames attribute was not copied over properly, causing an
issue when trying to write out the var_array, or manipulate it in other
framework routines like a var_array. Sometimes this would cause a
segfault, because constituentNames was not allocated on the duplicate
var_array.
