### PR TITLE
Move computation of invAreaCell field above first call to atm_compute_solve_diagnostics()

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -241,6 +241,14 @@ module atm_core
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(block % configs, 'config_do_DAcycling', config_do_DAcycling)
 
+      call mpas_pool_get_array(mesh, 'areaCell', areaCell)
+      call mpas_pool_get_array(mesh, 'invAreaCell', invAreaCell)
+      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+  
+      do iCell=1,nCells 
+         invAreaCell(iCell) = 1.0_RKIND / areaCell(iCell)
+      end do
+
       if (.not. config_do_restart .or. (config_do_restart .and. config_do_DAcycling)) then
          call atm_init_coupled_diagnostics( state, 1, diag, mesh, block % configs)
       end if
@@ -262,14 +270,6 @@ module atm_core
                             uReconstructZonal,         &
                             uReconstructMeridional     &
                            )
-
-      call mpas_pool_get_array(mesh, 'areaCell', areaCell)
-      call mpas_pool_get_array(mesh, 'invAreaCell', invAreaCell)
-      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-  
-      do iCell=1,nCells 
-         invAreaCell(iCell) = 1.0_RKIND / areaCell(iCell)
-      end do
    
 #ifdef DO_PHYSICS
       !check that all the physics options are correctly defined and that at least one physics


### PR DESCRIPTION
This merge moves the computation of invAreaCell field above first call to atm_compute_solve_diagnostics().

The atm_compute_solve_diagnostics() routine is called from the MPAS-A init routine,
and thereafter, toward the end of each timestep. This routine makes use of the invAreaCell
field, which wasn't computed until after the first call to the routine during model
init. Besides leading to some incorrect diagnostic fields in the first model timestep,
this broke bit-identical restarts of the model.
