### PR TITLE
Changing the loop to get CLI arguments

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -88,7 +88,8 @@ module mpas_subdriver
       streamsFile = domain % streams_filename
 
       nArgs = command_argument_count()
-      do iArg = 1, nArgs
+      iArg = 1
+      do while (iArg < nArgs)
          call get_command_argument(iArg, argument)
          if (len_trim(argument) == 0) exit
 


### PR DESCRIPTION
In fortran, loop indices cannot be modified within the a do loop. This
commit changes the loop from a "do iArg = 1, nArgs" loop to a "do while"
loop, to allow the iArg index to be modified within the loop.
