### PR TITLE
Move write of stream and namelist filenames

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -61,6 +61,7 @@ module mpas_subdriver
       type (MPAS_Time_type) :: ref_time
       type (MPAS_TimeInterval_type) :: filename_interval
       character(len=StrKIND) :: start_timestamp
+      logical :: streamsExists
 
 
       interface
@@ -130,7 +131,12 @@ module mpas_subdriver
       call mpas_core_setup_packages(domain_ptr % configs, domain_ptr % packages, ierr)
       call mpas_core_setup_clock(domain_ptr % clock, domain_ptr % configs, ierr)
 
-      write(stderrUnit,*) 'Reading streams configuration from file: ', trim(domain % streams_filename)
+      write(stderrUnit,*) 'Reading streams configuration from file '//trim(domain % streams_filename)
+      inquire(file=trim(domain % streams_filename), exist=streamsExists)
+
+      if ( .not. streamsExists ) then
+         call mpas_dmpar_global_abort('ERROR: Streams file '//trim(domain % streams_filename)//' does not exist.')
+      end if
 
       call mpas_timer_start('total time')
       call mpas_timer_start('initialize')

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -55,6 +55,7 @@ module mpas_framework
       integer, intent(in), optional :: stdoutUnit_in, stderrUnit_in
 
       character(len=StrKIND), pointer :: config_calendar_type
+      logical :: nmlExists
       integer, pointer :: config_pio_num_iotasks, config_pio_stride
       integer :: pio_num_iotasks
       integer :: pio_stride
@@ -71,10 +72,20 @@ module mpas_framework
       call mpas_allocate_domain(domain, dminfo)
 
       if (.not. present(nml_filename)) then
-         write(stderrUnit,*) 'Reading namelist from file: ', trim(domain % namelist_filename)
+         write(stderrUnit,*) 'Reading namelist from file '//trim(domain % namelist_filename)
+         inquire(file=trim(domain % namelist_filename), exist=nmlExists)
+
+         if ( .not. nmlExists ) then
+            call mpas_dmpar_global_abort('ERROR: Namelist file '//trim(domain % namelist_filename)//' does not exist.')
+         end if
          call mpas_setup_namelists(domain % configs, domain % namelist_filename, domain % dminfo)
       else
-         write(stderrUnit,*) 'Reading namelist from file: ', trim(nml_filename)
+         write(stderrUnit,*) 'Reading namelist from file '//trim(nml_filename)
+         inquire(file=nml_filename, exist=nmlExists)
+
+         if ( .not. nmlExists ) then
+            call mpas_dmpar_global_abort('ERROR: Namelist file '//trim(nml_filename)//' does not exist.')
+         end if
          call mpas_setup_namelists(domain % configs, nml_filename, domain % dminfo)
       end if
 


### PR DESCRIPTION
This commit moves the write of which stream and namelist files are read
(based on command line arguments) to right before they are actually
read. This allows these messages to be written to the relevant log files
and not be printed multiple times to the prompt.
