### PR TITLE
Change return type of get_mesh_stream() function to avoid runtime errors with ifort

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -157,7 +157,7 @@ module atm_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function atm_get_mesh_stream(configs) result(stream)
+   function atm_get_mesh_stream(configs, stream) result(ierr)
 
       use mpas_kind_types, only : StrKIND
       use mpas_derived_types, only : mpas_pool_type
@@ -166,9 +166,12 @@ module atm_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
 
       logical, pointer :: config_do_restart
+
+      ierr = 0
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -235,7 +235,7 @@ module init_atm_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function init_atm_get_mesh_stream(configs) result(stream)
+   function init_atm_get_mesh_stream(configs, stream) result(ierr)
 
       use mpas_kind_types, only : StrKIND
       use mpas_derived_types, only : mpas_pool_type
@@ -244,7 +244,10 @@ module init_atm_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
+
+      ierr = 0
 
       write(stream,'(a)') 'input'
 

--- a/src/core_landice/mpas_li_core_interface.F
+++ b/src/core_landice/mpas_li_core_interface.F
@@ -141,14 +141,17 @@ module li_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function li_get_mesh_stream(configs) result(stream)
+   function li_get_mesh_stream(configs, stream) result(ierr)
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
 
       logical, pointer :: config_do_restart
+
+      ierr = 0
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 

--- a/src/core_ocean/mode_analysis/mpas_ocn_core_interface.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_core_interface.F
@@ -191,7 +191,7 @@ module ocn_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function ocn_get_mesh_stream(configs) result(stream)!{{{
+   function ocn_get_mesh_stream(configs, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -199,9 +199,12 @@ module ocn_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
 
       logical, pointer :: config_do_restart
+
+      ierr = 0
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 

--- a/src/core_ocean/mode_forward/mpas_ocn_core_interface.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_core_interface.F
@@ -240,7 +240,7 @@ module ocn_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function ocn_get_mesh_stream(configs) result(stream)!{{{
+   function ocn_get_mesh_stream(configs, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -248,9 +248,12 @@ module ocn_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
 
       logical, pointer :: config_do_restart
+
+      ierr = 0
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -186,7 +186,7 @@ module sw_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function sw_get_mesh_stream(configs) result(stream)!{{{
+   function sw_get_mesh_stream(configs, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -194,9 +194,12 @@ module sw_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
 
       logical, pointer :: config_do_restart
+
+      ierr = 0
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -220,7 +220,7 @@ module test_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function test_get_mesh_stream(configs) result(stream)!{{{
+   function test_get_mesh_stream(configs, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -228,7 +228,10 @@ module test_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
-      character(len=StrKIND) :: stream
+      character(len=StrKIND), intent(out) :: stream
+      integer :: ierr
+
+      ierr = 0
 
       write(stream,'(a)') 'input'
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -227,7 +227,11 @@ module mpas_subdriver
       ! Using information from the namelist, a graph.info file, and a file containing
       !    mesh fields, build halos and allocate blocks in the domain
       !
-      mesh_stream = domain_ptr % core % get_mesh_stream(domain_ptr % configs)
+      ierr = domain_ptr % core % get_mesh_stream(domain_ptr % configs, mesh_stream)
+      if ( ierr /= 0 ) then
+         call mpas_dmpar_global_abort('ERROR: Failed to find mesh stream for core ' // trim(domain_ptr % core % coreName))
+      end if
+
       call mpas_f_to_c_string(domain_ptr % streams_filename, c_filename)
       call mpas_f_to_c_string(mesh_stream, c_mesh_stream)
       c_comm = domain_ptr % dminfo % comm

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -40,12 +40,13 @@
    end interface
 
    abstract interface
-      function mpas_get_mesh_stream_function(configs) result(stream)
+      function mpas_get_mesh_stream_function(configs, stream) result(iErr)
          use mpas_kind_types
          import mpas_pool_type
 
          type (mpas_pool_type), intent(inout) :: configs
-         character (len=StrKIND) :: stream
+         character (len=StrKIND), intent(out) :: stream
+         integer :: iErr
       end function mpas_get_mesh_stream_function
    end interface
 


### PR DESCRIPTION
This merge introduces changes to a core-framework interface function to avoid run-time failures when using the intel 13.1.2 compilers; this same error does not appear to exist with newer versions of the ifort compiler (version 14.0.1 or later) or other compilers (pgi, gnu).

More specifically, the ifort 13.1.2 compiler appears to have problems with function pointers that return character strings. To work around this issue, we change the return type of the mpas_get_mesh_stream_function() interface to be an integer error code; the name of the mesh stream that was formerly the return type is now returned via an intent(out) argument.

After changing the interface of the get_mesh_stream() function pointer in the core_type type, we also update the mesh stream function implementations in all cores.
