### PR TITLE
Add 1d mpas_reconstruct routine

### DIFF
--- a/src/operators/mpas_vector_reconstruction.F
+++ b/src/operators/mpas_vector_reconstruction.F
@@ -28,6 +28,11 @@ module mpas_vector_reconstruction
 
   public :: mpas_init_reconstruct, mpas_reconstruct
 
+  interface mpas_reconstruct
+     module procedure mpas_reconstruct_1d
+     module procedure mpas_reconstruct_2d
+  end interface
+
   contains
 
 !***********************************************************************
@@ -151,9 +156,9 @@ module mpas_vector_reconstruction
 
 !***********************************************************************
 !
-!  routine mpas_reconstruct
+!  routine mpas_reconstruct_2d
 !
-!> \brief   MPAS Vector reconstruction routine
+!> \brief   2d MPAS Vector reconstruction routine
 !> \author  Xylar Asay-Davis, Todd Ringler
 !> \date    03/28/13
 !> \details 
@@ -161,7 +166,7 @@ module mpas_vector_reconstruction
 !>  Input: grid meta data and vector component data residing at cell edges
 !>  Output: reconstructed vector field (measured in X,Y,Z) located at cell centers
 !-----------------------------------------------------------------------
-  subroutine mpas_reconstruct(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional)!{{{
+  subroutine mpas_reconstruct_2d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional)!{{{
 
     implicit none
 
@@ -237,7 +242,98 @@ module mpas_vector_reconstruction
       uReconstructMeridional = uReconstructY
     end if
 
-  end subroutine mpas_reconstruct!}}}
+  end subroutine mpas_reconstruct_2d!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_reconstruct_1d
+!
+!> \brief   1d MPAS Vector reconstruction routine
+!> \author  Xylar Asay-Davis, Todd Ringler, Matt Hoffman
+!> \date    03/28/13
+!> \details 
+!>  Purpose: reconstruct vector field at cell centers based on radial basis functions
+!>  Input: grid meta data and vector component data residing at cell edges
+!>  Output: reconstructed vector field (measured in X,Y,Z) located at cell centers
+!-----------------------------------------------------------------------
+  subroutine mpas_reconstruct_1d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional)!{{{
+
+    implicit none
+
+    type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+    real (kind=RKIND), dimension(:), intent(in) :: u !< Input: Velocity field on edges
+    real (kind=RKIND), dimension(:), intent(out) :: uReconstructX !< Output: X Component of velocity reconstructed to cell centers
+    real (kind=RKIND), dimension(:), intent(out) :: uReconstructY !< Output: Y Component of velocity reconstructed to cell centers
+    real (kind=RKIND), dimension(:), intent(out) :: uReconstructZ !< Output: Z Component of velocity reconstructed to cell centers
+    real (kind=RKIND), dimension(:), intent(out) :: uReconstructZonal !< Output: Zonal Component of velocity reconstructed to cell centers
+    real (kind=RKIND), dimension(:), intent(out) :: uReconstructMeridional !< Output: Meridional Component of velocity reconstructed to cell centers
+
+    !   temporary arrays needed in the compute procedure
+    integer, pointer :: nCellsSolve
+    integer, dimension(:,:), pointer :: edgesOnCell
+    integer, dimension(:), pointer :: nEdgesOnCell
+    integer :: iCell,iEdge, i
+    real(kind=RKIND), dimension(:), pointer :: latCell, lonCell
+
+    real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct
+
+    logical, pointer :: on_a_sphere
+
+    real (kind=RKIND) :: clat, slat, clon, slon
+
+
+    ! stored arrays used during compute procedure
+    call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', coeffs_reconstruct)
+
+    ! temporary variables
+    call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+    call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+    call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+    call mpas_pool_get_array(meshPool, 'latCell', latCell)
+    call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+
+    call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
+
+    ! init the intent(out)
+    uReconstructX = 0.0
+    uReconstructY = 0.0
+    uReconstructZ = 0.0
+
+    ! loop over cell centers
+    do iCell = 1, nCellsSolve
+      ! a more efficient reconstruction where rbf_values*matrix_reconstruct has been precomputed
+      ! in coeffs_reconstruct
+      do i=1,nEdgesOnCell(iCell)
+        iEdge = edgesOnCell(i,iCell)
+        uReconstructX(iCell) = uReconstructX(iCell) &
+          + coeffs_reconstruct(1,i,iCell) * u(iEdge)
+        uReconstructY(iCell) = uReconstructY(iCell) &
+          + coeffs_reconstruct(2,i,iCell) * u(iEdge)
+        uReconstructZ(iCell) = uReconstructZ(iCell) &
+          + coeffs_reconstruct(3,i,iCell) * u(iEdge)
+
+      enddo
+    enddo   ! iCell
+
+    if (on_a_sphere) then
+      do iCell = 1, nCellsSolve
+        clat = cos(latCell(iCell))
+        slat = sin(latCell(iCell))
+        clon = cos(lonCell(iCell))
+        slon = sin(lonCell(iCell))
+        uReconstructZonal(iCell) = -uReconstructX(iCell)*slon + uReconstructY(iCell)*clon
+        uReconstructMeridional(iCell) = -(uReconstructX(iCell)*clon &
+          + uReconstructY(iCell)*slon)*slat &
+          + uReconstructZ(iCell)*clat
+      end do
+    else
+      uReconstructZonal = uReconstructX
+      uReconstructMeridional = uReconstructY
+    end if
+
+  end subroutine mpas_reconstruct_1d!}}}
 
 end module mpas_vector_reconstruction
 


### PR DESCRIPTION
This commit adds a version of the mpas_reconstruct routine for 1d
vectors.  It also creates an interface called mpas_reconstruct that can
be called with either 1d or 2d fields.
