### PR TITLE
Allow immutable streams not in streams file to be added to other streams

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -5175,6 +5175,11 @@ subroutine stream_mgr_add_immutable_stream_fields_c(manager_c, streamID_c, refSt
 
     call MPAS_stream_mgr_get_property(manager, streamID, MPAS_STREAM_PROPERTY_IMMUTABLE, is_immutable, ierr=ierr)
     if (.not. is_immutable) then
+       if (ierr == MPAS_STREAM_MGR_NOERR) then
+          ierr_c = 0
+       else
+          ierr_c = 1
+       end if
        return ! This stream is not immutable so do not continue.
     endif
 

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1475,8 +1475,8 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			stream_mgr_add_immutable_stream_fields_c(manager, streamID, streamname_const, packages_local, &err);
 			if (err != 0) {
 				/* If that call was successful, we DID add an immutable_stream, so do not attempt to add
-				* a mutable stream below.  Otherwise do attempt to add a mutable stream and continue.
-				*/
+				 * a mutable stream below.  Otherwise do attempt to add a mutable stream and continue.
+				 */
 
 				for(streammatch_xml = ezxml_child(streams, "stream"); streammatch_xml; streammatch_xml = ezxml_next(streammatch_xml)) {
 					compstreamname_const = ezxml_attr(streammatch_xml, "name");


### PR DESCRIPTION
Currently, if an immutable stream is specified as a member of another stream
that is listed in a streams.CORE file, the immutable stream will only be added
if it is listed in the streams file itself, e.g.:

```
   <immutable_stream name="basicmesh" type="none" filename_template="not-to-be-used.nc"/>
```

This is a bit redundant, because all immutable_streams are defined in Registry.xml,
so it would be possible to eliminate the specification of these immutable_streams
within streams.CORE files.

This commit introduces changes to eliminate this restriction.  I.e., now any
immutable_streams defined in Registry.xml can be included as members of other
streams in streams.CORE files without needing to list the immutable_stream
separately in the streams.CORE file.

This is implemented by adding a new optional argument to subroutine
MPAS_stream_mgr_add_stream_fields that is called only_add_if_immutable.  If this
is true and the stream is mutable, then the routine returns an error.

The other piece is that xml_stream_parser has been modified to use this new
optional argument when it calls MPAS_stream_mgr_add_stream_fields.
Specifically, when xml_stream_parser attempts to add other streams to a stream,
it first calls MPAS_stream_mgr_add_stream_fields with only_add_if_immutable=.true.
If an error is returned, then xml_stream_parser attempts to add a mutable stream.
