### PR TITLE
Moving mpas_dmpar_global_abort into mpas_dmpar

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -162,6 +162,7 @@ module atm_core_interface
       use mpas_kind_types, only : StrKIND
       use mpas_derived_types, only : mpas_pool_type
       use mpas_pool_routines, only : mpas_pool_get_config
+      use mpas_dmpar, only: mpas_dmpar_global_abort
 
       implicit none
 

--- a/src/core_atmosphere/physics/mpas_atmphys_utilities.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_utilities.F
@@ -9,6 +9,7 @@
  module mpas_atmphys_utilities
 
  use mpas_kind_types
+ use mpas_dmpar, only : mpas_dmpar_global_abort
  implicit none
  private
  public:: physics_error_fatal, &

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
@@ -4,7 +4,7 @@ MODULE module_sf_bem
 ! -----------------------------------------------------------------------
 
 #ifdef mpas
-!USE mpas_dmpar, only : mpas_dmpar_global_abort
+USE mpas_dmpar, only : mpas_dmpar_global_abort
 #define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
 #else
 #define FATAL_ERROR(M) write(0,*) M ; stop

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
@@ -1,7 +1,7 @@
 MODULE module_sf_bep
 
 #ifdef mpas
-!USE mpas_dmpar, only : mpas_dmpar_global_abort
+USE mpas_dmpar, only : mpas_dmpar_global_abort
 #define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
 #else 
 #define FATAL_ERROR(M) write(0,*) M ; stop

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
@@ -1,7 +1,7 @@
 MODULE module_sf_bep_bem
 
 #ifdef mpas
-!USE mpas_dmpar, only : mpas_dmpar_global_abort
+USE mpas_dmpar, only : mpas_dmpar_global_abort
 #define FATAL_ERROR(M) call mpas_dmpar_global_abort( M )
 #else 
 #define FATAL_ERROR(M) write(0,*) M ; stop

--- a/src/core_init_atmosphere/mpas_atm_advection.F
+++ b/src/core_init_atmosphere/mpas_atm_advection.F
@@ -11,6 +11,7 @@ module atm_advection
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_constants
+   use mpas_dmpar, only : mpas_dmpar_global_abort
 
 
    contains

--- a/src/core_init_atmosphere/mpas_init_atm_llxy.F
+++ b/src/core_init_atmosphere/mpas_init_atm_llxy.F
@@ -2223,6 +2223,8 @@ MODULE init_atm_llxy
 
    SUBROUTINE llxy_error_fatal(mesg)
 
+      use mpas_dmpar, only : mpas_dmpar_global_abort
+
       IMPLICIT NONE
 
       CHARACTER (LEN=*), INTENT(IN) :: mesg

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -62,7 +62,7 @@ mpas_domain_routines.o: mpas_derived_types.o mpas_pool_routines.o
 
 mpas_field_routines.o: mpas_derived_types.o
 
-mpas_pool_routines.o: mpas_derived_types.o mpas_field_routines.o
+mpas_pool_routines.o: mpas_derived_types.o mpas_field_routines.o mpas_dmpar.o
 
 mpas_decomp.o: mpas_derived_types.o mpas_stream_manager.o
 
@@ -72,7 +72,7 @@ mpas_dmpar.o: mpas_sort.o streams.o mpas_kind_types.o mpas_derived_types.o mpas_
 
 mpas_sort.o: mpas_kind_types.o mpas_io_units.o
 
-mpas_timekeeping.o: mpas_kind_types.o mpas_io_units.o mpas_derived_types.o
+mpas_timekeeping.o: mpas_kind_types.o mpas_io_units.o mpas_derived_types.o mpas_dmpar.o
 
 mpas_timer.o: mpas_kind_types.o mpas_io_units.o mpas_dmpar.o
 

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -5924,8 +5924,6 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
        end if
    end subroutine mpas_dmpar_copy_field5d_real!}}}
 
-end module mpas_dmpar
-
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_global_abort
 !
@@ -5958,4 +5956,5 @@ end module mpas_dmpar
 
    end subroutine mpas_dmpar_global_abort!}}}
 
+end module mpas_dmpar
 

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -22,6 +22,7 @@ module mpas_pool_routines
    use mpas_derived_types
    use mpas_io_units
    use mpas_field_routines
+   use mpas_dmpar
    
    interface mpas_pool_add_field
       module procedure mpas_pool_add_field_0d_real

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -10,6 +10,7 @@ module mpas_timekeeping
    use mpas_kind_types
    use mpas_derived_types
    use mpas_io_units
+   use mpas_dmpar
 
    use ESMF
    use ESMF_BaseMod
@@ -2110,6 +2111,8 @@ end module mpas_timekeeping
 
 
 subroutine wrf_error_fatal(msg)
+
+   use mpas_dmpar
 
    implicit none
 

--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -23,6 +23,7 @@
         use mpas_kind_types
         use mpas_derived_types
         use mpas_io_units
+        use mpas_dmpar
 
         implicit none
         save


### PR DESCRIPTION
This merge makes the mpas_dmpar_global_abort subroutine non-global.
Previously, it lived in the mpas_dmpar file, but outside of the
mpas_dmpar module, which allowed it to be called anywhere, without using
the mpas_dmpar module. This was done to prevent circular dependencies
that were caused by trying to use the mpas_dmpar module when it hadn't
been built yet (or depended on parts of the other module that was being
built).

After this commit, mpas_dmpar_global_abort is now a subroutine within
the mpas_dmpar module.
