### PR TITLE
Avoid writing initial diagnostics output file on restart runs

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -361,9 +361,10 @@ module atm_core
       ! Avoid writing a restart file at the initial time
       call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_OUTPUT, ierr=ierr)
 
-      ! Also, for restart runs, avoid writing the initial history fields to avoid overwriting those from the preceding run
+      ! Also, for restart runs, avoid writing the initial history or diagnostics fields to avoid overwriting those from the preceding run
       if (config_do_restart) then
          call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='output', direction=MPAS_STREAM_OUTPUT, ierr=ierr)
+         call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='diagnostics', direction=MPAS_STREAM_OUTPUT, ierr=ierr)
       end if
 
       if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)) then


### PR DESCRIPTION
This merge introduces code in the atmosphere core to avoid writing initial diagnostics 
output file on restart runs.

Some diagnostic fields are not computed at model startup, and therefore aren't
available in the initial diagnostics file. For a restart run, it's reasonable
to expect that a diagnostics file would have been written at the same valid time
in the preceding segment of the run and would include valid diagnostics. Consequently,
we should follow what is already done for the history stream and not write the initial
diagnostics output file on model restart.

If it were ever necessary to get an initial diagnostics output file on model restart,
one could simply define a new stream that contains all diagnostic fields and has
output_interval="initial_only".
