### PR TITLE
Add surface kinetic energy variable.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -925,7 +925,6 @@
 			<var name="zMid"/>
 			<var name="zTop"/>
 			<var name="kineticEnergyCell"/>
-			<var name="kineticEnergyCellSurface"/>
 			<var name="relativeVorticityCell"/>
 			<var name="areaCellGlobal"/>
 			<var name="areaEdgeGlobal"/>
@@ -1572,6 +1571,9 @@
 			 description="curl of horizontal velocity, defined at vertices"
 		/>
 		<var name="relativeVorticityCell" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
+			 description="curl of horizontal velocity, averaged from vertices to cell centers"
+		/>
+		<var name="relativeVorticityCellSurface" type="real" dimensions="nCells Time" units="s^{-1}"
 			 description="curl of horizontal velocity, averaged from vertices to cell centers"
 		/>
 		<var name="normalizedRelativeVorticityEdge" type="real" dimensions="nVertLevels nEdges Time" units="s^{-1}"

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -111,7 +111,8 @@ contains
       real (kind=RKIND), dimension(:), allocatable:: pTop, div_hu,div_huTransport,div_huGMBolus
 
       real (kind=RKIND), dimension(:), pointer :: &
-        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh, seaSurfacePressure, kineticEnergyCellSurface
+        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh, seaSurfacePressure, &
+        kineticEnergyCellSurface, relativeVorticityCellSurface
       real (kind=RKIND), dimension(:,:), pointer :: &
         weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, normalGMBolusVelocity, tangentialVelocity, pressure,&
         circulation, kineticEnergyCell, montgomeryPotential, vertAleTransportTop, zMid, zTop, divergence, &
@@ -182,6 +183,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
       call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
       call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCellSurface', kineticEnergyCellSurface)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCellSurface', relativeVorticityCellSurface)
       call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
       call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
       call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
@@ -277,6 +279,10 @@ contains
             relativeVorticityCell(k, iCell) = relativeVorticityCell(k, iCell) + kiteAreasOnVertex(j, iVertex) * relativeVorticity(k, iVertex) * invAreaCell1
           end do
         end do
+      end do
+
+      do iCell = 1, nCells
+         relativeVorticityCellSurface(iCell) = relativeVorticityCell(1, iCell)
       end do
 
       !


### PR DESCRIPTION
For high resolution runs, I want to save frequent (daily or 5-day)
output for movies on all runs an minimal disk storage.  I would like
to have this surface kinetic energy variable available on all future
runs, just like there is surface tracer arrays already in the code.
