### PR TITLE
Add missing code for 2nd and 4th order vertical advection of 'u'

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2508,6 +2508,7 @@ module atm_time_integration
       real (kind=RKIND), pointer :: coef_3rd_order
       logical, pointer :: newpx
       logical, pointer :: config_mix_full
+      integer, pointer :: config_u_vadv_order
       integer, pointer :: config_theta_vadv_order
       character (len=StrKIND), pointer :: config_horiz_mixing
       integer, pointer :: config_theta_adv_order
@@ -2535,6 +2536,7 @@ module atm_time_integration
       call mpas_pool_get_config(configs, 'config_newpx', newpx)
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_mix_full', config_mix_full)
+      call mpas_pool_get_config(configs, 'config_u_vadv_order', config_u_vadv_order)
       call mpas_pool_get_config(configs, 'config_theta_vadv_order', config_theta_vadv_order)
       call mpas_pool_get_config(configs, 'config_horiz_mixing', config_horiz_mixing)
       call mpas_pool_get_config(configs, 'config_theta_adv_order', config_theta_adv_order)
@@ -2795,14 +2797,33 @@ module atm_time_integration
          ! vertical transport of u
 
          wduz(1) = 0.
-         k = 2
-         wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2) )*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))  
-         do k=3,nVertLevels-1
-            wduz(k) = flux3( u(k-2,iEdge),u(k-1,iEdge),u(k,iEdge),u(k+1,iEdge),0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
-         end do
-         k = nVertLevels
-         wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2) )*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))  
+         if (config_u_vadv_order == 2) then
 
+            do k=2,nVertLevels
+               wduz(k) = 0.5*(rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+            end do
+
+         else if (config_u_vadv_order == 3) then
+
+            k = 2
+            wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+            do k=3,nVertLevels-1
+               wduz(k) = flux3( u(k-2,iEdge),u(k-1,iEdge),u(k,iEdge),u(k+1,iEdge),0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
+            end do
+            k = nVertLevels
+            wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+
+         else if (config_u_vadv_order == 4) then
+
+            k = 2
+            wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+            do k=3,nVertLevels-1
+               wduz(k) = flux4( u(k-2,iEdge),u(k-1,iEdge),u(k,iEdge),u(k+1,iEdge),0.5*(rw(k,cell1)+rw(k,cell2)))
+            end do
+            k = nVertLevels
+            wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+
+         end if
          wduz(nVertLevels+1) = 0.
 
          do k=1,nVertLevels


### PR DESCRIPTION
This merge adds code for 2nd and 4th order vertical advection of 'u'.

Although there was a namelist option, config_u_vadv_order, that was intended
to allow the vertical advection order of 'u' to be changed, only code for
3rd order vertical advection was actually present in the atm_compute_dyn_tend()
subroutine. The default value of config_u_vadv_order is 3, so only those who changed
this namelist option would have been affected by the missing code; in such cases,
though, there would have been no indication in the log file that the requested order
was in fact not being used.
