### PR TITLE
Simplify analysis member template.

### DIFF
--- a/src/core_ocean/analysis_members/Registry_TEMPLATE.xml
+++ b/src/core_ocean/analysis_members/Registry_TEMPLATE.xml
@@ -13,14 +13,14 @@
 		/>
 	</nml_record>
 	<packages>
-		<package name="amTemplate" description="This package includes variables required for the amTemplate analysis member."/>
+		<package name="am_TEMPLATE" description="This package includes variables required for the am_TEMPLATE analysis member."/>
 	</packages>
 	<streams>
-		<stream name="TemplateOutput" type="output"
+		<stream name="TEMPLATEOutput" type="output"
 				filename_template="analysis_members/template.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"
-				packages="amTemplate"
+				packages="am_TEMPLATE"
 				clobber_mode="truncate"
 				runtime_format="single_file">
 			<var name="xtime"/> 
@@ -28,7 +28,7 @@
 			<var name="example_variable2"/> 
 		</stream>
 	</streams>
-	<var_struct name="amTemplate" time_levs="1" packages="amTemplate">
+	<var_struct name="am_TEMPLATE" time_levs="1" packages="am_TEMPLATE">
 		<var name="example_variable1" type="real" dimensions="nVertLevels nCells Time" units="UNITS HERE"
 			description="DESCRIPTION HERE"
 		/>

--- a/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
@@ -20,9 +20,8 @@
 !>     cp Registry_ocn_TEMPLATE.xml Registry_ocn_your_new_name.xml
 !>  
 !>  2. In those two new files, replace the following text:
-!>     TEMPLATE, amTemplate, FILL_IN_AUTHOR, FILL_IN_DATE
-!>     Note TEMPLATE uses underscores, like global_stats, while
-!>     amTemplate uses caps, e.g. amGlobalStats.
+!>     TEMPLATE, FILL_IN_AUTHOR, FILL_IN_DATE
+!>     Typically TEMPLATE uses underscores, like your_new_name
 !>  
 !>  3. Add a #include line for your registry to
 !>     Registry_analysis_members.xml
@@ -76,7 +75,7 @@ module ocn_TEMPLATE
    !
    !--------------------------------------------------------------------
 
-   type (timer_node), pointer :: amTemplateTimer
+   type (timer_node), pointer :: am_TEMPLATETimer
 
 !***********************************************************************
 
@@ -126,14 +125,14 @@ contains
       ! local variables
       !
       !-----------------------------------------------------------------
-      logical, pointer :: amTemplateActive
+      logical, pointer :: am_TEMPLATEActive
 
       err = 0
 
-      call mpas_pool_get_package(packagePool, 'amTemplateActive', amTemplateActive)
+      call mpas_pool_get_package(packagePool, 'am_TEMPLATEActive', am_TEMPLATEActive)
 
       ! turn on package for this analysis member
-      amTemplateActive = .true.
+      am_TEMPLATEActive = .true.
 
    end subroutine ocn_setup_packages_TEMPLATE!}}}
 
@@ -232,14 +231,14 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), pointer :: amTemplatePool
+      type (mpas_pool_type), pointer :: am_TEMPLATEPool
       type (dm_info) :: dminfo
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: diagnosticsPool
-      type (mpas_pool_type), pointer :: amTemplate
+      type (mpas_pool_type), pointer :: am_TEMPLATE
 
       ! Here are some example variables which may be needed for your analysis member
       integer, pointer :: nVertLevels, nCellsSolve, nEdgesSolve, nVerticesSolve, num_tracers
@@ -252,7 +251,7 @@ contains
 
       dminfo = domain % dminfo
 
-      call mpas_timer_start("compute_TEMPLATE", .false., amTemplateTimer)
+      call mpas_timer_start("compute_TEMPLATE", .false., am_TEMPLATETimer)
 
       block => domain % blocklist
       do while (associated(block))
@@ -260,7 +259,7 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_subpool(block % structs, 'amTemplate', amTemplatePool)
+         call mpas_pool_get_subpool(block % structs, 'am_TEMPLATE', am_TEMPLATEPool)
 
          ! Here are some example variables which may be needed for your analysis member
          call mpas_pool_get_dimension(statePool, 'num_tracers', num_tracers)
@@ -302,14 +301,14 @@ contains
       ! correct values for writing output.
       block => domain % blocklist
       do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'amTemplate', amTemplatePool)
+         call mpas_pool_get_subpool(block % structs, 'am_TEMPLATE', am_TEMPLATEPool)
 
-         ! assignment of final amTemplate variables could occur here.
+         ! assignment of final am_TEMPLATE variables could occur here.
 
          block => block % next
       end do
 
-      call mpas_timer_stop("TEMPLATE", amTemplateTimer)
+      call mpas_timer_stop("TEMPLATE", am_TEMPLATETimer)
 
    end subroutine ocn_compute_TEMPLATE!}}}
 


### PR DESCRIPTION
Before I had two text strings to replace, TEMPLATE and Template.
Simplify to one for easier creation of a new analysis member.
