### PR TITLE
Change name of default physics suite from 'wrf' to 'mesoscale_reference'

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -975,7 +975,7 @@
                 <nml_option name="config_greeness_update"            type="character"     default_value="24:00:00"   in_defaults="false"/>
                 <nml_option name="config_bucket_update"              type="character"     default_value="none"/>
 
-                <nml_option name="config_physics_suite"              type="character"     default_value="wrf"        in_defaults="true"/>
+                <nml_option name="config_physics_suite"              type="character"     default_value="mesoscale_reference"  in_defaults="true"/>
 
                 <nml_option name="config_microp_scheme"              type="character"     default_value="suite"      in_defaults="false"/>
                 <nml_option name="config_convection_scheme"          type="character"     default_value="suite"      in_defaults="false"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -90,7 +90,7 @@
  !
  ! Setup schemes according to the selected physics suite
  !
- if (trim(config_physics_suite) == 'wrf') then
+ if (trim(config_physics_suite) == 'mesoscale_reference') then
 
     if (trim(config_microp_scheme) == 'suite')     config_microp_scheme     = 'wsm6'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'tiedtke'


### PR DESCRIPTION
This merge simply changes the name of the default MPAS-A physics suite from 'wrf' to 'mesoscale_reference'. We make this change both in the Registry.xml and mpas_atmphys_control.F files.

The suite includes the same schemes as before; only the name has been changed.
