### PR TITLE
Changing the include path for ocean includes

### DIFF
--- a/src/core_ocean/build_options.mk
+++ b/src/core_ocean/build_options.mk
@@ -1,12 +1,14 @@
-PWD=$(shell pwd)
+ifeq "$(ROOT_DIR)" ""
+	ROOT_DIR=$(shell pwd)/src
+endif
 ifeq "$(MODE)" "analysis"
 	EXE_NAME=ocean_analysis_model
 	NAMELIST_SUFFIX=ocean_analysis
-	FCINCLUDES += -I$(PWD)/src/core_ocean/mode_analysis -I$(PWD)/src/core_ocean/shared -I$(PWD)/src/core_ocean/analysis_members -I$(PWD)/src/core_ocean/cvmix
+	FCINCLUDES += -I$(ROOT_DIR)/core_ocean/mode_analysis -I$(ROOT_DIR)/core_ocean/shared -I$(ROOT_DIR)/core_ocean/analysis_members -I$(ROOT_DIR)/core_ocean/cvmix
 else ifeq "$(MODE)" "forward"
 	EXE_NAME=ocean_forward_model
 	NAMELIST_SUFFIX=ocean_forward
-	FCINCLUDES += -I$(PWD)/src/core_ocean/mode_forward -I$(PWD)/src/core_ocean/shared -I$(PWD)/src/core_ocean/analysis_members -I$(PWD)/src/core_ocean/cvmix
+	FCINCLUDES += -I$(ROOT_DIR)/core_ocean/mode_forward -I$(ROOT_DIR)/core_ocean/shared -I$(ROOT_DIR)/core_ocean/analysis_members -I$(ROOT_DIR)/core_ocean/cvmix
 else
 	EXE_NAME=ocean*_model
 	NAMELIST_SUFFIX=ocean*


### PR DESCRIPTION
Previously ocean includes were defined using `pwd` always. This commit
changes those to use ROOT_DIR which can be overridden on a build line to
allow coupled models to specify where the includes should live.
