### PR TITLE
Updating error flags to be consistent with return values

### DIFF
--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
@@ -430,7 +430,7 @@ module mpas_core
       call mpas_timer_stop("diagnostic solve", initDiagSolveTimer)
 
       if (config_write_output_on_startup) then
-         call ocn_analysis_compute(domain, err) 
+         call ocn_analysis_compute(domain, ierr) 
          call mpas_timer_start('io_write', .false.)
          call mpas_stream_mgr_write(stream_manager, ierr=ierr)
          call mpas_timer_stop('io_write')

--- a/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_mpas_core.F
@@ -607,7 +607,7 @@ module mpas_core
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
       write(stderrUnit,*) 'Initial time ', trim(timeStamp)
 
-      call ocn_analysis_compute_startup(domain, stream_manager, err) 
+      call ocn_analysis_compute_startup(domain, stream_manager, ierr) 
 
       if (config_write_output_on_startup) then
           call mpas_timer_start('io_write', .false.)
@@ -662,8 +662,8 @@ module mpas_core
             block_ptr => block_ptr % next
          end do
       
-         call ocn_analysis_compute_w_alarms(stream_manager, domain, err) 
-         call ocn_analysis_write(stream_manager, err)
+         call ocn_analysis_compute_w_alarms(stream_manager, domain, ierr) 
+         call ocn_analysis_write(stream_manager, ierr)
 
          call mpas_timer_start('io_write', .false.)
          call mpas_stream_mgr_write(stream_manager, streamID='output', ierr=ierr)


### PR DESCRIPTION
Previously, err was used when calling subroutines within the
mpas_core_run routines, when ierr should have been used. This causes an
error code to be passed back to the driver which may cause issues in the
future.
