### PR TITLE
Fixing an issue when generating nested var_structs

### DIFF
--- a/src/registry/gen_inc.c
+++ b/src/registry/gen_inc.c
@@ -1812,6 +1812,7 @@ int parse_struct(FILE *fd, ezxml_t registry, ezxml_t superStruct, int subpool, c
 
 	// Extract all sub structs
 	for (struct_xml = ezxml_child(superStruct, "var_struct"); struct_xml; struct_xml = struct_xml->next){
+		substructname = ezxml_attr(struct_xml, "name");
 		fortprintf(fd, "      call mpas_generate%s%s_subpool_%s(block, newSubPool, dimensionPool, packagePool)\n", core_string, structname, substructname);
 	}
 


### PR DESCRIPTION
Previously, the name of a substruct was not extracted properly before
generating the call to generate a substruct of another struct. This
resulted in the call to the subroutine having (null) in it's name.

This commit fixes the issue by properly extracting the substruct name
when generating the subroutien call.
