### PR TITLE
LI: use stdoutUnit, stderrUnit in LI core

### DIFF
--- a/src/core_landice/mpas_li_diagnostic_vars.F
+++ b/src/core_landice/mpas_li_diagnostic_vars.F
@@ -402,7 +402,7 @@ contains
           ! Make sure lowerSurface calculation is reasonable.  This check could be deleted once this has been throroughly tested.
           do iCell = 1, nCells
              if (lowerSurface(iCell) < bedTopography(iCell)) then
-                write (0,*) 'lowerSurface less than bedTopography at cell:', iCell
+                write (stderrUnit,*) 'lowerSurface less than bedTopography at cell:', iCell
                 err = 1
              endif
           end do
@@ -561,7 +561,7 @@ contains
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in diagnostic_solve_before_velocity."
+          write (stderrUnit,*) "An error has occurred in diagnostic_solve_before_velocity."
       endif
 
    !--------------------------------------------------------------------
@@ -657,7 +657,7 @@ contains
             !!!h_edge = (thickness(k) + thickness(k) ) / 2.0  ! 2nd order 
          end do
       else
-          !write(6,*) 'layerThicknessEdge not calculated!'
+          !write(stdoutUnit,*) 'layerThicknessEdge not calculated!'
       endif
 
       ! Note: the outmost layerThicknessEdge may be wrong if its upwind cell is off this block - halo update should be done if this variable will be used.

--- a/src/core_landice/mpas_li_mask.F
+++ b/src/core_landice/mpas_li_mask.F
@@ -421,7 +421,7 @@ contains
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_calculate_mask."
+          write (stderrUnit,*) "An error has occurred in li_calculate_mask."
       endif
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_mpas_core.F
+++ b/src/core_landice/mpas_li_mpas_core.F
@@ -255,8 +255,8 @@ module mpas_core
       err = ior(err, err_tmp)
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
       err = ior(err, err_tmp)         
-      write(0,*) 'Initial timestep ', trim(timeStamp)
-      write(6,*) 'Initial timestep ', trim(timeStamp)
+      write(stderrUnit,*) 'Initial timestep ', trim(timeStamp)
+      write(stdoutUnit,*) 'Initial timestep ', trim(timeStamp)
 
 
       ! ===
@@ -331,10 +331,10 @@ module mpas_core
          currTime = mpas_get_clock_time(clock, MPAS_NOW, err_tmp)
          call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
          err = ior(err, err_tmp)
-         write(0,*) 'Doing timestep ', trim(timeStamp)
-         write(6,*) 'Doing timestep ', trim(timeStamp)
+         write(stderrUnit,*) 'Doing timestep ', trim(timeStamp)
+         write(stdoutUnit,*) 'Doing timestep ', trim(timeStamp)
 
-         !write(6,*) '  dt (s) = ', dtSeconds
+         !write(stdoutUnit,*) '  dt (s) = ', dtSeconds
 
          ! ===
          ! === Perform Timestep
@@ -720,7 +720,7 @@ subroutine mpas_core_get_mesh_stream(configs, stream, ierr)
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in init_block."
+          write (stderrUnit,*) "An error has occurred in init_block."
       endif
 
    !--------------------------------------------------------------------
@@ -786,7 +786,7 @@ subroutine mpas_core_get_mesh_stream(configs, stream, ierr)
    
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in mpas_timestep."
+          write (stderrUnit,*) "An error has occurred in mpas_timestep."
       endif
    
    end subroutine landice_timestep
@@ -883,7 +883,7 @@ subroutine mpas_core_get_mesh_stream(configs, stream, ierr)
             call mpas_set_time(curr_time=stopTime, dateTimeString=config_stop_time, ierr=err_tmp)
             ierr = ior(ierr,err_tmp)
             if(startTime + runduration /= stopTime) then
-               write(0,*) 'Warning: config_run_duration and config_stop_time are inconsistent: using config_run_duration.'
+               write(stderrUnit,*) 'Warning: config_run_duration and config_stop_time are inconsistent: using config_run_duration.'
             end if
          end if
       else if (trim(config_stop_time) /= "none") then
@@ -892,14 +892,14 @@ subroutine mpas_core_get_mesh_stream(configs, stream, ierr)
          call mpas_create_clock(core_clock, startTime=startTime, timeStep=timeStep, stopTime=stopTime, ierr=err_tmp)
          ierr = ior(ierr,err_tmp)
       else
-          write(0,*) 'Error: Neither config_run_duration nor config_stop_time were specified.'
+          write(stderrUnit,*) 'Error: Neither config_run_duration nor config_stop_time were specified.'
           ierr = 1
       end if
 
 
       ! === error check
       if (ierr > 0) then
-          write (0,*) "An error has occurred in simulation_clock_init."
+          write (stderrUnit,*) "An error has occurred in simulation_clock_init."
       endif
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_setup.F
+++ b/src/core_landice/mpas_li_setup.F
@@ -175,10 +175,10 @@ contains
       fractionTotal = sum(layerThicknessFractions)
       if (fractionTotal /= 1.0_RKIND) then
          if (abs(fractionTotal - 1.0_RKIND) > 0.001_RKIND) then
-            write(0,*) 'Error: The sum of layerThicknessFractions is different from 1.0 by more than 0.001.'
+            write(stderrUnit,*) 'Error: The sum of layerThicknessFractions is different from 1.0 by more than 0.001.'
             err = 1
          end if
-         write (6,*), 'Adjusting upper layerThicknessFrac by small amount because sum of layerThicknessFractions is slightly different from 1.0.'
+         write (stdoutUnit,*), 'Adjusting upper layerThicknessFrac by small amount because sum of layerThicknessFractions is slightly different from 1.0.'
          ! TODO - distribute the residual amongst all layers (and then put the residual of that in a single layer
          layerThicknessFractions(1) = layerThicknessFractions(1) - (fractionTotal - 1.0_RKIND)
       endif

--- a/src/core_landice/mpas_li_sia.F
+++ b/src/core_landice/mpas_li_sia.F
@@ -328,7 +328,7 @@ contains
 
      ! === error check
      if (err > 0) then
-         write (0,*) "An error has occurred in li_sia_solve."
+         write (stderrUnit,*) "An error has occurred in li_sia_solve."
      endif
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_tendency.F
+++ b/src/core_landice/mpas_li_tendency.F
@@ -191,7 +191,7 @@ module li_tendency
       case ('none')  !===================================================
         ! Do nothing
       case default  !===================================================
-        write(0,*) trim(config_thickness_advection), ' is not a valid thickness advection option.'
+        write(stderrUnit,*) trim(config_thickness_advection), ' is not a valid thickness advection option.'
         err_tmp = 1
       end select  !===================================================
       err = ior(err,err_tmp)
@@ -236,7 +236,7 @@ module li_tendency
 
       ! === error check
       if (err > 0) then
-         write (0,*) "An error has occurred in li_tendency_thickness."
+         write (stderrUnit,*) "An error has occurred in li_tendency_thickness."
       endif
 
    !--------------------------------------------------------------------
@@ -384,7 +384,7 @@ module li_tendency
 !!!     case ('None')  !===================================================
 !!!        ! Do nothing
 !!!     case default  !===================================================
-!!!        write(0,*) trim(config_tracer_advection), ' is not a valid tracer advection option.'
+!!!        write(stderrUnit,*) trim(config_tracer_advection), ' is not a valid tracer advection option.'
 !!!        call mpas_dmpar_abort(dminfo)
 !!!     end select  !===================================================
 
@@ -483,7 +483,7 @@ module li_tendency
 !!!               ! Convert to physical thickness - only needed if CFBC is on but this is always defined.
 !!!               physicalThickness = thickness(iCell) * areaCell(iCell) / iceArea(iCell)  ! iceArea should always be > 0 since we are only checking on ice cells.
 !!!               if (iceArea(iCell) == 0.0) then
-!!!                  write(0,*) 'iceArea is 0 on a cell with ice!'
+!!!                  write(stderrUnit,*) 'iceArea is 0 on a cell with ice!'
 !!!                  err = 1
 !!!               endif
 !!!               if (physicalThickness <= config_calving_critical_thickness) then
@@ -655,7 +655,7 @@ module li_tendency
                maxAllowableDt = 1.0e36_RKIND
             endif
             if ( maxAllowableDt < dt ) then
-                 !write(0,*) 'CFL violation at level, edge', k, iEdge                      
+                 !write(stderrUnit,*) 'CFL violation at level, edge', k, iEdge                      
                  err = err + 1
             endif
             MinOfMaxAllowableDt = min(MinOfMaxAllowableDt, maxAllowableDt)
@@ -674,12 +674,12 @@ module li_tendency
       err = ior(err,err_tmp)
 
       if (err > 0) then
-         write(0,*) 'CFL violation on this processor on ', err, ' level-edges!  Maximum allowable time step (seconds) for this processor is (Days_hhh:mmm:sss): ' // trim(allowableDtMinString)
+         write(stderrUnit,*) 'CFL violation on this processor on ', err, ' level-edges!  Maximum allowable time step (seconds) for this processor is (Days_hhh:mmm:sss): ' // trim(allowableDtMinString)
          err = 1
       endif
 
       if (config_print_thickness_advection_info) then
-         write(6,*) '  Maximum allowable time step (s) on THIS processor is (Days_hhh:mmm:sss):   ' // trim(allowableDtMinString)
+         write(stdoutUnit,*) '  Maximum allowable time step (s) on THIS processor is (Days_hhh:mmm:sss):   ' // trim(allowableDtMinString)
       endif
 
       ! Optional check for mass conservation
@@ -691,7 +691,7 @@ module li_tendency
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in tend_layerThickness_fo_upwind."
+          write (stderrUnit,*) "An error has occurred in tend_layerThickness_fo_upwind."
       endif
 
    !--------------------------------------------------------------------
@@ -917,7 +917,7 @@ module li_tendency
 !                 ubar = flux / thickness(cellUpwind)
 !                 if ( (abs(ubar) * dt/SecondsInYear) .gt. (0.5 * dcEdge(iEdge))) then
 !                      !maxAllowableDt = min(maxAllowableDt, (0.5 * dcEdge)/ubar )
-!                      write(0,*) 'CFL violation at edge', iEdge
+!                      write(stderrUnit,*) 'CFL violation at edge', iEdge
 !                      err = err + 1
 !                 endif
 !                 thickness_tend(cellUpwind) = thickness_tend(cellUpwind) - flux * dvEdge(iEdge) / areaCell(cellUpwind)
@@ -926,7 +926,7 @@ module li_tendency
 !      end do
 
 !      if (err .gt. 0) then
-!         write(6,*) 'CFL violation at ', err, ' edges!  Maximum time step should be ', maxAllowableDt
+!         write(stdoutUnit,*) 'CFL violation at ', err, ' edges!  Maximum time step should be ', maxAllowableDt
 !         err = 1
 !      endif
 !   !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_time_integration.F
+++ b/src/core_landice/mpas_li_time_integration.F
@@ -109,16 +109,16 @@ module li_time_integration
 
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
 
-      !write(*,*) 'Using ', trim(config_time_integration), ' time integration.'
+      !write(stdoutUnit,*) 'Using ', trim(config_time_integration), ' time integration.'
       select case (config_time_integration)
       case ('forward_euler')
          call li_time_integrator_forwardeuler(domain, dt, err_tmp)
       case ('rk4')
-         write(0,*) trim(config_time_integration), ' is not currently supported.'
+         write(stderrUnit,*) trim(config_time_integration), ' is not currently supported.'
          call mpas_dmpar_abort(domain % dminfo)
          err_tmp = 1
       case default
-         write(0,*) trim(config_time_integration), ' is not a valid land ice time integration option.'
+         write(stderrUnit,*) trim(config_time_integration), ' is not a valid land ice time integration option.'
          err_tmp = 1
       end select
       err = ior(err,err_tmp)
@@ -132,7 +132,7 @@ module li_time_integration
 
 !         ! Abort the simulation if NaNs occur in the velocity field
 !         if (isNaN(sum(block % state % time_levs(2) % state % u % array))) then
-!            write(0,*) 'Abort: NaN detected'
+!            write(stderrUnit,*) 'Abort: NaN detected'
 !            call mpas_dmpar_abort(dminfo)
 !         endif
 
@@ -141,7 +141,7 @@ module li_time_integration
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_timestep."
+          write (stderrUnit,*) "An error has occurred in li_timestep."
       endif
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mpas_li_time_integration_fe.F
@@ -136,7 +136,7 @@ module li_time_integration_fe
 
       ! === error check
       if (err == 1) then
-          write (0,*) "An error has occurred in li_time_integrator_forwardeuler."
+          write (stderrUnit,*) "An error has occurred in li_time_integrator_forwardeuler."
       endif
 
    !--------------------------------------------------------------------
@@ -251,11 +251,11 @@ module li_time_integration_fe
           err = ior(err,err_tmp)
           call mpas_get_timeInterval(allowableDtMinStringInterval, timeString=allowableDtMinString, ierr=err_tmp)
           err = ior(err,err_tmp)
-          write(6,*) '  Maximum allowable time step (yr) for all processors is (Days_hhh:mmm:sss): ' // trim(allowableDtMinString) //  '  Time step is limited by processor number ', allowableDtMinProcNumber
+          write(stdoutUnit,*) '  Maximum allowable time step (yr) for all processors is (Days_hhh:mmm:sss): ' // trim(allowableDtMinString) //  '  Time step is limited by processor number ', allowableDtMinProcNumber
       endif
 
       if (err .gt. 0) then
-           write(0,*) 'Error in calculating thickness tendency (possibly CFL violation)'
+           write(stderrUnit,*) 'Error in calculating thickness tendency (possibly CFL violation)'
       endif
 
 
@@ -298,7 +298,7 @@ module li_time_integration_fe
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in calculate_tendencies."
+          write (stderrUnit,*) "An error has occurred in calculate_tendencies."
       endif
 
    !--------------------------------------------------------------------
@@ -416,7 +416,7 @@ module li_time_integration_fe
 
          if (config_print_thickness_advection_info) then
             if (sum(masktmp) > 0) then
-               write(6,*) '  Cells with negative thickness (set to 0):',sum(masktmp)
+               write(stdoutUnit,*) '  Cells with negative thickness (set to 0):',sum(masktmp)
             endif
 
             ! Note how many cells have ice.
@@ -424,7 +424,7 @@ module li_time_integration_fe
             where (thicknessNew > 0.0_RKIND)
                masktmp = 1
             end where
-            write(6,*) '  Cells with nonzero thickness:', sum(masktmp)
+            write(stdoutUnit,*) '  Cells with nonzero thickness:', sum(masktmp)
          endif
          deallocate(masktmp)
 
@@ -453,7 +453,7 @@ module li_time_integration_fe
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in update_prognostics."
+          write (stderrUnit,*) "An error has occurred in update_prognostics."
       endif
 
 

--- a/src/core_landice/mpas_li_velocity.F
+++ b/src/core_landice/mpas_li_velocity.F
@@ -108,7 +108,7 @@ contains
 
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
 
-      write(*,*) 'Using ', trim(config_velocity_solver), ' dynamical core.'
+      write(stdoutUnit,*) 'Using ', trim(config_velocity_solver), ' dynamical core.'
       select case (config_velocity_solver)
       case ('none')
          ! Do nothing
@@ -117,13 +117,13 @@ contains
       case ('L1L2', 'FO', 'Stokes')
           call li_velocity_external_init(domain, err)
       case default
-          write(0,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
+          write(stderrUnit,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
           err = 1
       end select
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_init."
+          write (stderrUnit,*) "An error has occurred in li_velocity_init."
       endif
 
    !--------------------------------------------------------------------
@@ -186,14 +186,14 @@ contains
       case ('L1L2', 'FO', 'Stokes')
           call li_velocity_external_block_init(block, err)
       case default
-          write(*,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
+          write(stdoutUnit,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
           err = 1
           return
       end select
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_block_init."
+          write (stderrUnit,*) "An error has occurred in li_velocity_block_init."
       endif
 
    !--------------------------------------------------------------------
@@ -275,7 +275,7 @@ contains
       case ('L1L2', 'FO', 'Stokes')
           call li_velocity_external_solve(meshPool, statePool, timeLevel, err)
       case default
-          write(0,*) 'Error: ', trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
+          write(stderrUnit,*) 'Error: ', trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
           err = 1
           return
       end select
@@ -291,13 +291,13 @@ contains
          endif
       enddo
       if (err == 1) then
-         write(0,*) 'Error: Velocity has been calculated on non-dynamic edges.  There is a problem with the velocity solver.' !!!  Velocity on those edges have been set to 0, but this should be a fatal error.'
+         write(stderrUnit,*) 'Error: Velocity has been calculated on non-dynamic edges.  There is a problem with the velocity solver.' !!!  Velocity on those edges have been set to 0, but this should be a fatal error.'
          err = 1  ! a hack to let the code continue until this can be fixed in the velocity solver
       end if
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_solve."
+          write (stderrUnit,*) "An error has occurred in li_velocity_solve."
       endif
 
    !--------------------------------------------------------------------
@@ -360,14 +360,14 @@ contains
       case ('L1L2', 'FO', 'Stokes')
           call li_velocity_external_finalize(err)
       case default
-          write(*,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
+          write(stdoutUnit,*) trim(config_velocity_solver), ' is not a valid land ice velocity solver option.'
           err = 1
           return
       end select
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_finalize."
+          write (stderrUnit,*) "An error has occurred in li_velocity_finalize."
       endif
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mpas_li_velocity_external.F
+++ b/src/core_landice/mpas_li_velocity_external.F
@@ -115,12 +115,12 @@ contains
 
       ! Check for configuration options that are incompatible with external velocity solver conventions
       if (config_num_halos < 2) then
-         write(0,*) "Error: External velocity solvers require that config_num_halos >= 2"
+         write(stderrUnit,*) "Error: External velocity solvers require that config_num_halos >= 2"
          err_tmp = 1
       endif
       err = ior(err,err_tmp)
       if (config_number_of_blocks /= 0) then
-         write(0,*) "Error: External velocity solvers require that config_number_of_blocks=0"
+         write(stderrUnit,*) "Error: External velocity solvers require that config_number_of_blocks=0"
          err_tmp = 1
       endif
       err = ior(err,err_tmp)
@@ -133,7 +133,7 @@ contains
       call velocity_solver_init_mpi(domain % dminfo % comm)
 #else
       err = 1
-      write(0,*) "Error: To run with an external velocity solver you must compile MPAS with one."
+      write(stderrUnit,*) "Error: To run with an external velocity solver you must compile MPAS with one."
 #endif
 
 
@@ -141,7 +141,7 @@ contains
 #ifdef USE_EXTERNAL_STOKES
           call interface_phg_init(domain, err)
 #else
-          write(0,*) "Error: External Stokes library needed to run Stokes dycore."
+          write(stderrUnit,*) "Error: External Stokes library needed to run Stokes dycore."
           err = 1
           return
 #endif
@@ -151,7 +151,7 @@ contains
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_external_init."
+          write (stderrUnit,*) "An error has occurred in li_velocity_external_init."
       endif
 
    !--------------------------------------------------------------------
@@ -282,7 +282,7 @@ contains
               sendVerticesArray, recvVerticesArray)
       call mpas_timer_stop("velocity_solver_set_grid_data")
 #else
-      write(0,*) "Error: To run with an external velocity solver you must compile MPAS with one."
+      write(stderrUnit,*) "Error: To run with an external velocity solver you must compile MPAS with one."
       err = 1
 #endif
 
@@ -296,7 +296,7 @@ contains
 
       ! === error check
       if (err > 0) then
-          write (0,*) "An error has occurred in li_velocity_external_block_init."
+          write (stderrUnit,*) "An error has occurred in li_velocity_external_block_init."
       endif
 
    !--------------------------------------------------------------------
@@ -411,7 +411,7 @@ contains
           call velocity_solver_compute_2d_grid(vertexMask, dirichletVelocityMask, floatingEdges)
           call mpas_timer_stop("velocity_solver_compute_2d_grid")
 #else
-          write(0,*) "Error: To run with an external velocity solver you must compile MPAS with one."
+          write(stderrUnit,*) "Error: To run with an external velocity solver you must compile MPAS with one."
           err = 1
           return
 #endif
@@ -424,7 +424,7 @@ contains
               call velocity_solver_init_L1L2(layerThicknessFractions)
               call mpas_timer_stop("velocity_solver_init_L1L2")
 #else
-              write(0,*) "Error: External LifeV library needed to run L1L2 dycore."
+              write(stderrUnit,*) "Error: External LifeV library needed to run L1L2 dycore."
               err = 1
               return
 #endif
@@ -438,7 +438,7 @@ contains
               call velocity_solver_init_FO(layerThicknessFractions)
               call mpas_timer_stop("velocity_solver_init_FO")
 #else
-              write(0,*) "Error: External library needed to run FO dycore."
+              write(stderrUnit,*) "Error: External library needed to run FO dycore."
               err = 1
               return
 #endif
@@ -452,7 +452,7 @@ contains
               call velocity_solver_init_stokes(layerThicknessFractions)
               call mpas_timer_stop("velocity_solver_init_stokes")
 #else
-              write(0,*) "Error: External Stokes library needed to run stokes dycore."
+              write(stderrUnit,*) "Error: External Stokes library needed to run stokes dycore."
               err = 1
               return
 #endif
@@ -479,7 +479,7 @@ contains
           call velocity_solver_export_L1L2_velocity();
           call mpas_timer_stop("velocity_solver export")
 #else
-              write(0,*) "Error: External LifeV library needed to run L1L2 dycore."
+              write(stderrUnit,*) "Error: External LifeV library needed to run L1L2 dycore."
               err = 1
               return
 #endif
@@ -496,7 +496,7 @@ contains
           call velocity_solver_export_FO_velocity()
           call mpas_timer_stop("velocity_solver export")
 #else
-              write(0,*) "Error: External library needed to run FO dycore."
+              write(stderrUnit,*) "Error: External library needed to run FO dycore."
               err = 1
               return
 #endif
@@ -510,7 +510,7 @@ contains
           uReconstructZ = uReconstructZ / (365.0*24.0*3600.0)  ! convert from m/yr to m/s
           call mpas_timer_stop("velocity_solver_solve_stokes")
 #else
-          write(0,*) "Error: External Stokes library needed to run stokes dycore."
+          write(stderrUnit,*) "Error: External Stokes library needed to run stokes dycore."
           err = 1
           return
 #endif
@@ -574,7 +574,7 @@ contains
       ! This call is needed for using any of the external velocity solvers
       call velocity_solver_finalize()
 #else
-      write(0,*) "Error: To run with an external velocity solver you must compile MPAS with one."
+      write(stderrUnit,*) "Error: To run with an external velocity solver you must compile MPAS with one."
       err = 1
       return
 #endif
@@ -639,7 +639,7 @@ contains
       ! This call is needed for using any of the PHG velocity solvers
       call phg_init(domain % dminfo % comm)
 #else
-      write(0,*) "Error: External Stokes library needed to run stokes dycore."
+      write(stderrUnit,*) "Error: External Stokes library needed to run stokes dycore."
       err = 1
       return
 #endif


### PR DESCRIPTION
This replaces the 6 or 0 unit numbers in write statements with the stdoutUnit and stderrUnit variables defined by framework.
