### PR TITLE
Fixing an issue with duplicating fields

### DIFF
--- a/src/framework/duplicate_field_array.inc
+++ b/src/framework/duplicate_field_array.inc
@@ -41,6 +41,7 @@
             end if
             dst_cursor % isPersistent = src_cursor % isPersistent
             dst_cursor % isActive = src_cursor % isActive
+            dst_cursor % isDecomposed = src_cursor % isDecomposed
             dst_cursor % hasTimeDimension = src_cursor % hasTimeDimension
             dst_cursor % dimNames = src_cursor % dimNames
             dst_cursor % dimSizes = src_cursor % dimSizes

--- a/src/framework/duplicate_field_scalar.inc
+++ b/src/framework/duplicate_field_scalar.inc
@@ -36,6 +36,7 @@
             dst_cursor % fieldName = src_cursor % fieldName
             dst_cursor % isVarArray = src_cursor % isVarArray
             dst_cursor % isActive = src_cursor % isActive
+            dst_cursor % isDecomposed = src_cursor % isDecomposed
             dst_cursor % hasTimeDimension = src_cursor % hasTimeDimension
             dst_cursor % sendList => src_cursor % sendList
             dst_cursor % recvList => src_cursor % recvList


### PR DESCRIPTION
This merge fixes an issue related to duplicating fields. Previously
when adding decomposed fields, the isDecomposed attribute was added.
This commit correctly sets this attribute when duplicating fields to
ensure I/O is properly handled.
