### PR TITLE
Fix decomposition reuse bug in MPAS_io_set_var_indices()

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1149,6 +1149,7 @@ module mpas_io
       integer :: ndims
       integer (kind=PIO_OFFSET) :: pd, indx
       integer :: i 
+      integer :: early_return, early_return_global
       integer (kind=PIO_OFFSET) :: i1, i2, i3, i4, i5
       integer, dimension(:), pointer :: dimlist
       integer (kind=PIO_OFFSET), dimension(:), pointer :: compdof
@@ -1196,6 +1197,7 @@ module mpas_io
       !
       decomp_cursor => decomp_list
 !if (.not. associated(decomp_cursor)) write(stderrUnit,*) 'No existing decompositions to check...'
+      early_return = 0
       DECOMP_LOOP: do while (associated(decomp_cursor))
          if (decomp_cursor % decomphandle % field_type == field_cursor % fieldhandle % field_type) then
          if (size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims) then
@@ -1225,7 +1227,8 @@ module mpas_io
             ! OK, we have a match... just use this decomposition for the field and return
             field_cursor % fieldhandle % decomp => decomp_cursor % decomphandle 
 !write(stderrUnit,*) 'Found a matching decomposition that we can use'
-            return
+            early_return = 1
+            exit DECOMP_LOOP
          else if ((size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims - 1)  &
                   .and. field_cursor % fieldhandle % has_unlimited_dim  &
                  ) then
@@ -1257,11 +1260,21 @@ module mpas_io
             ! OK, we have a match... just use this decomposition for the field and return
             field_cursor % fieldhandle % decomp => decomp_cursor % decomphandle 
 !write(stderrUnit,*) 'Found a matching decomposition that we can use (aside from record dimension)'
-            return
+            early_return = 1
+            exit DECOMP_LOOP
          end if
          end if
          decomp_cursor => decomp_cursor % next
       end do DECOMP_LOOP
+
+      ! 
+      ! If all tasks have set early_return to 1, then we have a usable decomposition and can return
+      ! 
+      call mpas_dmpar_min_int(local_dminfo, early_return, early_return_global)
+      if (early_return_global == 1) then
+         return
+      end if
+
 
 !write(stderrUnit,*) 'Creating a new decomposition'
 


### PR DESCRIPTION
This pull request fixes an issue in MPAS_io_set_var_indices() when deciding if we can 
reuse a decomposition.

In MPAS_io_set_var_indices(), before committing to creating a new "decomposition"
with PIO_initdecomp, we first check whether we have already created a decomposition
that is compatible (in terms of type, dimensionality, and degrees of freedom).
This logic assumed that all tasks would agree on whether a matching decomposition
was found.

Under the right circumstances, however, an existing decomposition might match on one
or more tasks, but not on all tasks, causing the latter tasks to hang waiting for
those that exited early from the routine. To avoid this, we don't actually return
at the point where we decide that we can return, but instead set a flag value; at
the end of the logic for checking decompositions, we verify that all tasks agree on
the matching decomposition before returning.
