### PR TITLE
Adding a TOOL_TARGET_ARCH Build option

### DIFF
--- a/src/external/ezxml/Makefile
+++ b/src/external/ezxml/Makefile
@@ -2,7 +2,10 @@
 
 OBJS = ezxml.o
 
-all: $(OBJS)
+all: clean
+	$(MAKE) library
+
+library: $(OBJS)
 
 clean:
 	$(RM) *.o *.i

--- a/src/tools/input_gen/Makefile
+++ b/src/tools/input_gen/Makefile
@@ -7,7 +7,6 @@ ST_OBJS = streams_gen.o test_functions.o
 XML_OBJS = $(EZXML_PATH)/ezxml.o
 
 all: ezxml
-	($(MAKE) clean)
 	($(MAKE) namelist_gen CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 	($(MAKE) streams_gen CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 

--- a/src/tools/registry/Makefile
+++ b/src/tools/registry/Makefile
@@ -5,7 +5,6 @@ EZXML_PATH= ../../external/ezxml
 OBJS = parse.o dictionary.o gen_inc.o fortprintf.o utility.o
 
 all: ezxml parse
-	($(MAKE) clean)
 	($(MAKE) parse CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 
 ezxml:


### PR DESCRIPTION
This merge adds a TOOL_TARGET_ARCH build option allow the MPAS tools (registry, input_generators, etc) to be built using a special architecture dependent build flag.

Some machines (i.e. edison) generate executables that are not executable by login nodes by default. This change allows the tools to be built for the login nodes, followed by building the model for compute nodes with slightly different settings.
