### PR TITLE
Fixing an issue related to files with no unlimited dimension

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -274,10 +274,18 @@ module mpas_io
             return
          end if
 
-         pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
-         if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
-            return
+         ! Here we're depending on the undocumented behavior of PIO to return a
+         ! -1 dimension ID when an unlimited dimension is not found.  This
+         ! might change in the future, causing this code to break, though it
+         ! shouldn't break for files with unlimited dimensions.
+         if ( MPAS_io_open % pio_unlimited_dimid /= -1 ) then
+            pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
+            if (pio_ierr /= PIO_noerr) then
+               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               return
+            end if
+         else
+            MPAS_io_open % preexisting_records = -1
          end if
       end if
 


### PR DESCRIPTION
This merge fixes an issue that prevents reading files that have no
unlimited dimension. Previously, there was incorrect logic that would
attempt to read the length of an unlimited dimension, even if one didn't
exist from a file. If the length was not read (which it wouldn't be in
the case that an unlimited dimension doesn't exist) the file handle
would be marked as invalid and no additional information could be read
from the file.

This merge changes the logic to only query the length if the dimension
id was found, and if it was not the number of records is set to -1.
