### PR TITLE
* In module mpas_atmphys_driver_lsm.F, removed the global variable qz0 a...

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -437,7 +437,6 @@
 			<var name="lai"/>
 			<var name="noahres"/>
 			<var name="potevp"/>
-			<var name="qz0"/>
 			<var name="sfc_albedo"/>
 			<var name="sfc_emiss"/>
 			<var name="sfc_emibck"/>
@@ -1368,7 +1367,6 @@
                 <!-- lai            :leaf area index                                                                [-] -->
                 <!-- noahres        :residual of the noah land-surface scheme energy budget                     [W m-2] -->
                 <!-- potevp         :potential evaporation                                                      [W m-2] -->
-                <!-- qz0            :specific humidity at znt                                                 [kg kg-1] -->
                 <!-- sfc_albedo     :surface albedo                                                                 [-] -->
                 <!-- sfc_embck      :background emissivity                                                          [-] -->
                 <!-- sfc_emiss      :surface emissivity                                                             [-] -->
@@ -1394,7 +1392,6 @@
                 <var name="lai"           type="real"     dimensions="nCells Time"/>
                 <var name="noahres"       type="real"     dimensions="nCells Time"/>
                 <var name="potevp"        type="real"     dimensions="nCells Time"/>
-                <var name="qz0"           type="real"     dimensions="nCells Time"/>
                 <var name="sfc_albedo"    type="real"     dimensions="nCells Time"/>
                 <var name="sfc_emiss"     type="real"     dimensions="nCells Time"/>
                 <var name="sfc_emibck"    type="real"     dimensions="nCells Time"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -64,6 +64,9 @@
 !>    * moved the definition of isurban to landuse_init_forMPAS in mpas_atmphys_landuse.F.
 !>      isurban is now defined as a function of the input landuse data file.
 !>      Dominikus Heinzeller (IMK) / 2014-07-24.
+!>    * removed the global variable qz0 and initialized the local variable qz0_p to 0. qz0 is only
+!>      used in the MYJ PBL parameterization which is not available in MPAS.
+!>      Laura D. Fowler (laura@ucar.edu) / 2015-03-05.
 
 !>
 !> DOCUMENTATION:
@@ -220,7 +223,7 @@
 
  real(kind=RKIND),dimension(:),pointer  :: acsnom,acsnow,canwat,chs,chs2,chklowq,cpm,cqs2,glw, &
                                            grdflx,gsw,hfx,lai,lh,noahres,potevp,qfx,qgh,qsfc,  &
-                                           qz0,br,sfc_albedo,sfc_emibck,sfc_emiss,sfcrunoff,   &
+                                           br,sfc_albedo,sfc_emibck,sfc_emiss,sfcrunoff,       &
                                            smstav,smstot,snotime,snopcx,sr,udrunoff,z0,znt
  real(kind=RKIND),dimension(:),pointer  :: shdmin,shdmax,snoalb,sfc_albbck,snow,snowc,snowh,tmn, &
                                            skintemp,vegfra,xice,xland
@@ -252,7 +255,6 @@
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'qgh'       ,qgh       )
  call mpas_pool_get_array(diag_physics,'qsfc'      ,qsfc      )
- call mpas_pool_get_array(diag_physics,'qz0'       ,qz0       )
  call mpas_pool_get_array(diag_physics,'br'        ,br        )
  call mpas_pool_get_array(diag_physics,'raincv'    ,raincv    )
  call mpas_pool_get_array(diag_physics,'rainncv'   ,rainncv   )
@@ -325,7 +327,6 @@
     qfx_p(i,j)        = qfx(i)
     qgh_p(i,j)        = qgh(i)
     qsfc_p(i,j)       = qsfc(i)
-    qz0_p(i,j)        = qz0(i)
     br_p(i,j)         = br(i)
     sfc_albedo_p(i,j) = sfc_albedo(i)
     sfc_emibck_p(i,j) = sfc_emibck(i)
@@ -355,6 +356,7 @@
     xice_p(i,j)       = xice(i)
     xland_p(i,j)      = xland(i)
 
+    qz0_p(i,j) = 0._RKIND
  enddo
  enddo
 
@@ -381,7 +383,7 @@
 
  real(kind=RKIND),dimension(:),pointer  :: acsnom,acsnow,canwat,chs,chs2,chklowq,cpm,cqs2,glw, &
                                            grdflx,gsw,hfx,lai,lh,noahres,potevp,qfx,qgh,qsfc,  &
-                                           qz0,br,sfc_albedo,sfc_emibck,sfc_emiss,sfcrunoff,   &
+                                           br,sfc_albedo,sfc_emibck,sfc_emiss,sfcrunoff,       &
                                            smstav,smstot,snotime,snopcx,sr,udrunoff,z0,znt
  real(kind=RKIND),dimension(:),pointer  :: shdmin,shdmax,snoalb,sfc_albbck,snow,snowc,snowh,tmn, &
                                            skintemp,vegfra,xice,xland
@@ -412,7 +414,6 @@
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'qgh'       ,qgh       )
  call mpas_pool_get_array(diag_physics,'qsfc'      ,qsfc      )
- call mpas_pool_get_array(diag_physics,'qz0'       ,qz0       )
  call mpas_pool_get_array(diag_physics,'br'        ,br        )
  call mpas_pool_get_array(diag_physics,'raincv'    ,raincv    )
  call mpas_pool_get_array(diag_physics,'rainncv'   ,rainncv   )
@@ -480,7 +481,6 @@
     qfx(i)        = qfx_p(i,j)
     qgh(i)        = qgh_p(i,j)
     qsfc(i)       = qsfc_p(i,j)
-    qz0(i)        = qz0_p(i,j)
     br(i)         = br_p(i,j)
     sfc_albedo(i) = sfc_albedo_p(i,j)
     sfc_emibck(i) = sfc_emibck_p(i,j)


### PR DESCRIPTION
...nd initialized the local variable

  qz0_p to zero. In module module_sf_noahdrv.F, qz0 is only used in the MYJ PBL parameterization which is
  not available in MPAS.
- In Registry.xml, removed the global variable qz0 accordingly.
