### PR TITLE
Always return a value in integer functions 'generate_namelist' and 'generate_streams'

### DIFF
--- a/src/input_gen/namelist_gen.c
+++ b/src/input_gen/namelist_gen.c
@@ -128,7 +128,7 @@ int generate_namelist(ezxml_t registry, FILE* fd, int pairs, char **keys, char *
 		}
 	}
 
-
+	return 0;
 }/*}}}*/
 
 char* get_option_value(ezxml_t nml_option, int pairs, char **values){/*{{{*/

--- a/src/input_gen/streams_gen.c
+++ b/src/input_gen/streams_gen.c
@@ -256,6 +256,8 @@ int generate_streams(ezxml_t registry, FILE* fd, char *stream_file_prefix, int p
 		}
 	}
 	fprintf(fd, "</streams>\n");
+
+	return 0;
 }/*}}}*/
 
 void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/


### PR DESCRIPTION
This merge nsure that integer functions 'generate_namelist' and 'generate_streams' always return a value.

The lack of an unconditional return value caused some compilers to generate warnings.
