### PR TITLE
Fixing issues with when using multiple blocks

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -440,6 +440,7 @@ module ocn_time_integration_rk4
               call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
               call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
+              call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
               call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
               call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -441,6 +441,7 @@ module ocn_time_integration_split
                call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
                call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
+               call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
                call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityCur, 1)
                call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
                call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
@@ -452,7 +453,7 @@ module ocn_time_integration_split
 
                allocate(uTemp(nVertLevels))
 
-               ! Put f*normalBaroclinicVelocity^{perp} in uNew as a work variable
+               ! Put f*normalBaroclinicVelocity^{perp} in normalVelocityNew as a work variable
                call ocn_fuperp(statePool, meshPool, 2)
 
                do iEdge = 1, nEdges
@@ -1214,6 +1215,7 @@ module ocn_time_integration_split
 
             call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
             call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
             call mpas_pool_get_array(statePool, 'tracers', tracersCur, 1)
             call mpas_pool_get_array(statePool, 'tracers', tracersNew, 2)


### PR DESCRIPTION
Prior to a diagnostic_solve call, forcingPool was not associated with
the correct pool.

Two arrays (normalVelocityNew and maxLevelEdgeTop) were previously used
in a block loop without retrieving pointers to them from the current
block's pool.

When run with multiple blocks, this caused an array out of bounds issue
becuase the arrays would be associated to the last block's arrays. Which
might have a different size than the other blocks in the blocklist.
