### PR TITLE
Allow build-time streams to contain non-unique filename_templates

### DIFF
--- a/src/registry/parse.c
+++ b/src/registry/parse.c
@@ -90,7 +90,7 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 	const char *varname_in_code, *varname_in_stream;
 	const char *const_model, *const_core, *const_version;
 	const char *streamname, *streamtype, *streamfilename, *streamrecords, *streaminterval_in, *streaminterval_out, *streampackages;
-	const char *streamname2, *streamfilename2;
+	const char *streamname2, *streamtype2, *streamfilename2;
 	const char *time_levs;
 
 	char *string, *err_string;
@@ -595,17 +595,21 @@ done_searching:
 		for (stream_xml = ezxml_child(streams_xml, "stream"); stream_xml; stream_xml = stream_xml->next) {
 			streamname = ezxml_attr(stream_xml, "name");
 			streamfilename = ezxml_attr(stream_xml, "filename_template");
+			streamtype = ezxml_attr(stream_xml, "type");
 			
 			/* Check that this stream's filename template is unique among all streams */
 			for (streams_xml2 = ezxml_child(registry, "streams"); streams_xml2; streams_xml2 = streams_xml2->next) {
 				for (stream_xml2 = ezxml_child(streams_xml2, "stream"); stream_xml2; stream_xml2 = stream_xml2->next) {
 					streamname2 = ezxml_attr(stream_xml2, "name");
 					streamfilename2 = ezxml_attr(stream_xml2, "filename_template");
+					streamtype2 = ezxml_attr(stream_xml, "type");
 
 					if (stream_xml != stream_xml2) {
 						if (strcmp(streamfilename, streamfilename2) == 0) {
-							fprintf(stderr, "ERROR: Streams %s and %s have a conflicting filename template of %s.\n", streamname, streamname2, streamfilename);
-							return 1;
+							if ( strstr(streamtype, "output") != NULL || strstr(streamtype2, "output") != NULL ) {
+								fprintf(stderr, "ERROR: Streams %s and %s have a conflicting filename template of %s and one or more has a type that contains output.\n", streamname, streamname2, streamfilename);
+								return 1;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This commit allows streams defined within Registry that are parsed at
build time to contain non-unique filename_template attributes as long as
neither stream contains the type "output".
