### PR TITLE
make interface and functionality of linear EOS to be identical to JM EOS

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -127,8 +127,8 @@ contains
 
       if (linearEos) then
 
-         call ocn_equation_of_state_linear_density(meshPool, indexT, indexS, tracers, density, err, &
-            thermalExpansionCoeff, salineContractionCoeff)
+         call ocn_equation_of_state_linear_density(meshPool, k_displaced, displacement_type, indexT, indexS, tracers, density, err, &
+            tracersSurfaceValue, thermalExpansionCoeff, salineContractionCoeff)
 
       elseif (jmEos) then
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -20,8 +20,11 @@
 
 module ocn_equation_of_state_linear
 
+   use mpas_kind_types
    use mpas_grid_types
    use ocn_constants
+   use mpas_dmpar
+   use mpas_io_units
 
    implicit none
    private
@@ -71,51 +74,109 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_linear_density(meshPool, indexT, indexS, tracers, density, err, &
-      thermalExpansionCoeff, salineContractionCoeff)!{{{
+   subroutine ocn_equation_of_state_linear_density(meshPool, k_displaced, displacement_type, indexT, indexS, tracers, density, err, &
+      tracersSurfaceLayerValue, thermalExpansionCoeff, salineContractionCoeff)!{{{
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !  This module contains routines necessary for computing the density
    !  from model temperature and salinity using an equation of state.
    !
    ! Input: mesh - mesh metadata
    !        s - state: tracers
-   !        k_displaced 
-   !  If k_displaced<=0, state % density is returned with no displaced
-   !  If k_displaced>0,the state % densityDisplaced is returned, and is for
-   !  a parcel adiabatically displaced from its original level to level 
-   !  k_displaced.  This does not effect the linear EOS.
    !
    ! Output: s - state: computed density
+   !
+   !
+   !>  While somewhat unnecessary, we make the interface and capability
+   !>  of linear eos to be identical to nonlinear eos
+   !>
+   !>  Density can be computed in-situ using k_displaced=0 and
+   !>      displacement_type = 'relative'.
+   !>
+   !>  Potential density (referenced to top layer) can be computed
+   !>      using k_displaced=1 and displacement_type = 'absolute'.
+   !>
+   !>  The density of SST/SSS after adiabatic displacement to each layer
+   !>      can be computed using displacement_type = 'surfaceDisplaced'.
+   !>
+   !>  When using displacement_type = 'surfaceDisplaced', k_displaced is
+   !>      ignored and tracersSurfaceLayerValue must be present.
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       implicit none
 
       type (mpas_pool_type), intent(in) :: meshPool
-      integer, intent(in) :: indexT, indexS
+      character(len=*), intent(in) :: displacement_type
+      integer, intent(in) :: k_displaced, indexT, indexS
       real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers
       real (kind=RKIND), dimension(:,:), intent(inout) :: density
       integer, intent(out) :: err
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: tracersSurfaceLayerValue
       real (kind=RKIND), dimension(:,:), intent(out), optional :: &
          thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign)
          salineContractionCoeff   ! Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$
 
       integer, dimension(:), pointer :: maxLevelCell
-      integer :: iCell, k
-      integer, pointer :: nCells
+      integer :: iCell, k, k_displaced_local, k_ref
+      integer, pointer :: nCells, nVertLevels
+      character(len=60) :: displacement_type_local
       type (dm_info) :: dminfo
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       err = 0
 
-      do iCell = 1, nCells
-         do k = 1, maxLevelCell(iCell)
-            ! Linear equation of state
-            density(k,iCell) =  config_eos_linear_densityref &
-                  - config_eos_linear_alpha * (tracers(indexT,k,iCell) - config_eos_linear_Tref) &
-                  + config_eos_linear_beta  * (tracers(indexS,k,iCell) - config_eos_linear_Sref)
+      ! copy some intent(in) into local work space
+      displacement_type_local = trim(displacement_type)
+      k_displaced_local = k_displaced
+
+      ! test of request to address out of bounds
+      if (displacement_type_local == 'absolute' .and.   &
+         (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+         write (stderrUnit,*) 'Abort: In equation_of_state_jm', &
+             ' k_displaced must be between 1 and nVertLevels for ', &
+             'displacement_type = absolute'
+         call mpas_dmpar_abort(dminfo)
+      endif
+
+      ! if surfaceDisplaced, then compute density at all levels based on surface values
+      if (displacement_type_local == 'surfaceDisplaced') then
+         do iCell = 1, nCells
+            do k = 1, maxLevelCell(iCell)
+               ! Linear equation of state
+               density(k,iCell) =  config_eos_linear_densityref &
+                     - config_eos_linear_alpha * (tracersSurfaceLayerValue(indexT,iCell) - config_eos_linear_Tref) &
+                     + config_eos_linear_beta  * (tracersSurfaceLayerValue(indexS,iCell) - config_eos_linear_Sref)
+            end do
          end do
-      end do
+      endif
+
+
+      ! if absolute, then compute density at all levels based on k_displaced value
+      if (displacement_type_local == 'absolute') then
+         do iCell = 1, nCells
+            do k = 1, maxLevelCell(iCell)
+               ! Linear equation of state
+               density(k,iCell) =  config_eos_linear_densityref &
+                     - config_eos_linear_alpha * (tracers(indexT,k_displaced_local,iCell) - config_eos_linear_Tref) &
+                     + config_eos_linear_beta  * (tracers(indexS,k_displaced_local,iCell) - config_eos_linear_Sref)
+            end do
+         end do
+      endif
+
+      ! if relative, then compute density at all levels based on k+k_displaced value
+      if (displacement_type_local == 'relative') then
+         do iCell = 1, nCells
+            do k = 1, maxLevelCell(iCell)
+               k_ref = min(k + k_displaced_local, nVertLevels)
+               k_ref = max(k_ref, 1)
+               ! Linear equation of state
+               density(k,iCell) =  config_eos_linear_densityref &
+                     - config_eos_linear_alpha * (tracers(indexT,k_ref,iCell) - config_eos_linear_Tref) &
+                     + config_eos_linear_beta  * (tracers(indexS,k_ref,iCell) - config_eos_linear_Sref)
+            end do
+         end do
+      endif
 
       if (present(thermalExpansionCoeff)) then
          do iCell = 1, nCells


### PR DESCRIPTION
the change allows for the computation of "surfaceDisplaced" density that
is necessary for the the computation of bulkRichardson number needed
by KPP.

added "absolute" and "relative" displacements as well, just to insure
that the action of linear EOS is consistent with JM EOS.
