### PR TITLE
correct surface forcing

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1057,7 +1057,7 @@
 			<var name="surfaceThicknessFlux"/>
 			<var name="seaIceEnergy"/>
 			<var name="penetrativeTemperatureFlux"/>
-			<var name="transmissionCoefficients"/>
+			<var name="fractionAbsorbed"/>
 			<var name="windStressZonal"/>
 			<var name="windStressMeridional"/>
 			<var name="latentHeatFlux"/>
@@ -1903,7 +1903,7 @@
 		<var name="penetrativeTemperatureFlux" type="real" dimensions="nCells Time" units="^\circ C m s^{-1}"
 			 description="Penetrative temperature flux at the surface due to solar radiation. Positive is into the ocean."
 		/>
-		<var name="transmissionCoefficients" type="real" dimensions="nVertLevels nCells Time" units="percent"
+		<var name="fractionAbsorbed" type="real" dimensions="nVertLevels nCells Time" units="fractional"
 			 description="Divergence of transmission through interfaces of surface fluxes below the surface layer at cell centers. These are not applied to short wave."
 		/>
 

--- a/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
@@ -646,7 +646,7 @@ module mpas_core
            call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
            call ocn_forcing_build_arrays(meshPool, statePool, forcingPool, ierr, 1)
-           call ocn_forcing_build_transmission_array(meshPool, statePool, forcingpool, ierr, 1)
+           call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingpool, ierr, 1)
            block_ptr => block_ptr % next
          end do
 

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -46,7 +46,7 @@ module ocn_forcing
 
    public :: ocn_forcing_build_arrays, &
              ocn_forcing_init, &
-             ocn_forcing_build_transmission_array, &
+             ocn_forcing_build_fraction_absorbed_array, &
              ocn_forcing_transmission
 
    !--------------------------------------------------------------------
@@ -205,18 +205,18 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_forcing_build_transmission_array
+!  routine ocn_forcing_build_fraction_absorbed_array
 !
-!> \brief   Transmission coefficient array for surface forcing.
+!> \brief   fraction absorbed coefficient array for surface forcing.
 !> \author  Doug Jacobsen
 !> \date    10/03/2013
 !> \details 
-!>  This subroutine builds the transmission coefficient array for use in
+!>  This subroutine builds the fractionAbsorbed coefficient array for use in
 !>  applying surface fluxes deeper than the surface layer.
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_forcing_build_transmission_array(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
+    subroutine ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
         type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
         type (mpas_pool_type), intent(in) :: statePool !< Input: State information
         type (mpas_pool_type), intent(inout) :: forcingPool !< Input/Output: Forcing information
@@ -231,7 +231,7 @@ contains
 
         real (kind=RKIND) :: zTop, zBot, transmissionCoeffTop, transmissionCoeffBot
 
-        real (kind=RKIND), dimension(:,:), pointer :: layerThickness, transmissionCoefficients
+        real (kind=RKIND), dimension(:,:), pointer :: layerThickness, fractionAbsorbed
 
         integer :: iCell, k, timeLevel
         integer, pointer :: nCells
@@ -252,7 +252,7 @@ contains
 
         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
-        call mpas_pool_get_array(forcingPool, 'transmissionCoefficients', transmissionCoefficients)
+        call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
 
         do iCell = 1, nCells
            zTop = 0.0_RKIND
@@ -261,14 +261,14 @@ contains
               zBot = zTop - layerThickness(k,iCell)
               transmissionCoeffBot = ocn_forcing_transmission(zBot)
 
-              transmissionCoefficients(k, iCell) = transmissionCoeffTop - transmissionCoeffBot
+              fractionAbsorbed(k, iCell) = transmissionCoeffTop - transmissionCoeffBot
 
               zTop = zBot
               transmissionCoeffTop = transmissionCoeffBot
            end do
         end do
 
-    end subroutine ocn_forcing_build_transmission_array!}}}
+    end subroutine ocn_forcing_build_fraction_absorbed_array!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -105,7 +105,7 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, layerThicknessEdge, &
-         vertAleTransportTop, tend_layerThickness, normalTransportVelocity, transmissionCoefficients
+         vertAleTransportTop, tend_layerThickness, normalTransportVelocity, fractionAbsorbed
 
       integer :: err
 
@@ -122,7 +122,7 @@ contains
       call mpas_pool_get_array(tendPool, 'layerThickness', tend_layerThickness)
 
       call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
-      call mpas_pool_get_array(forcingPool, 'transmissionCoefficients', transmissionCoefficients)
+      call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
                   
       !
       ! height tendency: start accumulating tendency terms
@@ -155,7 +155,7 @@ contains
       !
       call mpas_timer_start("surface flux", .false.)
 
-      call ocn_thick_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceThicknessFlux, tend_layerThickness, err)
+      call ocn_thick_surface_flux_tend(meshPool, fractionAbsorbed, layerThickness, surfaceThicknessFlux, tend_layerThickness, err)
       call mpas_timer_stop("surface flux")
 
       call mpas_timer_stop("ocn_tend_thick")
@@ -330,7 +330,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:,:), pointer :: &
         normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
-        tend_layerThickness, normalThicknessFlux, surfaceTracerFlux, transmissionCoefficients, zMid, relativeSlopeTopOfEdge, &
+        tend_layerThickness, normalThicknessFlux, surfaceTracerFlux, fractionAbsorbed, zMid, relativeSlopeTopOfEdge, &
         relativeSlopeTapering, relativeSlopeTaperingCell
       real (kind=RKIND), dimension(:,:,:), pointer :: &
         tracers, tend_tr, vertNonLocalFlux
@@ -367,7 +367,7 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
       call mpas_pool_get_array(forcingPool, 'surfaceTracerFlux', surfaceTracerFlux)
-      call mpas_pool_get_array(forcingPool, 'transmissionCoefficients', transmissionCoefficients)
+      call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
 
       call mpas_pool_get_array(tendPool, 'tracers', tend_tr)
       call mpas_pool_get_array(tendPool, 'layerThickness', tend_layerThickness)
@@ -414,7 +414,7 @@ contains
       ! Perform forcing from surface fluxes
       !
       call mpas_timer_start("surface_flux", .false.)
-      call ocn_tracer_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceTracerFlux, tend_tr, err)
+      call ocn_tracer_surface_flux_tend(meshPool, fractionAbsorbed, layerThickness, surfaceTracerFlux, tend_tr, err)
       call mpas_timer_stop("surface_flux")
 
       !

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -147,7 +147,7 @@ contains
              depth = depth + refBottomDepth(k)
 
              call ocn_get_jerlov_fraction(depth, weights(k+1))
-             tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell)*(weights(k) - weights(k+1)) / layerThickness(k, iCell)
+             tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell)*(weights(k) - weights(k+1))
            end do
          end do
       else
@@ -157,7 +157,7 @@ contains
              depth = depth + layerThickness(k, iCell)
 
              call ocn_get_jerlov_fraction(depth, weights(k+1))
-             tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell)*(weights(k) - weights(k+1)) / layerThickness(k, iCell)
+             tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell)*(weights(k) - weights(k+1))
            end do
          end do
       end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux.F
@@ -68,7 +68,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_surface_flux_tend(meshPool, transmissionCoefficients, layerThickness, surfaceTracerFlux, tend, err)!{{{
+   subroutine ocn_tracer_surface_flux_tend(meshPool, fractionAbsorbed, layerThickness, surfaceTracerFlux, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -85,7 +85,7 @@ contains
         surfaceTracerFlux !< Input: surface tracer fluxes
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-        transmissionCoefficients !< Input: Coefficients for the application of surface fluxes
+        fractionAbsorbed !< Input: Coefficients for the application of surface fluxes
 
       !-----------------------------------------------------------------
       !
@@ -131,10 +131,10 @@ contains
       do iCell = 1, nCells
         remainingFlux = 1.0_RKIND
         do k = 1, maxLevelCell(iCell)
-          remainingFlux = remainingFlux - transmissionCoefficients(k, iCell)
+          remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
 
           do iTracer = 1, nTracers
-            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + cellMask(k, icell) * surfaceTracerFlux(iTracer, iCell) * transmissionCoefficients(k, iCell)
+            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + cellMask(k, icell) * surfaceTracerFlux(iTracer, iCell) * fractionAbsorbed(k, iCell)
           end do
         end do
 


### PR DESCRIPTION
this commit corrects two bugs in the surface forcing.

the first is a soft bug, corrected by changing transmission_coefficients to fractionAbsorbed:
we distribute the non-penetrative fluxes in the vertical by computing the transmission coefficient
at layer interaces. The difference between the transmission coefficients at top and bottom of the cell
is the fraction of the surface flux absorbed in that cell. Previously we called this amount
the "transmissionCoefficient" but in reality it is the fractionAbsorbed. This name change is made throughout.

the second is a hard bug, corrected by the new computation of the temperature tendency due to shortwave forcing:
shortwave comes from the coupler in units of W/m2. We multiply by "hflux" to change the units to K m / s.
we accumulate the temperature tendency in tend_tracer which has units of K m / s, where "m" is from the layer thickness h.

tend_tracer =   d/dz ( h S_{interface}) where S_{interface} is the flux at the top and bottom of the layer interface.

expanding, we have

tend_tracer(k) = ( h(k) \* (S(top) - S(bottom) / h(k) ) = S(top) - S(bottom)

S(top) = penetrativeTemperatureFlux \* weight(top)
S(bottom) = penetrativeTemperatureFlux \* weight(bottom)

so

tend_tracer(k) = penetrativeTemperatureFlux \* (weight(top)-weight(bottom))

previously we were dividing by layer thickness on the RHS of the line above. This was incorrect.
