### PR TITLE
Fix build error when including a var_struct in an immutable stream.

### DIFF
--- a/src/registry/gen_inc.c
+++ b/src/registry/gen_inc.c
@@ -2181,7 +2181,8 @@ int generate_immutable_streams(ezxml_t registry){/*{{{*/
 	fortprintf(fd, "subroutine mpas%ssetup_immutable_streams(manager)\n\n", core_string);
 	fortprintf(fd, "   use MPAS_stream_manager, only : MPAS_streamManager_type, MPAS_STREAM_INPUT_OUTPUT, MPAS_STREAM_INPUT, &\n");
 	fortprintf(fd, "                                   MPAS_STREAM_OUTPUT, MPAS_STREAM_NONE, MPAS_STREAM_PROPERTY_IMMUTABLE, &\n");
-	fortprintf(fd, "                                   MPAS_stream_mgr_create_stream, MPAS_stream_mgr_add_field, MPAS_stream_mgr_set_property\n\n");
+	fortprintf(fd, "                                   MPAS_stream_mgr_create_stream, MPAS_stream_mgr_add_field, &\n");
+	fortprintf(fd, "                                   MPAS_stream_mgr_add_pool, MPAS_stream_mgr_set_property\n\n");
 	fortprintf(fd, "   implicit none\n\n");
 	fortprintf(fd, "   type (MPAS_streamManager_type), pointer :: manager\n\n");
 	fortprintf(fd, "   integer :: ierr\n\n");


### PR DESCRIPTION
This merge corrects a bulid error that arises when an immutable stream includes a var_struct.

The registry-generated subroutine mpas_setup_immutable_streams() wasn't importing
the MPAS_stream_mgr_add_pool() routine from MPAS_stream_manager, causing build
failures when an immutable stream included a var_struct.
