### PR TITLE
Fixing an issue when generating streams files

### DIFF
--- a/src/tools/input_gen/streams_gen.c
+++ b/src/tools/input_gen/streams_gen.c
@@ -71,7 +71,7 @@ int main(int argc, char ** argv)/*{{{*/
 		keys[i] = malloc(sizeof(char)*1024);
 		values[i] = malloc(sizeof(char)*1024);
 
-		string = strdup(argv[4+i]);
+		string = strdup(argv[5+i]);
 		tofree = string;
 
 		token = strsep(&string, "=");


### PR DESCRIPTION
This commit fixes an issue that causes a seg fault when trying to
generate stream files using key, value pairs.

Previously the starting argument for pairs was not advanced when adding
the ability to control the order streams were written to the stream
file.
