### PR TITLE
Several fixes for atmosphere real-data initialization

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3286,7 +3286,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
             else if (field % iproj == PROJ_GAUSS) then
                call map_set(PROJ_GAUSS, proj, &
                             nlat = nint(field % deltalat), &
-                            loninc = real(field % deltalon,RKIND), &
+                            loninc = 360.0_RKIND / real(field % nx,RKIND), &
                             lat1 = real(field % startlat,RKIND), &
                             lon1 = real(field % startlon,RKIND))
 !                            nxmax = nint(360.0 / field % deltalon), &

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -303,7 +303,7 @@
  else if(field % iproj == PROJ_GAUSS) then
     call map_set(PROJ_GAUSS, proj, &
                  nlat = nint(field % deltalat), &
-                 loninc = real(field % deltalon,RKIND), &
+                 loninc = 360.0_RKIND / real(field % nx,RKIND), &
                  lat1 = real(field % startlat,RKIND), &
                  lon1 = real(field % startlon,RKIND))
 !   write(0,*) '--- The projection is PROJ_GAUSS.'


### PR DESCRIPTION
This merge includes several fixes that affect real-data initialization of the atmosphere core:

1) Fix two LANDSEA masking errors for real-data cases
2) Correctly detect non-isobaric data in real-data initialization
3) Set any negative soil moisture values to 0.001
4) Recompute longitude grid increment for Gaussian input data
