### PR TITLE
Fixing an issue with uneven block decompositions

### DIFF
--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -591,8 +591,8 @@ module mpas_block_decomp
          blocks_per_proc_min = total_blocks / dminfo % nProcs
          remaining_blocks = total_blocks - (blocks_per_proc_min * dminfo % nProcs)
          even_blocks = total_blocks - remaining_blocks
-  
-         if(global_block_number > even_blocks) then
+
+         if((global_block_number+1) > even_blocks) then
              owning_proc = global_block_number - even_blocks
          else
              owning_proc = global_block_number / blocks_per_proc_min


### PR DESCRIPTION
Previously when multiple blocks are used per MPI task, if there are an
un-even number of blocks relative to the number of MPI tasks an issue
occurs when trying to determine which processor owns each block.

This commit fixes the issue and allows framework to work properly for
uneven block decompositions.
