### PR TITLE
Remove unused &io namelist options from init_atmosphere and atmosphere Registry.xml files

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -82,7 +82,6 @@
                 <nml_option name="config_restart_timestamp_name"     type="character"     default_value="restart_timestamp"  in_defaults="false"/>
                 <nml_option name="config_pio_num_iotasks"            type="integer"       default_value="0"/>
                 <nml_option name="config_pio_stride"                 type="integer"       default_value="1"/>
-                <nml_option name="config_pio_format"                 type="character"     default_value="pnetcdf"            in_defaults="false"/>
         </nml_record>
 
         <nml_record name="decomposition" in_defaults="true">

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -73,7 +73,6 @@
         </nml_record>
 
         <nml_record name="io" in_defaults="true">
-                <nml_option name="config_frames_per_outfile"    type="integer"       default_value="0"                    in_defaults="false"/>
                 <nml_option name="config_pio_num_iotasks"       type="integer"       default_value="0"/>
                 <nml_option name="config_pio_stride"            type="integer"       default_value="1"/>
         </nml_record>


### PR DESCRIPTION
This merge removes unused namelist options from the &io namelist record in the
init_atmosphere and atmosphere cores.

In the init_atmosphere core, the Registry.xml file contained the deprecated &io record
namelist option config_frames_per_outfile.

In the atmosphere core, the Registry.xml file contained the unused &io record
namelist option config_pio_format.
