### PR TITLE
Fix calculation of dt in seconds for long time steps (>~60yr)

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1357,7 +1357,8 @@ module mpas_timekeeping
       end if
 
       if (present(dt)) then
-         dt = (days * 24 * 60 * 60) + seconds + (sn / sd)
+         dt = (real(days, RKIND) * 24.0_RKIND * 60.0_RKIND * 60.0_RKIND) + &
+              real(seconds, RKIND) + (real(sn, RKIND) / real(sd, RKIND))
       end if
 
       if (present(DD)) then


### PR DESCRIPTION
Calculating the dt in seconds in mpas_get_timeInterval() can cause weird
behavior (e.g., negative dt) when time steps are very large due to
single precision integer overflow.  This change performs that
conversion using RKIND reals.

For example, in the LI core with a 100 year time step (dome test case), before this commit adding print statements to mpas_get_interval reveals a negative dt:

```
 days,secs,sn,sd       36500                    0           0           1
 dt,  -1141367296.0000000
```

After this commit, the calculation is as expected:

```
 days,secs,sn,sd       36500                    0           0           1
 dt,   3153600000.0000000
```
