### PR TITLE
Fixing an issue with mpas_decomp that prevents building on macs

### DIFF
--- a/src/framework/mpas_decomp.F
+++ b/src/framework/mpas_decomp.F
@@ -35,7 +35,7 @@ module mpas_decomp
                          MPAS_DECOMP_ERROR = 1001
 
    abstract interface
-      function mpas_decomp_function(block, manager, globalDimSize, numBlocks) result(ownedIndices)
+      function mpas_decomp_function(block, manager, globalDimSize, numBlocks, ownedIndices) result(iErr)
          use mpas_grid_types
          use mpas_stream_manager
 
@@ -44,6 +44,7 @@ module mpas_decomp
          integer, intent(in) :: globalDimSize
          integer, intent(in) :: numBlocks
          integer, dimension(:), pointer :: ownedIndices
+         integer :: iErr
       end function
    end interface
 
@@ -272,13 +273,15 @@ module mpas_decomp
 !>  This function provides the owned indices for a uniform decomposition method.
 !
 !-----------------------------------------------------------------------
-   function mpas_uniform_decomp(block, manager, globalDimSize, numBlocks) result(ownedIndices)!{{{
+   function mpas_uniform_decomp(block, manager, globalDimSize, numBlocks, ownedIndices) result(iErr)!{{{
       type (block_type), intent(in) :: block
       type (mpas_streamManager_type), intent(inout) :: manager
       integer, intent(in) :: globalDimSize
       integer, intent(in) :: numBlocks
 
       integer, dimension(:), pointer :: ownedIndices
+
+      integer :: iErr
 
       integer :: blockDimSize, blockStart, i
 

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -833,7 +833,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 	fortprintf(fd, "      use mpas_grid_types\n");
 	fortprintf(fd, "      use mpas_decomp\n");
 	fortprintf(fd, "\n");
-	fortprintf(fd, "      type (block_type), intent(in) :: block !< Input: Pointer to block\n");
+	fortprintf(fd, "      type (block_type), intent(inout) :: block !< Input: Pointer to block\n");
 	fortprintf(fd, "      type (mpas_streamManager_type), intent(inout) :: manager !< Input: Stream manager\n");
 	fortprintf(fd, "      type (mpas_pool_type), intent(inout) :: readDimensions !< Input: Pool to pull read dimensions from\n");
 	fortprintf(fd, "      type (mpas_pool_type), intent(inout) :: dimensionPool !< Input/Output: Pool to add dimensions into\n");
@@ -885,7 +885,7 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				fortprintf(fd, "         ownedIndices %% defaultValue = 0\n");
 				fortprintf(fd, "         ownedIndices %% fieldName = '%sOwnedIndices'\n", dimname);
 				fortprintf(fd, "         ownedIndices %% dimNames(1) = '%s'\n", dimname);
-				fortprintf(fd, "         ownedIndices %% array => decompFunc(block, manager, %s, totalBlocks)\n", dimname);
+				fortprintf(fd, "         iErr = decompFunc(block, manager, %s, totalBlocks, ownedIndices %% array)\n", dimname);
 				fortprintf(fd, "         ownedIndices %% dimSizes(1) = size(ownedIndices %% array, dim=1)\n");
 				fortprintf(fd, "         call mpas_pool_add_field(block %% allFields, '%sOwnedIndices', ownedIndices)\n", dimname);
 				fortprintf(fd, "         call mpas_pool_get_dimension(block %% dimensions, '%s', %s)\n", dimname, dimname);


### PR DESCRIPTION
This merge changes the abstract interface for a decomposition method.
Previously the result frmo the decomposition method function was the
owned indicies array pointer, but gfortran built on macs using macports
(it's unclear if all of these are needed or not) fails to build the old
version.

The new abstract interface changes ownedIndices to be in the input
argument list, and changes the output result to be the iErr flag. Other
than that, the decomposition methods work the same as they did before.
