### PR TITLE
Remove the deprecated 'ioinfo' member from field types.

### DIFF
--- a/src/framework/duplicate_field_array.inc
+++ b/src/framework/duplicate_field_array.inc
@@ -32,8 +32,6 @@
          ! Fill in members of dst_cursor from src_cursor
          !
          if (.not. local_copy_only) then
-            allocate(dst_cursor % ioinfo)
-            dst_cursor % ioinfo = src_cursor % ioinfo
             dst_cursor % block => src_cursor % block
             dst_cursor % fieldName = src_cursor % fieldName
             dst_cursor % isVarArray = src_cursor % isVarArray

--- a/src/framework/duplicate_field_scalar.inc
+++ b/src/framework/duplicate_field_scalar.inc
@@ -32,8 +32,6 @@
          ! Fill in members of dst_cursor from src_cursor
          !
          if (.not. local_copy_only) then
-            allocate(dst_cursor % ioinfo)
-            dst_cursor % ioinfo = src_cursor % ioinfo
             dst_cursor % block => src_cursor % block
             dst_cursor % fieldName = src_cursor % fieldName
             dst_cursor % isVarArray = src_cursor % isVarArray

--- a/src/framework/mpas_block_creator.F
+++ b/src/framework/mpas_block_creator.F
@@ -87,7 +87,6 @@ module mpas_block_creator
        ! Link to block, and setup array size
        fieldCursor % block => blockCursor
        fieldCursor % dimSizes(1) = blockCount(i)
-       nullify(fieldCursor % ioinfo)
  
        ! Initialize exchange lists
        call mpas_dmpar_init_multihalo_exchange_list(fieldCursor % sendList, nHalos)
@@ -190,12 +189,6 @@ module mpas_block_creator
        cellsOnCellCursor % block => indexCursor % block
        verticesOnCellCursor % block => indexCursor % block
        edgesOnCellCursor % block => indexCursor % block
-
-       ! Nullify ioinfo, since this data is not read in
-       nullify(nEdgesCursor % ioinfo)
-       nullify(cellsOnCellCursor % ioinfo)
-       nullify(verticesOnCellCursor % ioinfo)
-       nullify(edgesOnCellCursor % ioinfo)
 
        ! Setup array sizes
        nEdgesCursor % dimSizes(1) = nCellsInBlock
@@ -323,14 +316,12 @@ module mpas_block_creator
 
        ! Setup indexToEdge block
        indexToEdgeCursor % block => indexToCellCursor % block
-       nullify(indexToEdgeCursor % ioinfo)
        indexToEdgeCursor % dimSizes(1) = nEdgesLocal
        allocate(indexToEdgeCursor % array(indexToEdgeCursor % dimSizes(1)))
        indexToEdgeCursor % array(:) = localEdgeList(:)
 
        ! Setup cellsOnEdge block
        cellsOnEdgeCursor % block => indexToCellCursor % block
-       nullify(cellsOnEdgeCursor % ioinfo)
        cellsOnEdgeCursor % dimSizes(1) = edgeDegree
        cellsOnEdgeCursor % dimSizes(2) = nEdgesLocal
        allocate(cellsOnEdgeCursor % array(cellsOnEdgeCursor % dimSizes(1), cellsOnEdgeCursor % dimSizes(2)))
@@ -403,12 +394,6 @@ module mpas_block_creator
        offSetCursor % block => indexToEdgeCursor % block
        edgeLimitCursor % block => indexToEdgeCursor % block
        nEdgesSolveCursor % block => indexToEdgeCursor % block
-
-       ! Nullify io info
-       nullify(haloCursor % ioinfo)
-       nullify(offSetCursor % ioinfo)
-       nullify(edgeLimitCursor % ioinfo)
-       nullify(nEdgesSolveCursor % ioinfo)
 
        ! Setup haloIndices
        haloCursor % dimSizes(1) = indexToEdgeCursor % dimSizes(1) - (haloStart-1)
@@ -532,19 +517,16 @@ module mpas_block_creator
        ! Setup offset
        offSetCursor % scalar = indexCursor % dimSizes(1)
        offSetCursor % block => indexCursor % block
-       nullify(offSetCursor % ioinfo)
 
        ! Setup nCellsSolve
        nCellsSolveCursor % dimSizes(1) = nHalos+1
        allocate(nCellsSolveCursor % array(nCellsSolveCursor % dimSizes(1)))
        nCellsSolveCursor % array(1) = indexCursor % dimSizes(1)
        nCellsSolveCursor % block => indexCursor % block
-       nullify(nCellsSolveCursor % ioinfo)
 
        ! Setup owned cellLimit
        cellLimitCursor % scalar = indexCursor % dimSizes(1)
        cellLimitCursor % block => indexCursor % block
-       nullify(cellLimitCursor % ioinfo)
 
        ! Advance cursors and create new blocks if needed
        indexCursor => indexCursor % next
@@ -621,7 +603,6 @@ module mpas_block_creator
          haloCursor % recvList => indexCursor % recvList
          haloCursor % copyList => indexCursor % copyList
          haloCursor % block => indexCursor % block
-         nullify(haloCursor % ioinfo)
 
          ! Deallocate block graphs
          deallocate(blockGraphWithHalo % vertexID)
@@ -811,11 +792,6 @@ module mpas_block_creator
        edgeLimitCursor % block => indexToEdgeCursor % block
        offSetCursor % block => indexToEdgeCursor % block
        haloCursor % block => indexToEdgeCursor % block
-
-       ! Nullify ioinfo
-       nullify(edgeLimitCursor % ioinfo)
-       nullify(offSetCursor % ioinfo)
-       nullify(haloCursor % ioinfo)
 
        ! Link exchange lists
        haloCursor % sendList => indexToEdgeCursor % sendList
@@ -1071,7 +1047,6 @@ module mpas_block_creator
        indexToCellIDPoolField % isPersistent = .true.
        nullify(indexToCellIDPoolField % next)
        nullify(indexToCellIDPoolField % prev)
-       nullify(indexToCellIDPoolField % ioinfo)
        nullify(indexToCellIDPoolField % sendList)
        nullify(indexToCellIDPoolField % recvList)
        nullify(indexToCellIDPoolField % copyList)
@@ -1090,7 +1065,6 @@ module mpas_block_creator
        indexToEdgeIDPoolField % isPersistent = .true.
        nullify(indexToEdgeIDPoolField % next)
        nullify(indexToEdgeIDPoolField % prev)
-       nullify(indexToEdgeIDPoolField % ioinfo)
        nullify(indexToEdgeIDPoolField % sendList)
        nullify(indexToEdgeIDPoolField % recvList)
        nullify(indexToEdgeIDPoolField % copyList)
@@ -1110,7 +1084,6 @@ module mpas_block_creator
        indexToVertexIDPoolField % isPersistent = .true.
        nullify(indexToVertexIDPoolField % next)
        nullify(indexToVertexIDPoolField % prev)
-       nullify(indexToVertexIDPoolField % ioinfo)
        nullify(indexToVertexIDPoolField % sendList)
        nullify(indexToVertexIDPoolField % recvList)
        nullify(indexToVertexIDPoolField % copyList)

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -519,10 +519,6 @@ module mpas_bootstrapping
 
      ! Global cell indices
      allocate(indexToCellID)
-     allocate(indexToCellID % ioinfo)
-     indexToCellID % ioinfo % fieldName = 'indexToCellID'
-     indexToCellID % ioinfo % start(1) = readCellStart
-     indexToCellID % ioinfo % count(1) = nReadCells
      allocate(indexToCellID % array(nReadCells))
      allocate(readIndices(nReadCells))
      do i=1,nReadCells
@@ -541,10 +537,6 @@ module mpas_bootstrapping
 
      ! Number of cell/edges/vertices adjacent to each cell
      allocate(nEdgesOnCell)
-     allocate(nEdgesOnCell % ioinfo)
-     nEdgesOnCell % ioinfo % fieldName = 'nEdgesOnCell'
-     nEdgesOnCell % ioinfo % start(1) = readCellStart
-     nEdgesOnCell % ioinfo % count(1) = nReadCells
      allocate(nEdgesOnCell % array(nReadCells))
      call MPAS_io_inq_var(inputHandle, 'nEdgesOnCell', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'nEdgesOnCell', readIndices, ierr=ierr)
@@ -558,12 +550,6 @@ module mpas_bootstrapping
 
      ! Global indices of cells adjacent to each cell
      allocate(cellsOnCell)
-     allocate(cellsOnCell % ioinfo)
-     cellsOnCell % ioinfo % fieldName = 'cellsOnCell'
-     cellsOnCell % ioinfo % start(1) = 1
-     cellsOnCell % ioinfo % start(2) = readCellStart
-     cellsOnCell % ioinfo % count(1) = maxEdges
-     cellsOnCell % ioinfo % count(2) = nReadCells
      allocate(cellsOnCell % array(maxEdges,nReadCells))
      call MPAS_io_inq_var(inputHandle, 'cellsOnCell', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'cellsOnCell', readIndices, ierr=ierr)
@@ -578,12 +564,6 @@ module mpas_bootstrapping
 
      ! Global indices of edges adjacent to each cell
      allocate(edgesOnCell)
-     allocate(edgesOnCell % ioinfo)
-     edgesOnCell % ioinfo % fieldName = 'edgesOnCell'
-     edgesOnCell % ioinfo % start(1) = 1
-     edgesOnCell % ioinfo % start(2) = readCellStart
-     edgesOnCell % ioinfo % count(1) = maxEdges
-     edgesOnCell % ioinfo % count(2) = nReadCells
      allocate(edgesOnCell % array(maxEdges,nReadCells))
      call MPAS_io_inq_var(inputHandle, 'edgesOnCell', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'edgesOnCell', readIndices, ierr=ierr)
@@ -598,12 +578,6 @@ module mpas_bootstrapping
 
      ! Global indices of vertices adjacent to each cell
      allocate(verticesOnCell)
-     allocate(verticesOnCell % ioinfo)
-     verticesOnCell % ioinfo % fieldName = 'verticesOnCell'
-     verticesOnCell % ioinfo % start(1) = 1
-     verticesOnCell % ioinfo % start(2) = readCellStart
-     verticesOnCell % ioinfo % count(1) = maxEdges
-     verticesOnCell % ioinfo % count(2) = nReadCells
      allocate(verticesOnCell % array(maxEdges,nReadCells))
      call MPAS_io_inq_var(inputHandle, 'verticesOnCell', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'verticesOnCell', readIndices, ierr=ierr)
@@ -649,10 +623,6 @@ module mpas_bootstrapping
 
      ! Global edge indices
      allocate(indexToEdgeID)
-     allocate(indexToEdgeID % ioinfo)
-     indexToEdgeID % ioinfo % fieldName = 'indexToEdgeID'
-     indexToEdgeID % ioinfo % start(1) = readEdgeStart
-     indexToEdgeID % ioinfo % count(1) = nReadEdges
      allocate(indexToEdgeID % array(nReadEdges))
      allocate(indexToEdgeID % array(nReadEdges))
      do i=1,nReadEdges
@@ -673,12 +643,6 @@ module mpas_bootstrapping
      !    used for determining which edges are owned by a block, where
      !    iEdge is owned iff cellsOnEdge(1,iEdge) is an owned cell
      allocate(cellsOnEdge)
-     allocate(cellsOnEdge % ioinfo)
-     cellsOnEdge % ioinfo % fieldName = 'cellsOnEdge'
-     cellsOnEdge % ioinfo % start(1) = 1
-     cellsOnEdge % ioinfo % start(2) = readEdgeStart
-     cellsOnEdge % ioinfo % count(1) = 2
-     cellsOnEdge % ioinfo % count(2) = nReadEdges
      allocate(cellsOnEdge % array(2,nReadEdges))
      call MPAS_io_inq_var(inputHandle, 'cellsOnEdge', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'cellsOnEdge', readIndices, ierr=ierr)
@@ -718,10 +682,6 @@ module mpas_bootstrapping
 
      ! Global vertex indices
      allocate(indexToVertexID)
-     allocate(indexToVertexID % ioinfo)
-     indexToVertexID % ioinfo % fieldName = 'indexToVertexID'
-     indexToVertexID % ioinfo % start(1) = readVertexStart
-     indexToVertexID % ioinfo % count(1) = nReadVertices
      allocate(indexToVertexID % array(nReadVertices))
      allocate(readIndices(nReadVertices))
      do i=1,nReadVertices
@@ -742,12 +702,6 @@ module mpas_bootstrapping
      !    used for determining which vertices are owned by a block, where
      !    iVtx is owned iff cellsOnVertex(1,iVtx) is an owned cell
      allocate(cellsOnVertex)
-     allocate(cellsOnVertex % ioinfo)
-     cellsOnVertex % ioinfo % fieldName = 'cellsOnVertex'
-     cellsOnVertex % ioinfo % start(1) = 1
-     cellsOnVertex % ioinfo % start(2) = readVertexStart
-     cellsOnVertex % ioinfo % count(1) = vertexDegree
-     cellsOnVertex % ioinfo % count(2) = nReadVertices
      allocate(cellsOnVertex % array(vertexDegree,nReadVertices))
      call MPAS_io_inq_var(inputHandle, 'cellsOnVertex', ierr=ierr)
      call MPAS_io_set_var_indices(inputHandle, 'cellsOnVertex', readIndices, ierr=ierr)

--- a/src/framework/mpas_field_routines.F
+++ b/src/framework/mpas_field_routines.F
@@ -932,10 +932,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          deallocate(f_cursor)
          f_cursor => f
        end do
@@ -967,10 +963,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          deallocate(f_cursor)
          f_cursor => f
        end do
@@ -999,10 +991,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then
@@ -1040,10 +1028,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          if(associated(f_cursor % array)) then
            deallocate(f_cursor % array)
          end if
@@ -1077,10 +1061,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then
@@ -1119,10 +1099,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          deallocate(f_cursor)
 
          f_cursor => f
@@ -1152,10 +1128,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then
@@ -1193,10 +1165,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          if(associated(f_cursor % array)) then
            deallocate(f_cursor % array)
          end if
@@ -1230,10 +1198,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then
@@ -1271,10 +1235,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          if(associated(f_cursor % array)) then
            deallocate(f_cursor % array)
          end if
@@ -1308,10 +1268,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then
@@ -1350,10 +1306,6 @@ module mpas_field_routines
            nullify(f)
          end if
 
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
-         end if
-
          deallocate(f_cursor)
          f_cursor => f
        end do
@@ -1382,10 +1334,6 @@ module mpas_field_routines
            f => f % next
          else
            nullify(f)
-         end if
-
-         if(associated(f_cursor % ioinfo)) then
-           deallocate(f_cursor % ioinfo)
          end if
 
          if(associated(f_cursor % array)) then

--- a/src/framework/mpas_field_types.inc
+++ b/src/framework/mpas_field_types.inc
@@ -6,19 +6,6 @@
                          MPAS_DECOMP_EDGES     = 1015, &
                          MPAS_DECOMP_VERTICES  = 1016
 
-   ! Derived type describing info for doing I/O specific to a field
-   type io_info
-      character (len=StrKIND) :: fieldName
-      character (len=StrKIND) :: units
-      character (len=StrKIND) :: description
-      integer, dimension(4) :: start
-      integer, dimension(4) :: count
-      logical :: input
-      logical :: sfc
-      logical :: restart
-      logical :: output
-   end type io_info
-
    ! Derived type for storing fields
    type field5DReal
   
@@ -29,7 +16,6 @@
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(5) :: dimNames
@@ -62,7 +48,6 @@
       real (kind=RKIND), dimension(:,:,:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(4) :: dimNames
@@ -96,7 +81,6 @@
       real (kind=RKIND), dimension(:,:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
@@ -129,7 +113,6 @@
       real (kind=RKIND), dimension(:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
@@ -162,7 +145,6 @@
       real (kind=RKIND), dimension(:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
@@ -195,7 +177,6 @@
       real (kind=RKIND) :: scalar
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       real (kind=RKIND) :: defaultValue
@@ -225,7 +206,6 @@
       integer, dimension(:,:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
@@ -258,7 +238,6 @@
       integer, dimension(:,:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
@@ -291,7 +270,6 @@
       integer, dimension(:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
@@ -324,7 +302,6 @@
       integer :: scalar
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       integer :: defaultValue
@@ -354,7 +331,6 @@
       character (len=StrKIND), dimension(:), pointer :: array
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
@@ -387,7 +363,6 @@
       character (len=StrKIND) :: scalar
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND) :: defaultValue
@@ -417,7 +392,6 @@
       logical :: scalar
 
       ! Information used by the I/O layer
-      type (io_info), pointer :: ioinfo       ! to be removed later
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       logical :: defaultValue

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -236,132 +236,71 @@ module mpas_pool_routines
 
                ! Do this through brute force...
                if (associated(dptr % r0)) then
-                  if (associated(dptr % r0 % ioinfo)) then
-                     deallocate(dptr % r0 % ioinfo)
-                  end if
-
                   deallocate(dptr % r0)
                else if (associated(dptr % r1)) then
-                  if (associated(dptr % r1 % ioinfo)) then
-                     deallocate(dptr % r1 % ioinfo)
-                  end if
-
                   if (associated(dptr % r1 % array)) then
                      deallocate(dptr % r1 % array)
                   end if
 
                   deallocate(dptr % r1)
                else if (associated(dptr % r2)) then
-                  if (associated(dptr % r2 % ioinfo)) then
-                     deallocate(dptr % r2 % ioinfo)
-                  end if
-
                   if (associated(dptr % r2 % array)) then
                      deallocate(dptr % r2 % array)
                   end if
 
                   deallocate(dptr % r2)
                else if (associated(dptr % r3)) then
-                  if (associated(dptr % r3 % ioinfo)) then
-                     deallocate(dptr % r3 % ioinfo)
-                  end if
-
                   if (associated(dptr % r3 % array)) then
                      deallocate(dptr % r3 % array)
                   end if
 
                   deallocate(dptr % r3)
                else if (associated(dptr % r4)) then
-                  if (associated(dptr % r4 % ioinfo)) then
-                     deallocate(dptr % r4 % ioinfo)
-                  end if
-
                   if (associated(dptr % r4 % array)) then
                      deallocate(dptr % r4 % array)
                   end if
 
                   deallocate(dptr % r4)
                else if (associated(dptr % r5)) then
-                  if (associated(dptr % r5 % ioinfo)) then
-                     deallocate(dptr % r5 % ioinfo)
-                  end if
-
                   if (associated(dptr % r5 % array)) then
                      deallocate(dptr % r5 % array)
                   end if
 
                   deallocate(dptr % r5)
                else if (associated(dptr % i0)) then
-                  if (associated(dptr % i0 % ioinfo)) then
-                     deallocate(dptr % i0 % ioinfo)
-                  end if
-
                   deallocate(dptr % i0)
                else if (associated(dptr % i1)) then
-                  if (associated(dptr % i1 % ioinfo)) then
-                     deallocate(dptr % i1 % ioinfo)
-                  end if
-
                   if (associated(dptr % i1 % array)) then
                      deallocate(dptr % i1 % array)
                   end if
 
                   deallocate(dptr % i1)
                else if (associated(dptr % i2)) then
-                  if (associated(dptr % i2 % ioinfo)) then
-                     deallocate(dptr % i2 % ioinfo)
-                  end if
-
                   if (associated(dptr % i2 % array)) then
                      deallocate(dptr % i2 % array)
                   end if
 
                   deallocate(dptr % i2)
                else if (associated(dptr % i3)) then
-                  if (associated(dptr % i3 % ioinfo)) then
-                     deallocate(dptr % i3 % ioinfo)
-                  end if
-
                   if (associated(dptr % i3 % array)) then
                      deallocate(dptr % i3 % array)
                   end if
 
                   deallocate(dptr % i3)
                else if (associated(dptr % c0)) then
-                  if (associated(dptr % c0 % ioinfo)) then
-                     deallocate(dptr % c0 % ioinfo)
-                  end if
-
                   deallocate(dptr % c0)
                else if (associated(dptr % c1)) then
-                  if (associated(dptr % c1 % ioinfo)) then
-                     deallocate(dptr % c1 % ioinfo)
-                  end if
-
                   if (associated(dptr % c1 % array)) then
                      deallocate(dptr % c1 % array)
                   end if
 
                   deallocate(dptr % c1)
                else if (associated(dptr % l0)) then
-                  if (associated(dptr % l0 % ioinfo)) then
-                     deallocate(dptr % l0 % ioinfo)
-                  end if
-
                   deallocate(dptr % l0)
                else if (associated(dptr % r0a)) then
-                  do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r0a(j) % ioinfo)) then
-                        deallocate(dptr % r0a(j) % ioinfo)
-                     end if
-                  end do
                   deallocate(dptr % r0a)
                else if (associated(dptr % r1a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r1a(j) % ioinfo)) then
-                        deallocate(dptr % r1a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % r1a(j) % array)) then
                         deallocate(dptr % r1a(j) % array)
                      end if
@@ -369,10 +308,6 @@ module mpas_pool_routines
                   deallocate(dptr % r1a)
                else if (associated(dptr % r2a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r2a(j) % ioinfo)) then
-                        deallocate(dptr % r2a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % r2a(j) % array)) then
                         deallocate(dptr % r2a(j) % array)
                      end if
@@ -380,10 +315,6 @@ module mpas_pool_routines
                   deallocate(dptr % r2a)
                else if (associated(dptr % r3a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r3a(j) % ioinfo)) then
-                        deallocate(dptr % r3a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % r3a(j) % array)) then
                         deallocate(dptr % r3a(j) % array)
                      end if
@@ -391,10 +322,6 @@ module mpas_pool_routines
                   deallocate(dptr % r3a)
                else if (associated(dptr % r4a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r4a(j) % ioinfo)) then
-                        deallocate(dptr % r4a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % r4a(j) % array)) then
                         deallocate(dptr % r4a(j) % array)
                      end if
@@ -402,28 +329,15 @@ module mpas_pool_routines
                   deallocate(dptr % r4a)
                else if (associated(dptr % r5a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % r5a(j) % ioinfo)) then
-                        deallocate(dptr % r5a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % r5a(j) % array)) then
                         deallocate(dptr % r5a(j) % array)
                      end if
                   end do
                   deallocate(dptr % r5a)
                else if (associated(dptr % i0a)) then
-                  do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % i0a(j) % ioinfo)) then
-                        deallocate(dptr % i0a(j) % ioinfo)
-                     end if
-                  end do
                   deallocate(dptr % i0a)
                else if (associated(dptr % i1a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % i1a(j) % ioinfo)) then
-                        deallocate(dptr % i1a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % i1a(j) % array)) then
                         deallocate(dptr % i1a(j) % array)
                      end if
@@ -431,10 +345,6 @@ module mpas_pool_routines
                   deallocate(dptr % i1a)
                else if (associated(dptr % i2a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % i2a(j) % ioinfo)) then
-                        deallocate(dptr % i2a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % i2a(j) % array)) then
                         deallocate(dptr % i2a(j) % array)
                      end if
@@ -442,39 +352,21 @@ module mpas_pool_routines
                   deallocate(dptr % i2a)
                else if (associated(dptr % i3a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % i3a(j) % ioinfo)) then
-                        deallocate(dptr % i3a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % i3a(j) % array)) then
                         deallocate(dptr % i3a(j) % array)
                      end if
                   end do
                   deallocate(dptr % i3a)
                else if (associated(dptr % c0a)) then
-                  do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % c0a(j) % ioinfo)) then
-                        deallocate(dptr % c0a(j) % ioinfo)
-                     end if
-                  end do
                   deallocate(dptr % c0a)
                else if (associated(dptr % c1a)) then
                   do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % c1a(j) % ioinfo)) then
-                        deallocate(dptr % c1a(j) % ioinfo)
-                     end if
-
                      if (associated(dptr % c1a(j) % array)) then
                         deallocate(dptr % c1a(j) % array)
                      end if
                   end do
                   deallocate(dptr % c1a)
                else if (associated(dptr % l0a)) then
-                  do j=1,dptr % contentsTimeLevs
-                     if (associated(dptr % l0a(j) % ioinfo)) then
-                        deallocate(dptr % l0a(j) % ioinfo)
-                     end if
-                  end do
                   deallocate(dptr % l0a)
                else
                   call pool_mesg('While destroying pool, member '//trim(ptr % key)//' has no valid field pointers.')

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -4007,7 +4007,6 @@ module mpas_stream_manager
             call mpas_pool_get_dimension(indexToCellID % block % dimensions, 'vertexDegree', vertexDegree)
 
             if (associated(cellsOnCell)) then
-                nullify(cellsOnCell_ptr % ioinfo)
                 cellsOnCell_ptr % array => cellsOnCell % array
                 allocate(cellsOnCell % array(maxEdges, nCells+1))
 
@@ -4028,7 +4027,6 @@ module mpas_stream_manager
             end if
 
             if (associated(edgesOnCell)) then
-                nullify(edgesOnCell_ptr % ioinfo)
                 edgesOnCell_ptr % array => edgesOnCell % array
                 allocate(edgesOnCell % array(maxEdges, nCells+1))
 
@@ -4049,7 +4047,6 @@ module mpas_stream_manager
             end if
 
             if (associated(verticesOnCell)) then
-                nullify(verticesOnCell_ptr % ioinfo)
                 verticesOnCell_ptr % array => verticesOnCell % array
                 allocate(verticesOnCell % array(maxEdges, nCells+1))
 
@@ -4070,7 +4067,6 @@ module mpas_stream_manager
             end if
 
             if (associated(cellsOnEdge)) then
-                nullify(cellsOnEdge_ptr % ioinfo)
                 cellsOnEdge_ptr % array => cellsOnEdge % array
                 allocate(cellsOnEdge % array(2, nEdges+1))
 
@@ -4088,7 +4084,6 @@ module mpas_stream_manager
             end if
 
             if (associated(verticesOnEdge)) then
-                nullify(verticesOnEdge_ptr % ioinfo)
                 verticesOnEdge_ptr % array => verticesOnEdge % array
                 allocate(verticesOnEdge % array(2, nEdges+1))
 
@@ -4106,7 +4101,6 @@ module mpas_stream_manager
             end if
 
             if (associated(edgesOnEdge)) then
-                nullify(edgesOnEdge_ptr % ioinfo)
                 edgesOnEdge_ptr % array => edgesOnEdge % array
                 allocate(edgesOnEdge % array(maxEdges2, nEdges+1))
 
@@ -4127,7 +4121,6 @@ module mpas_stream_manager
             end if
 
             if (associated(cellsOnVertex)) then
-                nullify(cellsOnVertex_ptr % ioinfo)
                 cellsOnVertex_ptr % array => cellsOnVertex % array
                 allocate(cellsOnVertex % array(vertexDegree, nVertices+1))
 
@@ -4146,7 +4139,6 @@ module mpas_stream_manager
             end if
 
             if (associated(edgesOnVertex)) then
-                nullify(edgesOnVertex_ptr % ioinfo)
                 edgesOnVertex_ptr % array => edgesOnVertex % array
                 allocate(edgesOnVertex % array(vertexDegree, nVertices+1))
 

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -877,7 +877,6 @@ int parse_dimensions_from_registry(ezxml_t registry)/*{{{*/
 				fortprintf(fd, "         end if\n");
 				fortprintf(fd, "\n");
 				fortprintf(fd, "         allocate(ownedIndices)\n");
-				fortprintf(fd, "         nullify(ownedIndices %% ioinfo)\n");
 				fortprintf(fd, "         ownedIndices %% hasTimeDimension = .false.\n");
 				fortprintf(fd, "         ownedIndices %% isActive = .true.\n");
 				fortprintf(fd, "         ownedIndices %% isVarArray = .false.\n");
@@ -1168,7 +1167,6 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	for(time_lev = 1; time_lev <= time_levs; time_lev++){
 		fortprintf(fd, "! Defining time level %d\n", time_lev);
 		fortprintf(fd, "      allocate( %s(%d) %% constituentNames(numConstituents) )\n", pointer_name, time_lev);
-		fortprintf(fd, "      allocate(%s(%d) %% ioinfo)\n", pointer_name, time_lev);
 		fortprintf(fd, "      %s(%d) %% fieldName = '%s'\n", pointer_name, time_lev, vararrname);
 		if (decomp != -1) {
 			fortprintf(fd, "      %s(%d) %% isDecomposed = .true.\n", pointer_name, time_lev);
@@ -1365,7 +1363,6 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	for(time_lev = 1; time_lev <= time_levs; time_lev++){
 		fortprintf(fd, "\n");
 		fortprintf(fd, "! Setting up time level %d\n", time_lev);
-		fortprintf(fd, "      allocate(%s(%d) %% ioinfo)\n", pointer_name, time_lev);
 		fortprintf(fd, "      %s(%d) %% fieldName = '%s'\n", pointer_name, time_lev, varname);
 		fortprintf(fd, "      %s(%d) %% isVarArray = .false.\n", pointer_name, time_lev);
 		if (decomp != -1) {


### PR DESCRIPTION
This merge removes the deprecated 'ioinfo' member from all MPAS field types.

The 'ioinfo' member of field types was used before the introduction of run-time
configurable streams in MPAS. This member is no longer needed, and can be deleted,
along with the definition of the 'io_info' derived type.
