### PR TITLE
Don't abort if errors occur when computing the MSLP diagnostic

### DIFF
--- a/src/core_atmosphere/mpas_atm_interp_diagnostics.F
+++ b/src/core_atmosphere/mpas_atm_interp_diagnostics.F
@@ -567,7 +567,9 @@
           write(0,*) 'Troubles finding level ', pconst,' above ground.'
           write(0,*) 'Problems first occur at (',icol,')'
           write(0,*) 'Surface pressure = ',p(1,icol),' hPa.'
-          call mpas_dmpar_global_abort('ERROR: Error_in_finding_100_hPa_up')
+          write(0,*) '*** MSLP field will not be computed'
+          slp(:) = 0.0
+          return
        end if
    
     end do


### PR DESCRIPTION
This merge prevents the MPAS-Atmosphere model from aborting if 
an invalid pressure field is encountered when computing the MSLP 
diagnostic field.

The code to compute mean sea-level pressure looks for a layer that
is 100 hPa above the surface; if this layer was not found, the code
previously called mpas_dmpar_abort(). However, for certain idealized
test cases where a base-state pressure is not supplied (specifically,
the mountain wave test case), the derived full pressure field is not
valid, and the trap in the MSLP code would cause the model to abort.

Rather than aborting, it is much preferable to simply print a message
informing users that the diagnostic will not be computed, and to continue
with the simulation. Really, this situation should only affect those running
certain idealized cases, since we always supply a base-state pressure
for real-data cases.
