### PR TITLE
Converting surfaceMassFlux to surfaceThicknessFlux

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1048,7 +1048,7 @@
 			<var_array name="vertNonLocalFlux"/>
 			<var name="surfaceWindStressMagnitude"/>
 			<var name="surfaceWindStress"/>
-			<var name="surfaceMassFlux"/>
+			<var name="surfaceThicknessFlux"/>
 			<var name="seaIceEnergy"/>
 			<var name="penetrativeTemperatureFlux"/>
 			<var name="transmissionCoefficients"/>
@@ -1850,13 +1850,20 @@
 		/>
 	</var_struct>
 	<var_struct name="forcing" time_levs="1">
+		<!-- *********************************************************************
+
+				The fields listed below are built within MPAS-O. If they are
+				read in from an input file, their values will be overwritten by
+				constituent fields, depending on the forcing options selected.
+
+			 ********************************************************************* -->
 		<var name="surfaceWindStress" type="real" dimensions="nEdges Time" units="N m^{-2}"
 			 description="Wind stress at the surface of the ocean defined at edge midpoints. Magintude in direction of edge normal."
 		/>
 		<var name="surfaceWindStressMagnitude" type="real" dimensions="nCells Time" units="N m^{-2}"
 			 description="Magnitude of wind stress at the surface of the ocean, at cell centers."
 		/>
-		<var name="surfaceMassFlux" type="real" dimensions="nCells Time" units="m s^{-1}"
+		<var name="surfaceThicknessFlux" type="real" dimensions="nCells Time" units="m s^{-1}"
 			 description="Flux of mass through the ocean surface. Positive into ocean."
 		/>
 		<var_array name="surfaceTracerFlux" type="real" dimensions="nCells Time">
@@ -1871,6 +1878,15 @@
 			/>
 		</var_array>
 
+
+		<!-- *********************************************************************
+
+				The fields listed below are constituent fields for coupling.
+				Their use depends on the forcing options selected (check their
+				packages). Some are used as input for simulations, while others
+				are outputs.
+
+			 ********************************************************************* -->
 		<var name="seaSurfacePressure" type="real" dimensions="nCells Time" units="Pa"
 			 description="Pressure defined at the sea surface."
 		/>

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1105,7 +1105,7 @@ contains
 
       ! real pointers
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
-      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceMassFlux, &
+      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
            surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
            normalVelocitySurfaceLayer
       real (kind=RKIND), dimension(:), pointer :: surfaceWindStress, surfaceWindStressMagnitude
@@ -1169,7 +1169,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
       call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceMassFlux', surfaceMassFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
       call mpas_pool_get_array(forcingPool, 'surfaceTracerFlux', surfaceTracerFlux)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
       call mpas_pool_get_array(forcingPool, 'surfaceWindStress', surfaceWindStress)
@@ -1202,15 +1202,15 @@ contains
        ! everything below should be consistent with that specified in Registry
        ! everything below should be consistent with the CVMix/KPP documentation: https://www.dropbox.com/s/6hqgc0rsoa828nf/cvmix_20aug2013.pdf
        !
-       !    surfaceMassFlux: surface mass flux, m/s, positive into ocean
+       !    surfaceThicknessFlux: surface mass flux, m/s, positive into ocean
        !    surfaceTracerFlux(indexTempFlux): non-penetrative temperature flux, C m/s, positive into ocean
        !    penetrativeTemperatureFlux: penetrative surface temperature flux at ocean surface, positive into ocean
        !    surfaceTracerFlux(indexSaltFlux): salinity flux, PSU m/s, positive into ocean
        !    penetrativeTemperatureFluxOBL: penetrative temperature flux computed at z=OBL, positive down
        !
        ! note: the following fields used the CVMix/KPP computation of buoyancy forcing are not included here
-       !    1. Tm: temperature associated with surfaceMassFlux, C  (here we assume Tm == temperatureSurfaceValue)
-       !    2. Sm: salinity associated with surfaceMassFlux, PSU (here we assume Sm == salinitySurfaceValue and account for salinity flux in surfaceTracerFlux array)
+       !    1. Tm: temperature associated with surfaceThicknessFlux, C  (here we assume Tm == temperatureSurfaceValue)
+       !    2. Sm: salinity associated with surfaceThicknessFlux, PSU (here we assume Sm == salinitySurfaceValue and account for salinity flux in surfaceTracerFlux array)
        !
          surfaceBuoyancyForcing(iCell) =  thermalExpansionCoeff (1,iCell) *  &
                (surfaceTracerFlux(indexTempFlux,iCell) + penetrativeTemperatureFlux(iCell) - penetrativeTemperatureFluxOBL(iCell)) &

--- a/src/core_ocean/shared/mpas_ocn_forcing_bulk.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing_bulk.F
@@ -50,6 +50,8 @@ module ocn_forcing_bulk
    !
    !--------------------------------------------------------------------
 
+   real (kind=RKIND) :: refDensity
+
 !***********************************************************************
 
 contains
@@ -113,7 +115,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: rainFlux
       real (kind=RKIND), dimension(:), pointer :: seaSurfacePressure, iceFraction
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceMassFlux, surfaceWindStress, surfaceWindStressMagnitude
+      real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux, surfaceWindStress, surfaceWindStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer :: surfaceTracerFlux
 
       err = 0
@@ -150,7 +152,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'seaSurfacePressure', seaSurfacePressure)
       call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceMassFlux', surfaceMassFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
       call mpas_pool_get_array(forcingPool, 'surfaceTracerFlux', surfaceTracerFlux)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
 
@@ -174,7 +176,7 @@ contains
 
         surfaceTracerFlux(index_salinity_flux, iCell) = seaIceSalinityFlux(iCell) * sflux_factor
 
-        surfaceMassFlux(iCell) = snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) + seaIceFreshWaterFlux(iCell) + iceRunoffFlux(iCell) + riverRunoffFlux(iCell)
+        surfaceThicknessFlux(iCell) = ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) + seaIceFreshWaterFlux(iCell) + iceRunoffFlux(iCell) + riverRunoffFlux(iCell) ) / refDensity
       end do
 
       penetrativeTemperatureFlux = shortWaveHeatFlux * hflux_factor
@@ -197,7 +199,14 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
+      real (kind=RKIND), pointer :: config_density0
+
       err = 0
+
+
+      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
+
+      refDensity = config_density0
 
    end subroutine ocn_forcing_bulk_init!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -103,7 +103,7 @@ contains
       type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceMassFlux
+      real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, layerThicknessEdge, &
          vertAleTransportTop, tend_layerThickness, normalTransportVelocity, transmissionCoefficients
 
@@ -121,7 +121,7 @@ contains
 
       call mpas_pool_get_array(tendPool, 'layerThickness', tend_layerThickness)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceMassFlux', surfaceMassFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
       call mpas_pool_get_array(forcingPool, 'transmissionCoefficients', transmissionCoefficients)
                   
       !
@@ -155,7 +155,7 @@ contains
       !
       call mpas_timer_start("surface flux", .false.)
 
-      call ocn_thick_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceMassFlux, tend_layerThickness, err)
+      call ocn_thick_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceThicknessFlux, tend_layerThickness, err)
       call mpas_timer_stop("surface flux")
 
       call mpas_timer_stop("ocn_tend_thick")

--- a/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
@@ -50,9 +50,7 @@ module ocn_thick_surface_flux
    !
    !--------------------------------------------------------------------
 
-   logical :: surfaceMassFluxOn
-   real (kind=RKIND) :: refDensity
-
+   logical :: surfaceThicknessFluxOn
 
 !***********************************************************************
 
@@ -71,7 +69,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_thick_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceMassFlux, tend, err)!{{{
+   subroutine ocn_thick_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceThicknessFlux, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -88,7 +86,7 @@ contains
          layerThickness   !< Input: Layer thickness
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         surfaceMassFlux   !< Input: surface flux of mass
+         surfaceThicknessFlux   !< Input: surface flux of thickness
 
 
       !-----------------------------------------------------------------
@@ -123,7 +121,7 @@ contains
 
       err = 0
 
-      if (.not. surfaceMassFluxOn) return
+      if (.not. surfaceThicknessFluxOn) return
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
@@ -135,11 +133,11 @@ contains
         do k = 1, maxLevelCell(iCell)
           remainingFlux = remainingFlux - transmissionCoefficients(k, iCell)
 
-          tend(k, iCell) = tend(k, iCell) + cellMask(k, iCell) * (surfaceMassFlux(iCell) / refDensity) * transmissionCoefficients(k, iCell)
+          tend(k, iCell) = tend(k, iCell) + cellMask(k, iCell) * surfaceThicknessFlux(iCell) * transmissionCoefficients(k, iCell)
         end do
 
         if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
-          tend(maxLevelCell(iCell), iCell) = tend(maxLevelCell(iCell), iCell) + cellMask(maxLevelCell(iCell), iCell) * remainingFlux * surfaceMassFlux(iCell) / refDensity
+          tend(maxLevelCell(iCell), iCell) = tend(maxLevelCell(iCell), iCell) + cellMask(maxLevelCell(iCell), iCell) * remainingFlux * surfaceThicknessFlux(iCell)
         end if
       end do
 
@@ -174,24 +172,20 @@ contains
 
       logical, pointer :: config_disable_thick_sflux
       character (len=StrKIND), pointer :: config_forcing_type
-      real (kind=RKIND), pointer :: config_density0
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_disable_thick_sflux', config_disable_thick_sflux)
       call mpas_pool_get_config(ocnConfigs, 'config_forcing_type', config_forcing_type)
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
 
-      refDensity = config_density0
-
-      surfaceMassFluxOn = .true.
+      surfaceThicknessFluxOn = .true.
 
       if (config_disable_thick_sflux) then
-         surfaceMassFluxOn = .false.
+         surfaceThicknessFluxOn = .false.
       end if
 
       if (config_forcing_type == trim('off')) then
-         surfaceMassFluxOn = .false.
+         surfaceThicknessFluxOn = .false.
       end if
 
 


### PR DESCRIPTION
This commit changes surfaceMassFlux to surfaceThicknessFlux. It moves
the conversion from a mass flux to a thickness flux into the bulk
forcing module instead of the thick_surface_flux module.
