### PR TITLE
Remove tracer1.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -798,6 +798,10 @@
 					description="Disables tendencies on the tracer fields from CVMix/KPP nonlocal fluxes."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_use_tracer1" type="logical" default_value=".false." units="unitless"
+					description="If true, a tracer named tracer1 is included in solving the tracer equation.  It is used to test that a unit tracer remains constant."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<packages>
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
@@ -805,6 +809,7 @@
 		<package name="surfaceRestoring" description="This package includes variables required for surface tracer restoring."/>
 		<package name="bulkForcing" description="This package includes varibles required for bulk surface forcing."/>
 		<package name="frazilIce" description="This package includes variables required for frazil ice formation."/>
+		<package name="tracer1" description="This package includes variables required for tracer1 as a debugging and verification tool."/>
 		<package name="inSituEOS" description="This package includes variables required for to compute in situ equation of state derivatives, like thermal expansion and haline contraction."/>
 	</packages>
 	<streams>
@@ -1126,6 +1131,9 @@
 			<var name="salinity" array_group="dynamics" units="grams salt per kilogram seawater"
 				 description="salinity"
 			/>
+			<var name="tracer1" array_group="dynamics" units="na"
+				 description="tracer" packages="tracer1"
+			/>
 		</var_array>
 		<var name="normalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="horizonal velocity, normal component to an edge"
@@ -1407,6 +1415,9 @@
 			<var name="tendSalinity" array_group="dynamics" units="PSU s^{-1}" name_in_code="salinity"
 				 description="time tendency of salinity measured as change in practical salinity units per second"
 			/>
+			<var name="tendTracer1" array_group="dynamics" units="na" name_in_code="tracer1"
+				 description="test tracer" packages="tracer1"
+			/>
 		</var_array>
 		<var name="tendNormalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}" name_in_code="normalVelocity"
 			 description="time tendency of normal component of velocity"
@@ -1437,6 +1448,9 @@
 			<var name="salinitySurfaceValue" array_group="surfaceValues" units="PSU" name_in_code="salinitySurfaceValue"
 				description="salinity extrapolated to ocean surface"
 			/>
+			<var name="tracer1SurfaceValue" array_group="surfaceValues" units="na"
+				description="Tracer of 1 extrapolated to ocean surface" packages="tracer1"
+			/>
 		</var_array>
 		<var_array name="tracersSurfaceLayerValue" type="real" dimensions="nCells Time">
 			<var name="temperatureSurfaceLayerValue" array_group="surfaceLayerValues" units="degrees Celsius" name_in_code="temperatureSurfaceLayerValue"
@@ -1444,6 +1458,10 @@
 			/>
 			<var name="salinitySurfaceLayerValue" array_group="surfaceLayerValues" units="PSU" name_in_code="salinitySurfaceLayerValue"
 				description="salinity averaged over ocean surface layer (generally 0.1 of the ocean boundary layer)"
+			/>
+			<var name="tracer1SurfaceLayerValue" array_group="surfaceLayerValues" units="na"
+				description="Tracer of 1 averaged over ocean surface layer (generally 0.1 of the ocean boundary layer)" 
+				packages="tracer1"
 			/>
 		</var_array>
 		<var name="normalVelocitySurfaceLayer" type="real" dimensions="nEdges Time" nits="m s^{-1}"
@@ -1841,6 +1859,9 @@
 			<var name="surfaceSalinityFlux" array_group="dynamics" units="PSU m s^{-1}"
 				 description="Flux of salinity through the ocean surface. Positive into ocean."
 			/>
+			<var name="surfaceTracer1Flux" array_group="testing" units="percent"
+				 description="Flux of tracer1 through the ocean surface. Positive into ocean." packages="tracer1"
+			/>
 		</var_array>
 
 		<var name="seaSurfacePressure" type="real" dimensions="nCells Time" units="Pa"
@@ -1960,6 +1981,9 @@
 			/>
 			<var name="avgSalinitySurfaceValue" array_group="surfaceValues" units="PSU" 
 				 description="Time averaged salinity extrapolated to ocean surface"
+			/>
+			<var name="avgTracer1SurfaceValue" array_group="surfaceValues" units="percent"
+				 description="Time averaged tracer1 extrapolated to ocean surface" packages="tracer1"
 			/>
 		</var_array>
 		<var_array name="avgSurfaceVelocity" type="real" dimensions="nCells Time">

--- a/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
@@ -917,10 +917,12 @@ module mpas_core
       logical, pointer :: surfaceRestoringActive
       logical, pointer :: bulkForcingActive
       logical, pointer :: frazilIceActive
+      logical, pointer :: tracer1Active
       logical, pointer :: inSituEOSActive
 
       logical, pointer :: config_use_freq_filtered_thickness
       logical, pointer :: config_frazil_ice_formation
+      logical, pointer :: config_use_tracer1
       character (len=StrKIND), pointer :: config_time_integrator, config_forcing_type, config_pressure_gradient_type
 
       call mpas_pool_get_package(packagePool, 'thicknessFilterActive', thicknessFilterActive)
@@ -928,12 +930,14 @@ module mpas_core
       call mpas_pool_get_package(packagePool, 'surfaceRestoringActive', surfaceRestoringActive)
       call mpas_pool_get_package(packagePool, 'bulkForcingActive', bulkForcingActive)
       call mpas_pool_get_package(packagePool, 'frazilIceActive', frazilIceActive)
+      call mpas_pool_get_package(packagePool, 'tracer1Active', tracer1Active)
       call mpas_pool_get_package(packagePool, 'inSituEOSActive', inSituEOSActive)
 
       call mpas_pool_get_config(configPool, 'config_use_freq_filtered_thickness', config_use_freq_filtered_thickness)
       call mpas_pool_get_config(configPool, 'config_time_integrator', config_time_integrator)
       call mpas_pool_get_config(configPool, 'config_forcing_type', config_forcing_type)
       call mpas_pool_get_config(configPool, 'config_frazil_ice_formation', config_frazil_ice_formation)
+      call mpas_pool_get_config(configPool, 'config_use_tracer1', config_use_tracer1)
       call mpas_pool_get_config(configPool, 'config_pressure_gradient_type', config_pressure_gradient_type)
 
       ierr = 0
@@ -960,6 +964,10 @@ module mpas_core
 
       if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
          inSituEOSActive = .true.
+      end if
+
+      if (config_use_tracer1) then
+         tracer1Active = .true.
       end if
 
       call ocn_analysis_setup_packages(configPool, packagePool, err_tmp)


### PR DESCRIPTION
Tracer1 is useful to test advection and timestepping schemes,
but now that we are regularly running large simulations, I want
it out of the defaults so we don't do the extra computation.

In the last test with tracer1, I ran version 3.0 out ten years
for all QU meshes and get good results.  For example, here is the
QU.15km, where 10 digits are kept after 10 years with dt=10min.

wf-fe1.lanl.gov> pwd
/lustre/scratch1/turquoise/mpeterse/runs/c44e
wf-fe1.lanl.gov> tail -n 2 stats_max.txt | awk '{print $18}'
1.00000000006453E+00
wf-fe1.lanl.gov> tail -n 2 stats_avg.txt | awk '{print $18}'
1.00000000000873E+00
wf-fe1.lanl.gov> tail -n 2 stats_min.txt | awk '{print $18}'
9.99999999944709E-01
wf-fe1.lanl.gov> cat stats_time.txt
         0          0010-01-01_00:00:00
