### PR TITLE
Fix intent for output arguments in interface for xml_stream_get_attributes()

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -93,9 +93,9 @@ module mpas_subdriver
             character(kind=c_char), dimension(*), intent(in) :: xmlname
             character(kind=c_char), dimension(*), intent(in) :: streamname
             integer(kind=c_int), intent(inout) :: comm
-            character(kind=c_char), dimension(*), intent(in) :: filename
-            character(kind=c_char), dimension(*), intent(in) :: ref_time
-            character(kind=c_char), dimension(*), intent(in) :: filename_interval
+            character(kind=c_char), dimension(*), intent(out) :: filename
+            character(kind=c_char), dimension(*), intent(out) :: ref_time
+            character(kind=c_char), dimension(*), intent(out) :: filename_interval
             character(kind=c_char), dimension(*), intent(out) :: io_type
             integer(kind=c_int), intent(out) :: ierr
          end subroutine xml_stream_get_attributes


### PR DESCRIPTION
This merge adds a fix to correctly declare the intent for output arguments in the interface for xml_stream_get_attributes().

The interface in mpas_init() for the C xml_stream_get_attributes() function erroneously
declared the intent of the output arguments of this function as intent(in). However
unlikely, it is possible that with the arguments declared as intent(in), the results returned
by the function would not appear in the actual arguments, since intent(in) implies that
the value upon exit from the call should be the same as the value upon entry to the call,
i.e., the arguments are not modified by the call.
