### PR TITLE
Adding a CPP_DEF_FLAG makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,12 @@ else
 	override CPPFLAGS += -DMPAS_GIT_VERSION="unknown"
 endif # END OF GIT DESCRIBE VERSION
 
+ifneq "$(CPP_DEF_FLAG)" ""
+	override FFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(FFLAGS))
+	override CFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CFLAGS))
+	override CPPFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CPPFLAGS))
+endif
+
 ####################################################
 # Section for adding external libraries and includes
 ####################################################

--- a/src/Makefile.in.ACME
+++ b/src/Makefile.in.ACME
@@ -41,6 +41,11 @@ ifeq ($(DEBUG), TRUE)
     override CPPFLAGS += -DMPAS_DEBUG
 endif
 
+ifneq "$(CPP_DEF_FLAG)" ""
+	override FFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(FFLAGS))
+	override CFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CFLAGS))
+	override CPPFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CPPFLAGS))
+endif
 
 all:
 	@echo $(CPPINCLUDES)

--- a/src/Makefile.in.CESM
+++ b/src/Makefile.in.CESM
@@ -41,6 +41,11 @@ ifeq ($(DEBUG), TRUE)
     override CPPFLAGS += -DMPAS_DEBUG
 endif
 
+ifneq "$(CPP_DEF_FLAG)" ""
+	override FFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(FFLAGS))
+	override CFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CFLAGS))
+	override CPPFLAGS := $(patsubst -D%,$(CPP_DEF_FLAG)%,$(CPPFLAGS))
+endif
 
 all:
 	@echo $(CPPINCLUDES)


### PR DESCRIPTION
This merge adds a new makefile variable named CPP_DEF_FLAG which can be
used to override the -D flag used when pre-processing fortran files.

Some compilers (for example xlf) don't use -D to #define variables, and
instead use '-WF,-D'.

When building, the -D flag can be overridden using:
`make target CORE=core CPP_DEF_FLAG=-WF,-D`
