### PR TITLE
Fix bug when including both a var_struct and another mutable stream inside a mutable stream.

### DIFF
--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1436,7 +1436,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 						}
 					}
 
-					for (varstruct_xml = ezxml_child(stream_xml, "var_struct"); varstruct_xml; varstruct_xml = ezxml_next(varstruct_xml)) {
+					for (varstruct_xml = ezxml_child(streammatch_xml, "var_struct"); varstruct_xml; varstruct_xml = ezxml_next(varstruct_xml)) {
 						structname_const = ezxml_attr(varstruct_xml, "name");
 						stream_mgr_add_pool_c(manager, streamID, structname_const, &err);
 						if (err != 0){


### PR DESCRIPTION
This merge corrects a bug when a mutable stream includes both a var_struct and another mutable stream.

The logic to add the contents of a mutable stream "B" to another mutable stream "A" iterated
over the wrong xml node when checking for var_struct members of "B", causing any var_structs
included in "A" to be added twice.
