### PR TITLE
Set default surface update interval to 86400 s during initialization

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -52,7 +52,7 @@
                 <nml_option name="config_geog_data_path"        type="character"     default_value="/glade/p/work/wrfhelp/WPS_GEOG/"/>
                 <nml_option name="config_met_prefix"            type="character"     default_value="CFSR"/>
                 <nml_option name="config_sfc_prefix"            type="character"     default_value="SST"/>
-                <nml_option name="config_fg_interval"           type="integer"       default_value="21600"/>
+                <nml_option name="config_fg_interval"           type="integer"       default_value="86400"/>
                 <nml_option name="config_landuse_data"          type="character"     default_value="USGS"/>
         </nml_record>
 
@@ -344,7 +344,7 @@
 		<stream name="surface" 
                         type="output" 
                         filename_template="x1.40962.sfc_update.nc"
-                        output_interval="none" 
+                        output_interval="86400" 
                         filename_interval="none"
                         packages="sfc_update"
                         immutable="true">


### PR DESCRIPTION
This merge updates the default values for config_fg_interval and the output_interval 
for the surface stream in the Registry.xml file for the init_atmosphere core.

Setting the default output_interval for the "surface" stream in the initialization
core to 86400 s, and correspondingly, the config_fg_interval, will require fewer
changes to files for anyone working with daily SST and sea-ice analyses.

Also, there's no harm in setting the output_interval for the "surface" stream
to a value other than "none", since this stream is only activated when creating
a surface update file.
