### PR TITLE
Set return value in function mpas_uniform_decomp.

### DIFF
--- a/src/framework/mpas_decomp.F
+++ b/src/framework/mpas_decomp.F
@@ -285,6 +285,8 @@ module mpas_decomp
 
       integer :: blockDimSize, blockStart, i
 
+      iErr = 0
+
       DECOMP_DEBUG_WRITE('* Providing a uniform decomposition')
 
       blockDimSize = globalDimSize / numBlocks


### PR DESCRIPTION
This merge sets the return value in the mpas_uniform_decomp decomposition function.

The return value iErr was otherwise not set, causing warnings when building with some compilers.
