### PR TITLE
Moving the write for the restart timestamp

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
@@ -672,15 +672,16 @@ module mpas_core
          call mpas_stream_mgr_reset_alarms(stream_manager, streamID='output', ierr=ierr)
          call mpas_timer_stop('reset_io_alarms')
 
+         call mpas_timer_start('io_write', .false.)
+         call mpas_stream_mgr_write(stream_manager, streamID='restart', ierr=ierr)
+         call mpas_timer_stop('io_write')
+
          if ( mpas_stream_mgr_ringing_alarms(stream_manager, streamID='restart', direction=MPAS_STREAM_OUTPUT, ierr=ierr) ) then
             open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
             write(22, *) trim(timeStamp)
             close(22)
          end if
 
-         call mpas_timer_start('io_write', .false.)
-         call mpas_stream_mgr_write(stream_manager, streamID='restart', ierr=ierr)
-         call mpas_timer_stop('io_write')
          call mpas_timer_start('reset_io_alarms', .false.)
          call mpas_stream_mgr_reset_alarms(stream_manager, streamID='restart', ierr=ierr)
          call mpas_timer_stop('reset_io_alarms')


### PR DESCRIPTION
Previously, the restart timestamp file was written before writting the
actually restart file. If the run died while writing the restart file,
the restart timestamp file would not be incompatible with the run, as it
pointed to a non-existent time.

This merge introduces a fix that moves the write of the timestamp after
the write of the restart file.
