### PR TITLE
Fixing restarts within coupled simulations

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -910,6 +910,12 @@
 			<var name="xtime"/>
 			<var name="surfaceWindStress"/>
 			<var name="seaSurfacePressure"/>
+			<var name="boundaryLayerDepth"/>
+			<var_array name="tracersSurfaceValue"/>
+			<var_array name="surfaceVelocity"/>
+			<var_array name="SSHGradient"/>
+			<var_array name="vertNonLocalFlux"/>
+
 		</stream>
 		<stream name="output" 
 				type="output"


### PR DESCRIPTION
Previously, coupled simulations were not bit-restartable. This commit
adds required fields to the restart file for coupled simulations.
