### PR TITLE
Only write 'restart_timestamp' file from MPI rank 0

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -470,9 +470,11 @@ module atm_core
          ! Only after we've successfully written the restart file should we we
          !    write the restart_timestamp file
          if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_OUTPUT, ierr=ierr)) then
-            open(22,file=trim(config_restart_timestamp_name),form='formatted',status='replace')
-            write(22,*) trim(timeStamp)
-            close(22)
+            if (domain % dminfo % my_proc_id == 0) then
+               open(22,file=trim(config_restart_timestamp_name),form='formatted',status='replace')
+               write(22,*) trim(timeStamp)
+               close(22)
+            end if
          end if
 
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)


### PR DESCRIPTION
This merge prevents all but MPI rank 0 from writing the 'restart_timestamp' file 
in the atmosphere core.

This file was previously written by all MPI tasks, which seems slightly
dangerous and potentially detrimental to performance for large task counts.

There appears to be no downside to this change: if an MPI rank >0 crashes
before reaching the point where the 'restart_timestamp' file is written, rank 0
will write the file (same behavior as before, though not necessarily desirable:
rank 0 will still write the file), and if MPI rank 0 crashes before reaching
the code to write the file, the file will not be written (which is desirable:
the file should ideally only be written if all tasks successfully get past
writing the restart file).

Thanks to Dominikus Heinzeller (KIT) for suggesting this change.
