### PR TITLE
Fix associated check in mpas_decomp_destroy_decomp_list

### DIFF
--- a/src/framework/mpas_decomp.F
+++ b/src/framework/mpas_decomp.F
@@ -83,7 +83,7 @@ module mpas_decomp
       do while (associated(decompList % next))
          decompCursor => decompList % next
 
-         if ( associated(decompList % next) ) then
+         if ( associated(decompCursor % next) ) then
             decompList % next => decompCursor % next
          else
             nullify(decompList % next)


### PR DESCRIPTION
The linked list loop was incorrectly checking if decompList%next was
associated instead of decompCursor%next.  Thus, decompList%next never
would get nullified.
