### PR TITLE
Fix underscores in okubo weiss c code

### DIFF
--- a/src/core_ocean/analysis_members/Makefile
+++ b/src/core_ocean/analysis_members/Makefile
@@ -27,4 +27,4 @@ else
 endif
 
 .c.o:
-	$(CC) $(CFLAGS) $(CINCLUDES) -c $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CINCLUDES) -c $<

--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
@@ -21,6 +21,16 @@
 
 #include <math.h>
 
+#ifdef UNDERSCORE
+#define compute_ev_2 compute_ev_2_
+#define compute_ev_3 compute_ev_3_
+#else
+#ifdef DOUBLEUNDERSCORE
+#define compute_ev_2 compute_ev_2__
+#define compute_ev_3 compute_ev_3__
+#endif
+#endif
+
 #ifdef SINGLE_PRECISION
     typedef float real;
 #else
@@ -62,7 +72,7 @@ inline void sort_descending_complex_3(real* wr, real* wi)
 !
 !-----------------------------------------------------------------------
 */
-void compute_ev_2_(real A[4], real wr[2], real wi[2])
+void compute_ev_2(real A[4], real wr[2], real wi[2])
 {
     real a = A[0];
     real b = A[1];
@@ -118,7 +128,7 @@ void compute_ev_2_(real A[4], real wr[2], real wi[2])
 !
 !-----------------------------------------------------------------------
 */
-void compute_ev_3_(real* mat, real* wr, real* wi )
+void compute_ev_3(real* mat, real* wr, real* wi )
 {
     /* find value to normalize with, to protect against over-/underflow */
     double maxAbsVal = 0.;


### PR DESCRIPTION
This merge fixes an issue related to c / fortran interoperability
due to underscores. It mainly updates the Okubo Weiss c code to follow
the rest of the MPAS format related to c code (defining the function
names based on how many underscores, if any, they should have).

In addition, it forces c code in the analysis member directory to obey
the CFLAGS definition.
