### PR TITLE
Fix bug in geostrophic rebalancing in test case initialization.

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -348,6 +348,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(nVertLevels) :: flux_zonal
       real (kind=RKIND), dimension(nVertLevels + 1, nlat) :: zgrid_2d
       real (kind=RKIND), dimension(nVertLevels, nlat) :: u_2d, pp_2d, rho_2d, qv_2d, etavs_2d, zz_2d
+      real (kind=RKIND), dimension(nVertLevels, nlat) :: p_2d, pb_2d, ppb_2d, rr_2d, rb_2d, tb_2d, rtb_2d
       real (kind=RKIND), dimension(nVertLevels, nlat-1) :: zx_2d 
       real (kind=RKIND), dimension(nlat) :: lat_2d
       real (kind=RKIND) :: dlat, hx_1d
@@ -637,35 +638,35 @@ module init_atm_cases
                          + ah(k) * sh(k)* zt	
         end do
         do k=1,nz1
-          zz_2d (k,i) = (zw(k+1)-zw(k))/(zgrid_2d(k+1,i)-zgrid_2d(k,i))
+          zz_2d(k,i) = (zw(k+1)-zw(k))/(zgrid_2d(k+1,i)-zgrid_2d(k,i))
         end do
 
         do k=1,nz1
           ztemp    = .5*(zgrid_2d(k+1,i)+zgrid_2d(k,i))
-          ppb(k,i) = p0*exp(-gravity*ztemp/(rgas*t0b)) 
-          pb (k,i) = (ppb(k,i)/p0)**(rgas/cp)
-          rb (k,i) = ppb(k,i)/(rgas*t0b*zz_2d(k,i))
-          tb (k,i) = t0b/pb(k,i)
-          rtb(k,i) = rb(k,i)*tb(k,i)
-          p  (k,i) = pb(k,i)
-          pp (k,i) = 0.
-          rr (k,i) = 0.
+          ppb_2d(k,i) = p0*exp(-gravity*ztemp/(rgas*t0b)) 
+          pb_2d(k,i) = (ppb_2d(k,i)/p0)**(rgas/cp)
+          rb_2d(k,i) = ppb_2d(k,i)/(rgas*t0b*zz_2d(k,i))
+          tb_2d(k,i) = t0b/pb_2d(k,i)
+          rtb_2d(k,i) = rb_2d(k,i)*tb_2d(k,i)
+          p_2d(k,i) = pb_2d(k,i)
+          pp_2d(k,i) = 0.0
+          rr_2d(k,i) = 0.0
         end do
 
 
         do itr = 1,10
 
           do k=1,nz1
-            eta (k) = (ppb(k,i)+pp(k,i))/p0
+            eta (k) = (ppb_2d(k,i)+pp_2d(k,i))/p0
             etav(k) = (eta(k)-.252)*pii/2.
-            if(eta(k).ge.znut)  then
+            if(eta(k) >= znut)  then
               teta(k) = t0*eta(k)**(rgas*dtdz/gravity)
             else
               teta(k) = t0*eta(k)**(rgas*dtdz/gravity) + delta_t*(znut-eta(k))**5
             end if
           end do
 
-          phi = lat_2d (i)
+          phi = lat_2d(i)
           do k=1,nz1
             temperature_1d(k) = teta(k)+.75*eta(k)*pii*u0/rgas*sin(etav(k))      &
                             *sqrt(cos(etav(k)))*                   &
@@ -677,7 +678,7 @@ module init_atm_cases
 
 
             ztemp   = .5*(zgrid_2d(k,i)+zgrid_2d(k+1,i))
-            ptemp   = ppb(k,i) + pp(k,i)
+            ptemp   = ppb_2d(k,i) + pp_2d(k,i)
 
             !get moisture 
             if (moisture) then
@@ -689,27 +690,23 @@ module init_atm_cases
 
           do itrp = 1,25
             do k=1,nz1				
-              rr(k,i)  = (pp(k,i)/(rgas*zz_2d(k,i)) - rb(k,i)*(tt(k)-t0b))/tt(k)
+              rr_2d(k,i)  = (pp_2d(k,i)/(rgas*zz_2d(k,i)) - rb_2d(k,i)*(tt(k)-t0b))/tt(k)
             end do
 
             ppi(1) = p0-.5*dzw(1)*gravity                            &
-                          *(1.25*(rr(1,i)+rb(1,i))*(1.+qv_2d(1,i))   &
-                            -.25*(rr(2,i)+rb(2,i))*(1.+qv_2d(2,i)))
+                          *(1.25*(rr_2d(1,i)+rb_2d(1,i))*(1.+qv_2d(1,i))   &
+                            -.25*(rr_2d(2,i)+rb_2d(2,i))*(1.+qv_2d(2,i)))
 
-            ppi(1) = ppi(1)-ppb(1,i)
+            ppi(1) = ppi(1)-ppb_2d(1,i)
             do k=1,nz1-1
 
-!              ppi(k+1) = ppi(k)-.5*dzu(k+1)*gravity*                        &
-!                            (rr(k  ,i)+(rr(k  ,i)+rb(k  ,i))*qv_2d(k  ,i)   &
-!                            +rr(k+1,i)+(rr(k+1,i)+rb(k+1,i))*qv_2d(k+1,i))
-
               ppi(k+1) = ppi(k)-dzu(k+1)*gravity*                                       &
-                            ( (rr(k  ,i)+(rr(k  ,i)+rb(k  ,i))*qv_2d(k  ,i))*fzp(k+1)   &
-                            + (rr(k+1,i)+(rr(k+1,i)+rb(k+1,i))*qv_2d(k+1,i))*fzm(k+1) )
+                            ( (rr_2d(k  ,i)+(rr_2d(k  ,i)+rb_2d(k  ,i))*qv_2d(k  ,i))*fzp(k+1)   &
+                            + (rr_2d(k+1,i)+(rr_2d(k+1,i)+rb_2d(k+1,i))*qv_2d(k+1,i))*fzm(k+1) )
             end do
 
             do k=1,nz1
-              pp(k,i) = .2*ppi(k)+.8*pp(k,i)
+              pp_2d(k,i) = .2*ppi(k)+.8*pp_2d(k,i)
             end do
 
           end do  ! end inner iteration loop itrp
@@ -717,9 +714,8 @@ module init_atm_cases
         end do  ! end outer iteration loop itr
 
         do k=1,nz1
-          rho_2d(k,i) = rr(k,i)+rb(k,i)
-          pp_2d(k,i) = pp(k,i)
-          etavs_2d(k,i) = ((ppb(k,i)+pp(k,i))/p0 - 0.252)*pii/2.
+          rho_2d(k,i) = rr_2d(k,i)+rb_2d(k,i)
+          etavs_2d(k,i) = ((ppb_2d(k,i)+pp_2d(k,i))/p0 - 0.252)*pii/2.
           u_2d(k,i) = u0*(sin(2.*lat_2d(i))**2) *(cos(etavs_2d(k,i))**1.5)
         end do
 


### PR DESCRIPTION
Several arrays dimensioned by nCells were being used to store values in
a pole-to-pole cross-section with 721 (nlat) points; this causes out-of-bounds
array references when each MPI task owns fewer than 721 (nlat) grid columns.
