### PR TITLE
Address two issues when creating files with MPAS_io_open() and no-clobber

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -366,7 +366,10 @@ module mpas_io
 
       if (mode == MPAS_IO_WRITE) then
 !write(stderrUnit,*) 'MGD PIO_createfile'
-         inquire(file=trim(filename), exist=exists)
+         if (local_dminfo % my_proc_id == 0) then
+            inquire(file=trim(filename), exist=exists)
+         end if
+         call mpas_dmpar_bcast_logical(local_dminfo, exists)
 
          ! If the file exists and we are not allowed to clobber it, return an
          !    appropriate error code


### PR DESCRIPTION
This merge corrects two issues that arise when creating output files with MPAS_io_open() with the "no-clobber" option.

1) Return from MPAS_io_open() as soon as a clobber error is detected.

This commit simply adds a return statement immediately after the return error
code is set to MPAS_IO_ERR_WOULD_CLOBBER in MPAS_io_open(). Previously, we did
not return once a clobber error condition was detected, leading to a subsequent
call to PIO_openfile(), and an eventual exit of MPAS_io_open() with the error
code MPAS_IO_ERR_WOULD_CLOBBER. Ultimately, the open filehandle created by
the erroneous call to PIO_openfile() was never closed, and this could lead to
bad exit codes from MPAS itself with certain compilers and I/O libraries
(e.g., ifort 15.0.1 and NetCDF-4 4.3.2 with HDF5 support).

2) Fix race condition in MPAS_io_open() when creating new output files with "no clobber" option.

When creating a new output file with clobber_file=.false. (the default if not specified),
it can occasionally happen that the previously non-existent output file is created by
the call to PIO_createfile() on one or more tasks before other tasks have reached the point
of inquiring whether the output file exists. In such cases, the laggardly tasks detect that
the file exists and return early, causing the MPAS job to hang since not all tasks
participate in subsequent collective I/O calls.

The root cause of this issue appears to be the behavior of some iotype options, which
create output files before all MPI tasks have entered the call to create the file.
