### PR TITLE
Ensure that iclobber variable is always initialized in xml_stream_parser.c

### DIFF
--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -980,6 +980,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		fprintf(stderr, "        %-20s%s\n", "filename interval:", filename_interval_string);
 
 		/* NB: These clobber constants must match those in the mpas_stream_manager module! */
+		iclobber = 0;
 		if (clobber != NULL) {
 			if (strstr(clobber, "never_modify") != NULL) {
 				iclobber = 0;
@@ -1208,6 +1209,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		fprintf(stderr, "        %-20s%s\n", "filename interval:", filename_interval_string);
 
 		/* NB: These clobber constants must match those in the mpas_stream_manager module! */
+		iclobber = 0;
 		if (clobber != NULL) {
 			if (strstr(clobber, "never_modify") != NULL) {
 				iclobber = 0;


### PR DESCRIPTION
In cases where the clobber_mode is not set to a valid option in the definition of a stream, the iclobber variable was never initialized to its default value in xml_stream_parser.c.
