### PR TITLE
Fix compile bug in forcing module.

### DIFF
--- a/src/framework/mpas_forcing.F
+++ b/src/framework/mpas_forcing.F
@@ -1415,7 +1415,7 @@ contains
           FORCING_ERROR_WRITE('Error: -- Forcing: mpas_forcing_get_forcing: READ: ' COMMA ierr)
        endif
 
-       FORCING_DEBUG_WRITE('-- Forcing: mpas_forcing_get_forcing: READ: '//trim(forcingTimeCycleStr))//' ' COMMA ierr
+       FORCING_DEBUG_WRITE('-- Forcing: mpas_forcing_get_forcing: READ: '//trim(forcingTimeCycleStr)//' ' COMMA ierr)
 
     endif ! forcingAlarmID ringing
 


### PR DESCRIPTION
Develop will not compile right now, using ifort, without this bug fix.
