### PR TITLE
Fix an issue realted to core_run failing for the ocean model

### DIFF
--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_core.F
@@ -433,6 +433,8 @@ module ocn_core
          call mpas_stream_mgr_write(domain % streamManager, ierr=ierr)
       endif
 
+      err = iErr
+
    end function ocn_core_run!}}}
    
    function ocn_core_finalize(domain) result(iErr)!{{{

--- a/src/core_ocean/mode_forward/mpas_ocn_core.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_core.F
@@ -672,6 +672,8 @@ module ocn_core
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
       end do
 
+      err = iErr
+
    end function ocn_core_run!}}}
    
    subroutine mpas_timestep(domain, itimestep, dt, timeStamp)!{{{


### PR DESCRIPTION
This merge fixes and issue where the core_run function returns a
non-zero error code, and framework says that the ocean model has failed
to run.
