### PR TITLE
Improve numerical accuracy of computation of spherical angles in mpas_atm_advection.F

### DIFF
--- a/src/core_init_atmosphere/mpas_atm_advection.F
+++ b/src/core_init_atmosphere/mpas_atm_advection.F
@@ -432,9 +432,9 @@ module atm_advection
       real (kind=RKIND) :: s                ! Semiperimeter of the triangle
       real (kind=RKIND) :: sin_angle
    
-      a = acos(max(min(bx*cx + by*cy + bz*cz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (3)
-      b = acos(max(min(ax*cx + ay*cy + az*cz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (2)
-      c = acos(max(min(ax*bx + ay*by + az*bz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (1)
+      a = arc_length(bx, by, bz, cx, cy, cz)
+      b = arc_length(ax, ay, az, cx, cy, cz)
+      c = arc_length(ax, ay, az, bx, by, bz)
    
       ABx = bx - ax
       ABy = by - ay


### PR DESCRIPTION
Improve numerical accuracy of computation of spherical angles in mpas_atm_advection.F

This computation involves the semi-perimeter of the triangle formed by the two spherical
arcs. Previously, we computed the edge lengths of this triangle using a dot product, which
proves to be too inaccurate in single-precision (sometimes returning zero length) when
the points defining the triangle are very close together.

This inaccurate arc length computation has been replaced by a more accurate one, namely,
the method used in the arc_length function.
