### PR TITLE
Convert inline function to static to fix an issue in debug mode

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
@@ -39,7 +39,7 @@
 
 #define swap(A, B) tmp = A; A = B; B = tmp;
 
-inline void sort_descending_complex_3(real* wr, real* wi)
+static inline void sort_descending_complex_3(real* wr, real* wi)
 {
     real tmp;
     if (wr[0] < wr[1])


### PR DESCRIPTION
This merge fixes an issue that prevented ocean/develop from cleanly compiling with DEBUG=true (running make clean CORE=ocean) because a function was not inlined properly when compiling with -g unless it is declared static, indicating it is a local function to the file.
