### PR TITLE
LIGHT analysis member (parallel compute/IO):

### DIFF
--- a/src/core_ocean/analysis_members/Makefile
+++ b/src/core_ocean/analysis_members/Makefile
@@ -11,6 +11,9 @@ MEMBERS = mpas_ocn_global_stats.o \
           mpas_ocn_test_compute_interval.o \
           mpas_ocn_high_frequency_output.o \
           mpas_ocn_zonal_mean.o \
+          mpas_ocn_lagrangian_particle_tracking_interpolations.o \
+          mpas_ocn_particle_list.o \
+          mpas_ocn_lagrangian_particle_tracking.o \
           mpas_ocn_eliassen_palm.o \
           mpas_ocn_time_filters.o \
           mpas_ocn_mixed_layer_depths.o
@@ -20,6 +23,10 @@ all: $(OBJS)
 mpas_ocn_analysis_driver.o: $(MEMBERS)
 
 mpas_ocn_okubo_weiss.o: mpas_ocn_okubo_weiss_eigenvalues.o
+
+mpas_ocn_particle_list.o:
+
+mpas_ocn_lagrangian_particle_tracking.o: mpas_ocn_particle_list.o mpas_ocn_lagrangian_particle_tracking_interpolations.o 
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/analysis_members/Registry_analysis_members.xml
+++ b/src/core_ocean/analysis_members/Registry_analysis_members.xml
@@ -8,5 +8,6 @@
 #include "Registry_test_compute_interval.xml"
 #include "Registry_high_frequency_output.xml"
 #include "Registry_time_filters.xml"
+#include "Registry_lagrangian_particle_tracking.xml"
 #include "Registry_eliassen_palm.xml"
 #include "Registry_mixed_layer_depths.xml"

--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -1,0 +1,305 @@
+	<nml_record name="AM_lagrPartTrack" mode="forward;analysis">
+		<nml_option name="config_AM_lagrPartTrack_enable" type="logical" default_value=".false." units="unitless"
+					description="If true, ocean analysis member lagrPartTrack is called."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_AM_lagrPartTrack_compute_interval" type="character" default_value="dt" units="unitless"
+					description="Timestamp determining how often analysis member computation should be performed."
+					possible_values="'DDDD_HH:MM:SS', 'output', 'dt'"
+		/>
+		<nml_option name="config_AM_lagrPartTrack_compute_on_startup" type="logical" default_value=".true." units="unitless"
+					description="Logical flag determining if an analysis member computation occurs on start-up."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_AM_lagrPartTrack_stream_name" type="character" default_value="lagrPartTrackOutput" units="unitless"
+					description="Name of the stream that the lagrPartTrack analysis member should be tied to."
+					possible_values="Any existing stream name or 'none'"
+		/>
+		<nml_option name="config_AM_lagrPartTrack_write_on_startup" type="logical" default_value=".true." units="unitless"
+					description="Logical flag determining if an analysis member write occurs on start-up."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_AM_lagrPartTrack_filter_number" type="integer" default_value="0" units="unitless"
+					description="Number of times to apply filtering operation."
+					possible_values="0, 1, 2, ..."
+		/>
+	</nml_record>
+
+	<dims>
+		<dim name="nParticles" units="unitless" decomposition="uniform" 
+			 description="The total number of particles in the simlulation."
+		/>
+		<dim name="nBuoyancySurfaces" definition="1" units="unitless"
+			 description="The total number of buoyancy surfaces on which to interpolate velocity."
+		/>
+	</dims>
+
+	<packages>
+		<package name="lagrPartTrackAMPKG" description="This package includes variables required for the lagrPartTrack analysis member."/>
+	</packages>
+
+	<streams>
+		<stream name="lagrPartTrackOutput" type="output"
+				mode="forward;analysis"
+				filename_template="analysis_members/lagrPartTrack.$Y-$M-$D_$h.$m.$s.nc"
+				filename_interval="01-00-00_00:00:00"
+				output_interval="0002_00:00:00"
+				packages="lagrPartTrackAMPKG"
+				clobber_mode="truncate"
+		  runtime_format="single_file">
+
+			<var name="xtime"/>
+			<var name="indexToParticleID"/>
+			<var name="currentBlock"/>
+			<var name="currentCell"/>
+			<var name="xParticle"/>
+			<var name="yParticle"/>
+			<var name="zParticle"/>
+			<var name="zLevelParticle"/>
+			<var name="buoyancyParticle"/>
+			<var name="vertexReconstMethod"/>
+			<var name="horizontalTreatment"/>
+			<var name="verticalTreatment"/>
+			<var name="dtParticle"/>
+			<var name="timeIntegration"/>
+			<var name="indexLevel"/>
+			<var name="uVertexVelocity"/>
+			<var name="vVertexVelocity"/>
+			<var name="wVertexVelocity"/>
+			<var name="filteredVelocityU"/>
+			<var name="filteredVelocityV"/>
+			<var name="filteredVelocityW"/>
+			<var name="cellOwnerBlock"/>
+			<var name="transfered"/>
+			<var name="lonVel"/>
+			<var name="latVel"/>
+			<var name="sumU"/>
+			<var name="sumV"/>
+			<var name="sumUU"/>
+			<var name="sumUV"/>
+			<var name="sumVV"/>
+			<var name="buoyancySurfaceValues"/>
+			<var name="buoyancySurfaceVelocityMeridional"/>
+			<var name="buoyancySurfaceVelocityZonal"/>
+			<var name="buoyancySurfaceDepth"/>
+	  </stream>
+
+		<stream name="lagrPartTrackRestart" type="input;output"
+				mode="forward"
+				filename_template="analysis_members/lagrangianParticleTrackingRestart.$Y-$M-$D_$h.$m.$s.nc"
+				filename_interval="output_interval"
+				clobber_mode="truncate"
+				input_interval="initial_only"
+				output_interval="0030_00:00:00"
+				packages="lagrPartTrackAMPKG"
+		  immutable="true">
+
+			<var name="xtime"/>
+			<var name="indexToParticleID"/>
+			<var name="currentBlock"/>
+			<var name="currentCell"/>
+			<var name="xParticle"/>
+			<var name="yParticle"/>
+			<var name="zParticle"/>
+			<var name="zLevelParticle"/>
+			<var name="buoyancyParticle"/>
+			<var name="vertexReconstMethod"/>
+			<var name="horizontalTreatment"/>
+			<var name="verticalTreatment"/>
+			<var name="dtParticle"/>
+			<var name="timeIntegration"/>
+			<var name="indexLevel"/>
+			<var name="transfered"/>
+			<var name="sumU"/>
+			<var name="sumV"/>
+			<var name="sumUU"/>
+			<var name="sumUV"/>
+			<var name="sumVV"/>
+			<var name="buoyancySurfaceValues"/>
+	  </stream>
+
+		<stream name="lagrPartTrackInput" type="input"
+						mode="forward;analysis"
+						filename_template="analysis_members/lagrangianParticleTrackingInput.nc"
+						input_interval="initial_only"
+						packages="lagrPartTrackAMPKG"
+						immutable="true">
+			<var name="indexToParticleID"/>
+			<var name="currentBlock"/>
+			<var name="currentCell"/>
+			<var name="xParticle"/>
+			<var name="yParticle"/>
+			<var name="zParticle"/>
+			<var name="zLevelParticle"/>
+			<var name="buoyancyParticle"/>
+			<var name="vertexReconstMethod"/>
+			<var name="horizontalTreatment"/>
+			<var name="verticalTreatment"/>
+			<var name="dtParticle"/>
+			<var name="timeIntegration"/>
+			<var name="indexLevel"/>
+			<var name="transfered"/>
+			<var name="buoyancySurfaceValues"/>
+		</stream>
+	</streams>
+
+	<var_struct name="lagrPartTrackFields" time_levs="2" packages="lagrPartTrackAMPKG">
+		<var name="uVertexVelocity" type="real" dimensions="nVertLevels nVertices Time" units="m s^{-1}"
+			 description="recostructed u horizontal velocity at vertices"
+		/>
+		<var name="vVertexVelocity" type="real" dimensions="nVertLevels nVertices Time" units="m s^{-1}"
+			 description="recostructed v horizontal velocity at vertices"
+		/>
+		<var name="wVertexVelocity" type="real" dimensions="nVertLevels nVertices Time" units="m s^{-1}"
+			 description="recostructed w horizontal velocity at vertices"
+		/>
+		<var name="buoyancy" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3}"
+			 description="buoyancy values at cell mid points, currently proxy for density"
+		/>
+	</var_struct>
+	<var_struct name="lagrPartTrackCells" time_levs="1" packages="lagrPartTrackAMPKG">
+		<var name="cellOwnerBlock" type="integer" dimensions="nCells" units="unitless"
+			 description="designates ownership of cell in terms of computational block"
+		/>
+		<var name="filteredVelocityW" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="filtered u horizontal velocity at cells"
+		/>
+		<var name="filteredVelocityV" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="filtered v horizontal velocity at cells"
+		/>
+		<var name="filteredVelocityU" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="filtered w horizontal velocity at cells"
+		/>
+		<var name="buoyancySurfaceVelocityZonal" type="real" dimensions="nBuoyancySurfaces nCells Time" units="m s^{-1}"
+			 description="horizontal zonal velocity on buoyancy surface"
+		/>
+		<var name="buoyancySurfaceVelocityMeridional" type="real" dimensions="nBuoyancySurfaces nCells Time" units="m s^{-1}"
+			 description="horizontal meridional velocity on buoyancy surface"
+		/>
+		<var name="buoyancySurfaceDepth" type="real" dimensions="nBuoyancySurfaces nCells Time" units="m s^{-1}"
+			 description="depth of buoyancy surface"
+		/>
+		<var name="buoyancySurfaceValues" type="real" dimensions="nBuoyancySurfaces" units="kg m^{-3}"
+			 description="definition of buoyancy surfaces in terms of potential density"
+		/>
+		<var name="wachspressAreaB" type="real" dimensions="nCells maxEdges" units="m^2"
+			 description="cached polygon subarea B_i used in Wachspess calculation"
+		/>
+	</var_struct>
+	<var_struct name="lagrPartTrackHalo" time_levs="1" packages="lagrPartTrackAMPKG">
+		<var name="ioBlock" type="integer" dimensions="nParticles" units="unitless"
+			 description="input / output Proc for particle"
+		/>
+		<var name="currentBlock" type="integer" dimensions="nParticles Time" units="unitless"
+			 description="current block a particle is on"
+		/>
+		<var name="currentCell" type="integer" dimensions="nParticles Time" units="unitless"
+			 description="current cell a particle is on"
+		/>
+		<var name="indexToParticleID" type="integer" dimensions="nParticles" units="unitless"
+			 description="designates global ID for a particle"
+		/>
+		<var name="xParticle" type="real" dimensions="nParticles Time" units="m"
+			 description="x location of horizontal particle position"
+		/>
+		<var name="yParticle" type="real" dimensions="nParticles Time" units="m"
+			 description="y location of horizontal particle position"
+		/>
+		<var name="zParticle" type="real" dimensions="nParticles Time" units="m"
+			 description="z location of horizontal particle position"
+		/>
+		<var name="zLevelParticle" type="real" dimensions="nParticles Time" units="m"
+			 description="z-level for vertical elevation of particle position"
+		/>
+		<var name="vertexReconstMethod" type="integer" dimensions="nParticles Time", units="unitless"
+			 description="type of vertex reconstruction method, with possible_values='RBFlinear(1)' as ENUMs"
+		/>
+		<var name="timeIntegration" type="integer" dimensions="nParticles Time", units="unitless"
+			 description="type of temporal interpolation with possible_values='EE(1), RK2(2), RK4(4)' as ENUMs"
+		/>
+		<var name="horizontalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+			 description="select type of horizontal treatment to be used, with possible_values='wachspress' as ENUMs"
+		/>
+		<var name="verticalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+			 description="select type of vertical treatment to be used, with possible_values='indexLevel','fixedZLevel','passiveFloat','buoyancySurface','argoFloat' (ENUM)"
+		/>
+		<var name="indexLevel" type="integer" dimensions="nParticles Time" units="unitless"
+			 description="0 if particle is fixed, or index level if particle is free-floating"
+		/>
+		<var name="dtParticle" type="real" dimensions="nParticles Time" units="s"
+			 description="Any positive real value, but limited by CFL condition."
+		/>
+		<var name="buoyancyParticle" type="real" dimensions="nParticles Time" units="kg m^{-3}"
+			 description="buoyancy values for particle, currently proxy for density"
+		/>
+		<var name="transfered" type ="integer" dimensions="nParticles Time" units="unitless"
+			 description="flag to monitor if the particle was transfered"
+		/>
+		<var name="sumU" type="real" dimensions="nParticles Time" units="m s^{-1}"
+			 description="summed velocity: \sum_i U_i"
+		/>
+		<var name="sumV" type="real" dimensions="nParticles Time" units="m s^{-1}"
+			 description="summed velocity: \sum_i V_i"
+		/>
+		<var name="sumUU" type="real" dimensions="nParticles Time" units="m^2 s^{-2}"
+			 description="summed energy: \sum_i U*U"
+		/>
+		<var name="sumUV" type="real" dimensions="nParticles Time" units="m^2 s^{-2}"
+			 description="summed energy: \sum_i U*V"
+		/>
+		<var name="sumVV" type="real" dimensions="nParticles Time" units="m^2 s^{-2}"
+			 description="summed energy: \sum_i V*V"
+		/>
+		<var name="lonVel" type="real" dimensions="nParticles Time" units="m s^{-1}"
+			 description="u velocity of particle - zonal direction"
+		/>
+		<var name="latVel" type="real" dimensions="nParticles Time" units="m s^{-1}"
+			 description="v velocity of particle - meridional direction"
+		/>
+	</var_struct>
+	<var_struct name="lagrPartTrackNonHalo" time_levs="1" packages="lagrPartTrackAMPKG">
+	</var_struct>
+	<var_struct name="lagrPartTrackScratch" time_levs="1" packages="lagrPartTrackAMPKG">
+		<var name="ucReconstructX" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="reconstructed cell center velocity- x component"
+		/>
+		<var name="ucReconstructY" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="reconstructed cell center velocity- y component"
+		/>
+		<var name="ucReconstructZ" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="reconstructed cell center velocity- z component"
+		/>
+		<var name="ucTemp" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="cell velocity"
+		/>
+		<var name="ucX" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="cell velocity- x component"
+		/>
+		<var name="ucY" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="cell velocity- y component"
+		/>
+		<var name="ucZ" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="cell velocity- z component"
+		/>
+		<var name="uvX" type="real" dimensions="nVertLevels nVertices" units="m s^{-1}"
+			 description="vertex velocity- x component"
+		/>
+		<var name="uvY" type="real" dimensions="nVertLevels nVertices" units="m s^{-1}"
+			 description="vertex velocity- y component"
+		/>
+		<var name="uvZ" type="real" dimensions="nVertLevels nVertices" units="m s^{-1}"
+			 description="vertex velocity- z component"
+		/>
+		<var name="ucReconstructMeridional" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="reconstructed cell center velocity- meridional component"
+		/>
+		<var name="ucReconstructZonal" type="real" dimensions="nVertLevels nCells" units="m s^{-1}"
+			 description="reconstructed cell center velocity- zonal component"
+		/>
+		<var name="boundaryVertexGlobal" type="integer" dimensions="nVertLevels nVertices" units="unitless"
+			 description="Mask for determining boundary vertices, but global. A boundary vertex has at least one inactive cell neighboring it."
+		/>
+		<var name="boundaryCellGlobal" type="integer" dimensions="nVertLevels nCells" units="unitless"
+			 description="Mask for determining boundary cells, but global. A boundary cell has at least one inactive cell neighboring it."
+		/>
+	</var_struct>

--- a/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
@@ -36,6 +36,7 @@ module ocn_analysis_driver
    use ocn_test_compute_interval
    use ocn_high_frequency_output
    use ocn_time_filters
+   use ocn_lagrangian_particle_tracking
    use ocn_eliassen_palm
    use ocn_mixed_layer_depths
 !   use ocn_TEM_PLATE
@@ -151,6 +152,7 @@ contains
       call mpas_pool_add_config(analysisMemberList, 'zonalMean', 1)
       call mpas_pool_add_config(analysisMemberList, 'highFrequencyOutput', 1)
       call mpas_pool_add_config(analysisMemberList, 'timeFilters', 1)
+      call mpas_pool_add_config(analysisMemberList, 'lagrPartTrack', 1)
       call mpas_pool_add_config(analysisMemberList, 'eliassenPalm', 1)
       call mpas_pool_add_config(analysisMemberList, 'mixedLayerDepths', 1)
 !     call mpas_pool_add_config(analysisMemberList, 'temPlate', 1)
@@ -749,6 +751,8 @@ contains
         call ocn_init_high_frequency_output(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'timeFilters' ) then
         call ocn_init_time_filters(domain, err_tmp)
+     else if ( analysisMemberName(1:nameLength) == 'lagrPartTrack' ) then
+        call ocn_init_lagrangian_particle_tracking(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'eliassenPalm' ) then
         call ocn_init_eliassen_palm(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'mixedLayerDepths' ) then
@@ -804,6 +808,8 @@ contains
         call ocn_compute_high_frequency_output(domain, timeLevel, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'timeFilters' ) then
         call ocn_compute_time_filters(domain, timeLevel, err_tmp)
+     else if ( analysisMemberName(1:nameLength) == 'lagrPartTrack' ) then
+        call ocn_compute_lagrangian_particle_tracking(domain, timeLevel, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'eliassenPalm' ) then
         call ocn_compute_eliassen_palm(domain, timeLevel, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'mixedLayerDepths' ) then
@@ -858,6 +864,8 @@ contains
         call ocn_restart_high_frequency_output(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'timeFilters' ) then
         call ocn_restart_time_filters(domain, err_tmp)
+     else if ( analysisMemberName(1:nameLength) == 'lagrPartTrack' ) then
+        call ocn_restart_lagrangian_particle_tracking(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'eliassenPalm' ) then
         call ocn_restart_eliassen_palm(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'mixedLayerDepths' ) then
@@ -912,6 +920,8 @@ contains
         call ocn_finalize_high_frequency_output(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'timeFilters' ) then
         call ocn_finalize_time_filters(domain, err_tmp)
+     else if ( analysisMemberName(1:nameLength) == 'lagrPartTrack' ) then
+        call ocn_finalize_lagrangian_particle_tracking(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'eliassenPalm' ) then
         call ocn_finalize_eliassen_palm(domain, err_tmp)
      else if ( analysisMemberName(1:nameLength) == 'mixedLayerDepths' ) then

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -1,0 +1,2698 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_lagrangian_particle_tracking
+!
+!> \brief MPAS ocean analysis mode member: lagrangian_particle_tracking
+!> \author Phillip J. Wolfram
+!> \date   02/20/14 and 07/23/2015
+!> \details
+!>  MPAS ocean analysis core member: lagrangian particle tracking
+!>  module computes Lagrangian particle trajectories and associated
+!>  diagnostics
+!-----------------------------------------------------------------------
+
+module ocn_lagrangian_particle_tracking
+
+   use mpas_timer
+   use mpas_dmpar
+   use mpas_timekeeping
+   use mpas_stream_manager
+
+   use ocn_constants
+
+   use ocn_particle_list
+   use ocn_lagrangian_particle_tracking_interpolations
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_init_lagrangian_particle_tracking, &
+             ocn_compute_lagrangian_particle_tracking, &
+             ocn_restart_lagrangian_particle_tracking, &
+             ocn_finalize_lagrangian_particle_tracking
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   ! timer
+   type (timer_node), pointer :: timerTotalLPT, timerInitAlarms, timerInit, timerComputeStartup, timerCompute, timerWrite, timerRestart, timerFinalize, timerValidatedCell
+   type (timer_node), pointer :: timerValidatedCell_out, timerValidatedCell_init, timerVerticalID, timerTransferParticles, timerVelTimeInterp
+   type (timer_node), pointer :: timerVelTimeInterp_out, timerHorizMovement, timerUpdateIOHalo, timerConvertXYZLatLon, timerCellID, timerCellID_init, timerReconstFilter
+   type (timer_node), pointer :: timerReconstFilter_init, timerVelocityPotDensity, timerTimeStepLPT, timerTransferParticles_init, timerTransferParticles_write, timerMemTasksLPT
+   type (timer_node), pointer ::  timerSinglePartStats, timerParticleAssignment, timerHorizVelInterp
+   ! neighboring processors and arrays for send numbers / recvs, total number of neighboring processors to a particular processor
+   ! allocated in init, deallocated in finalize
+   ! these globals could be moved to the framework component, as well
+   ! as quite a few of the subroutines
+   integer, dimension(:), pointer :: g_ProcNeighs => null(), g_ioProcNeighs=>null()
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_init_lagrangian_particle_tracking
+!
+!> \brief   Initialize MPAS-Ocean analysis member
+!> \author  Phillip J. Wolfram
+!> \date    02/20/14
+!> \details
+!>  This routine conducts all initializations required for the
+!>  MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_init_lagrangian_particle_tracking(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      logical, pointer :: config_do_restart
+
+      err = 0
+
+      write(stderrUnit,*) 'starting ocn_init_lagrangian_particle_tracking'
+      call mpas_timer_start("totalLPT", .false., timerTotalLPT)
+      call mpas_timer_start("initLPT", .false., timerInit)
+
+      ! load in data
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'starting reading stream for lagrPartTrack'
+#endif
+      call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
+      if (config_do_restart) then
+        call MPAS_stream_mgr_read(domain % streamManager, streamID='lagrPartTrackRestart', ierr=err)
+      else
+        call MPAS_stream_mgr_read(domain % streamManager, streamID='lagrPartTrackInput', ierr=err)
+      end if
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'finished reading stream for lagrPartTrack'
+#endif
+      ! resets likely are unnecessary
+      !call mpas_stream_mgr_reset_alarms(stream_manager, streamID='lagrPartTrackInput', ierr=err)
+      !call mpas_stream_mgr_reset_alarms(stream_manager, streamID='lagrPartTrackRestart', ierr=err)
+
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      ! init
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      ! build up the particles lists and fill them with their data
+      call mpas_particle_list_build_and_assign_particle_list(domain, err)
+      ! now we have built the particlelist for a given block
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'finished building and allocating particles in init'
+#endif
+
+      ! parallel code:
+
+      ! get "MPI halos" for communication of particles in halo during computational step
+      call mpas_particle_list_build_computation_halos(domain, err, g_ProcNeighs)
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'finished building and computational halos'
+#endif
+
+      ! get "MPI halos" for IO communication during write and restart steps (ioBlock to currentBlocks)
+      call mpas_particle_list_build_io_halos(domain, err, 'currentBlock', g_ioProcNeighs)
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'g_ioProcNeighs=', g_ioProcNeighs
+      write(stderrUnit,*) 'finished building io halos'
+#endif
+
+      ! transfer particles to their appropriate blocks (currentBlock) via MPI
+      ! note, don't necessarily need to have g_ionSend and g_ionRecv comeout
+#ifdef MPAS_DEBUG
+      call mpas_timer_start("trans_from_block_to_blockLPT", .false., timerTransferParticles_init)
+      call mpas_particle_list_test_numparticles_to_neighprocs(domain % dminfo % my_proc_id, g_ProcNeighs, g_ioProcNeighs)
+#endif
+      call mpas_particle_list_transfer_particles_from_block_to_named_block(domain, err, .True., .False., 'currentBlock', &
+        g_ioProcNeighs)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("trans_from_block_to_blockLPT", timerTransferParticles_init)
+      !call MPI_Barrier(domain % dminfo % comm, err)
+#endif
+
+      ! tests to make sure all the values are ok !{{{
+#ifdef MPAS_DEBUG
+      call mpas_particle_list_test_neighscalc(domain, err)
+      call mpas_particle_list_test_numparticles_to_neighprocs(domain % dminfo % my_proc_id, g_ProcNeighs, g_ioProcNeighs)
+      call mpas_particle_list_test_num_current_particlelist(domain)
+#endif
+      !}}}
+
+      ! now set sums for autocorrelation calculation to be zero
+      call zero_autocorrelation_sums(domain)
+
+      ! previous compute startup calls
+      call intialize_wachspress_coefficients(domain, err)
+      call initalize_fields(domain, err)
+      call compute_velocity_on_potentialdensity_surface(domain,err,1)
+      call compute_velocity_on_potentialdensity_surface(domain,err,2)
+      call initialize_particle_properties(domain,2,err)
+      call write_lagrangian_particle_tracking(domain, err)
+
+      write(stderrunit,*) 'finished ocn_init_lagrangian_particle_tracking'
+      call mpas_timer_stop("initLPT", timerInit)
+
+      call mpas_timer_stop("totalLPT", timerTotalLPT)
+
+   end subroutine ocn_init_lagrangian_particle_tracking!}}}
+
+
+!***********************************************************************
+!
+!  routine ocn_compute_lagrangian_particle_tracking
+!
+!> \brief   Compute MPAS-Ocean analysis member
+!> \author  Phillip J. Wolfram
+!> \date    02/20/14
+!> \details
+!>  This routine conducts all computation required for this
+!>  MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_compute_lagrangian_particle_tracking(domain, timeLevel, err)!{{{
+
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: timeLevel
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type (dm_info) :: dminfo
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: statePool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: scratchPool
+      type (mpas_pool_type), pointer :: diagnosticsPool
+      type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackCellsPool, lagrPartTrackScratchPool
+      integer, dimension(:), pointer :: cellOwnerBlock
+      integer, pointer :: currentBlock, ioBlock, indexToParticleID, transfered
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (mpas_particle_type), pointer :: particle
+
+      real (kind=RKIND), dimension(3) :: particlePosition, particleVelocity
+      real (kind=RKIND), pointer :: xParticle, yParticle, zParticle, lonVel, latVel, buoyancyParticle, sumU, sumV, sumUU, sumUV, sumVV
+      real (kind=RKIND), dimension(3) :: xSubStep, diffSubStep, diffParticlePosition
+      real (kind=RKIND), pointer :: zLevelParticle
+      real (kind=RKIND), dimension(:,:), pointer :: zTop, vertVelocityTop, zMid, areaBArray
+      real (kind=RKIND), dimension(:), pointer :: bottomDepth
+      type (field2DReal), pointer :: normalVelocity, uVertexVelocity, vVertexVelocity, wVertexVelocity, layerThickness
+
+      real (kind=RKIND), dimension(:,:), pointer :: uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, buoyancyTimeInterp, potentialDensity
+
+      real(kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
+      real(kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+
+      integer, dimension(:,:), pointer :: verticesOnCell, boundaryVertex
+      integer, dimension(:), pointer :: maxLevelCell
+
+      integer theVertex, iLevel, iLevelBuoyancy, aVertex, &
+        nSteps, timeStep, subStep, subStepOrder, timeInterpOrder, aTimeLevel, nCellVertices, blockProc, arrayIndex
+      integer, pointer :: nCells, nVertLevels, iCell
+      integer, dimension(:), pointer :: nCellVerticesArray
+      integer, dimension(:,:), pointer :: cellsOnCell
+      logical, dimension(:,:), pointer :: ioProcRecvList
+      logical, dimension(:), pointer :: ioProcSendList
+      logical, pointer :: onSphere
+
+      real (kind=RKIND), dimension(4) :: kWeightK, kWeightKVert
+      real (kind=RKIND), dimension(3,4) :: kWeightX
+      real (kind=RKIND), dimension(4) :: kWeightXVert
+      real (kind=RKIND), dimension(4) :: kWeightT, kWeightTVert
+      real (kind=RKIND), dimension(3,5) :: kCoeff
+      real (kind=RKIND), dimension(5) :: kCoeffVert
+      real (kind=RKIND), dimension(2) :: timeCoeff
+      real (kind=RKIND) :: dt, dtSim, tSubStep
+      real (kind=RKIND), pointer :: dtParticle
+      real (kind=RKIND) :: zSubStep
+      real (kind=RKIND) :: diffSubStepVert, diffParticlePositionVert, particleVelocityVert, verticalVelocityInterp
+      real (kind=RKIND) :: buoyancyInterp
+      real (kind=RKIND), pointer :: sphereRadius
+      integer, pointer :: verticalTreatment, vertexReconstMethod, timeIntegration, indexLevel, filterNum
+      character(len=StrKIND), pointer :: config_dt
+      type (MPAS_timeInterval_type) :: timeStepESMF
+      integer :: err_tmp
+
+      err = 0
+
+      !! don't do compute for debugging purposes
+      !write(stderrUnit,*) 'Computing Lagrangian Particle Tracking -- NO COMPUTATION!'
+      !return
+
+      dminfo = domain % dminfo
+
+      write(stderrUnit,*) 'Computing Lagrangian Particle Tracking...'
+      call mpas_timer_start("totalLPT", .false., timerTotalLPT)
+      call mpas_timer_start("computeLPT", .false., timerCompute)
+
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_filter_number', filterNum)
+
+      allocate(ioProcRecvList(size(g_ioProcNeighs), domain % dminfo % nprocs))
+      allocate(ioProcSendList(domain % dminfo % nprocs))
+      ioProcRecvList = .False.
+      ioProcSendList = .False.
+
+      ! get the most recent velocities on the potential density surfaces
+#ifdef MPAS_DEBUG
+      call mpas_timer_start("velocity_pot_density_LPT", .false., timerVelocityPotDensity)
+#endif
+      call compute_velocity_on_potentialdensity_surface(domain,err,2)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("velocity_pot_density_LPT",timerVelocityPotDensity)
+#endif
+
+      block => domain % blocklist
+      do while (associated(block)) !{{{
+#ifdef MPAS_DEBUG
+        call mpas_timer_start("memtasksLPT", .false., timerMemTasksLPT)
+#endif
+        ! allocate scratch memory / setup pointers / get block !{{{
+        call mpas_pool_get_subpool(block % structs, 'state', statePool)
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
+
+        ! particlelist should be stored in the structs pool probably (need to seriously rework the code!)
+        particlelist => block % particlelist
+
+        call mpas_pool_get_array(meshPool, 'xCell', xCell)
+        call mpas_pool_get_array(meshPool, 'yCell', yCell)
+        call mpas_pool_get_array(meshPool, 'zCell', zCell)
+        call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+        call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+        call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'wachspressAreaB', areaBArray)
+        call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
+        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+        call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
+
+        ! note, originally this was diagnostics % state % normalVelocity (without time level), but
+        ! now there is a time level so selection of the correct time level appears to be tricky
+        ! the issue is large, nearly NAN normalVelocities with timeLevel=2
+        call mpas_pool_get_field(statePool, 'normalVelocity', normalVelocity, timeLevel=timeLevel)
+        ! potentially a costly function call, but ensures halos are ok
+        !call mpas_dmpar_exch_halo_field(normalVelocity)
+        call mpas_pool_get_field(statePool, 'layerThickness', layerThickness, timeLevel=timeLevel)
+
+        call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
+        call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+        call mpas_pool_get_array(meshPool, 'boundaryVertex', boundaryVertex)
+        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+        call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nCellVerticesArray)
+        call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+
+        call mpas_pool_get_config(meshPool, 'on_a_sphere', onSphere)
+        call mpas_pool_get_config(meshPool, 'sphere_radius', sphereRadius)
+        call mpas_pool_get_config(block % configs, 'config_dt', config_dt)
+        call mpas_set_timeInterval(timeStepESMF, timeString=config_dt, ierr=err)
+        !}}}
+
+        !{{{
+        ! flip previous time level to back (switching memory pointers)
+        call mpas_pool_shift_time_levels(lagrPartTrackFieldsPool)
+        call mpas_pool_get_field(lagrPartTrackFieldsPool, 'uVertexVelocity', uVertexVelocity, timeLevel=2)
+        call mpas_pool_get_field(lagrPartTrackFieldsPool, 'vVertexVelocity', vVertexVelocity, timeLevel=2)
+        call mpas_pool_get_field(lagrPartTrackFieldsPool, 'wVertexVelocity', wVertexVelocity, timeLevel=2)
+#ifdef MPAS_DEBUG
+        call mpas_timer_stop("memtasksLPT",timerMemTasksLPT)
+#endif
+
+#ifdef MPAS_DEBUG
+        call mpas_timer_start("reconst_filter_LPT", .false., timerReconstFilter)
+#endif
+        call ocn_vertex_reconstruction(filterNum, meshPool, lagrPartTrackScratchPool, lagrPartTrackCellsPool, &
+          layerThickness % array, normalVelocity % array, &
+          uVertexVelocity, vVertexVelocity, wVertexVelocity)
+#ifdef MPAS_DEBUG
+        call mpas_timer_stop("reconst_filter_LPT", timerReconstFilter)
+        write(stderrUnit,*) 'uVertexVelocity=',uVertexVelocity % array
+        write(stderrUnit,*) 'vVertexVelocity=',vVertexVelocity % array
+        write(stderrUnit,*) 'wVertexVelocity=',wVertexVelocity % array
+#endif
+        !}}}
+
+#ifdef MPAS_DEBUG
+        write(stderrUnit,*) 'beginning particle loop with particlelist associated =  ', associated(particlelist)
+        ! error is here
+        call mpas_particle_list_test_num_current_particlelist(domain)
+#endif
+
+        !!!!!!!!!! LOOP OVER PARTICLES !!!!!!!!!!
+        ! update the particle position (just from initialized value for now)
+        ! this is a loop over particle list and its datastructures
+        do while(associated(particlelist)) !{{{
+          ! get pointers / option values
+          particle => particlelist % particle
+
+          ! get values {{{
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("memtasksLPT", .false., timerMemTasksLPT)
+#endif
+          call mpas_pool_get_array(particle % haloDataPool, 'xParticle', xParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'yParticle', yParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'zParticle', zParticle)
+          particlePosition(1) = xParticle
+          particlePosition(2) = yParticle
+          particlePosition(3) = zParticle
+
+          call mpas_pool_get_array(particle % haloDataPool, 'zLevelParticle', zLevelParticle)
+
+          call mpas_pool_get_array(particle % haloDataPool, 'verticalTreatment', verticalTreatment)
+          call mpas_pool_get_array(particle % haloDataPool, 'vertexReconstMethod', vertexReconstMethod)
+          call mpas_pool_get_array(particle % haloDataPool, 'indexLevel', indexLevel)
+          call mpas_pool_get_array(particle % haloDataPool, 'timeIntegration', timeIntegration)
+          call mpas_pool_get_array(particle % haloDataPool, 'dtParticle', dtParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'buoyancyParticle', buoyancyParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'indexToParticleID', indexToParticleID)
+          call mpas_pool_get_array(particle % haloDataPool, 'currentCell', iCell)
+
+          call mpas_pool_get_array(particle % haloDataPool, 'lonVel', lonVel)
+          call mpas_pool_get_array(particle % haloDataPool, 'latVel', latVel)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumU', sumU)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumV', sumV)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumUU', sumUU)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumUV', sumUV)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumVV', sumVV)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("memtasksLPT",timerMemTasksLPT)
+#endif
+          ! process timers / particle reset functions here (need a timer and ability to reset particle to
+          ! some set of initial values for the reset
+          !}}}
+
+          !!!!!!!!!! COMPUTE TIME STEP INFORMATION !!!!!!!!!!
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("time_step_LPT", .false., timerTimeStepLPT)
+#endif
+          ! would eventually need to correspond to domain dt, but for now this is a
+          ! global constant
+          call mpas_get_timeInterval(timeStepESMF, dt=dtSim)
+          ! adjust time step for consistency with integer number of steps
+          nSteps = ceiling(dtSim/dtParticle)
+          dt = dtSim/nSteps
+
+          !!!!!!!!!! ASSIGN TEMPORAL INTEGRATION COEFFICIENTS !!!!!!!!!!
+          ! kCoeff   is (3,subStepOrder+1)
+          ! kWeightX is subStepOrder
+          ! kWeightK is subStepOrder
+          ! kWeightT is subStepOrder
+          select case (timeIntegration) !{{{
+            case(1) ! EE integration
+              kWeightK(1) = 0.0_RKIND
+
+              kWeightT(1) = 0.0_RKIND
+
+              kWeightX(:,1) = 1.0_RKIND
+
+              subStepOrder = 1
+            case(2) ! RK2 integration
+              kWeightK(1) = 0.0_RKIND
+              kWeightK(2) = 0.5_RKIND
+
+              kWeightT(1) = 0.0_RKIND
+              kWeightT(2) = 0.5_RKIND
+
+              kWeightX(:,1) = 0.0_RKIND
+              kWeightX(:,2) = 1.0_RKIND
+
+              subStepOrder = 2
+            case(4) ! RK4 integration
+              kWeightK(1) = 0.0_RKIND
+              kWeightK(2) = 0.5_RKIND
+              kWeightK(3) = 0.5_RKIND
+              kWeightK(4) = 1.0_RKIND
+
+              kWeightT(1) = 0.0_RKIND
+              kWeightT(2) = 0.5_RKIND
+              kWeightT(3) = 0.5_RKIND
+              kWeightT(4) = 1.0_RKIND
+
+              kWeightX(:,1) = 1.0_RKIND/6.0_RKIND
+              kWeightX(:,2) = 1.0_RKIND/3.0_RKIND
+              kWeightX(:,3) = 1.0_RKIND/3.0_RKIND
+              kWeightX(:,4) = 1.0_RKIND/6.0_RKIND
+
+              subStepOrder = 4
+            case default ! RK2 integration
+              kWeightK(1) = 0.0_RKIND
+              kWeightK(2) = 0.5_RKIND
+
+              kWeightT(1) = 0.0_RKIND
+              kWeightT(2) = 0.5_RKIND
+
+              kWeightX(:,1) = 0.0_RKIND
+              kWeightX(:,2) = 1.0_RKIND
+
+              subStepOrder = 2
+          end select  !}}}
+
+          ! use same integration coefficients for the vertical
+          kWeightKVert = kWeightK
+          kWeightXVert = kWeightX(1,:)
+          kWeightTVert = kWeightT
+          kCoeffVert   = kCoeff(1,:)
+
+          !!!!!!!!!! LOOP OVER TIME STEPS !!!!!!!!!!
+          do timeStep = 1, nSteps !{{{
+            ! kCoeff   is (3,subStepOrder+1)
+            kCoeff = 0.0_RKIND
+            kCoeffVert = 0.0_RKIND
+            ! compute first
+            do subStep = 1, subStepOrder !{{{
+
+              !!!!!!!!!! COMPUTE PARTICLE SUBSTEP POSITIONS USE FOR VELOCITY !!!!!!!!!!
+              ! horizontal
+              xSubStep = particlePosition
+              diffSubStep = kWeightK(subStep) * kCoeff(:,subStep)
+
+              if(kWeightK(subStep) /= 0.0_RKIND) then
+                ! project substep to correct spherical shell because diffSubStep isn't 0 and particle moves
+#ifdef MPAS_DEBUG
+                call mpas_timer_start("particle_horizontal_movementLPT", .false., timerHorizMovement)
+#endif
+                call particle_horizontal_movement(xSubStep, diffSubStep, onSphere)
+#ifdef MPAS_DEBUG
+                call mpas_timer_stop("particle_horizontal_movementLPT", timerHorizMovement)
+#endif
+              end if
+
+              ! vertical
+              zSubStep = zLevelParticle
+              diffSubStepVert = kWeightKVert(subStep) * kCoeffVert(subStep)
+
+              if(kWeightKVert(subStep) /= 0.0_RKIND) then
+                zSubStep = zSubStep + diffSubStepVert
+              end if
+
+              ! get new time step (tm = (timestep-1)*dt)
+              tSubStep = (timeStep-1 + kWeightT(subStep)) * dt
+
+              !!!!!!!!!! GET SPECIFIC CELL INDICES AND GEOMETRY !!!!!!!!!!
+
+              ! determine cell location
+#ifdef MPAS_DEBUG
+              call mpas_timer_start("get_validated_cell_idLPT", .false., timerValidatedCell)
+              write(stderrUnit, *) 'beginning of substeps'
+#endif
+              call get_validated_cell_id(nCells, xCell,yCell,zCell , xVertex,yVertex,zVertex, &
+                xSubStep(1),xSubStep(2),xSubStep(3), onSphere, &
+                nCellVerticesArray, verticesOnCell, iCell, nCellVertices, cellsOnCell)
+#ifdef MPAS_DEBUG
+              write(stderrUnit,*) 'iCell=',iCell
+              call mpas_timer_stop("get_validated_cell_idLPT", timerValidatedCell)
+#endif
+
+              if(verticalTreatment /= 4) then
+                ! other cases using zSubStep for iLevel and vertical interpolation
+#ifdef MPAS_DEBUG
+                call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+                iLevel = mpas_get_vertical_id(maxLevelCell(iCell), zSubStep, zMid(:,iCell))
+#ifdef MPAS_DEBUG
+                call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+                write(stderrUnit,*) 'iLevel=', iLevel
+#endif
+              end if
+
+              !!!!!!!!!! TEMPORALLY INTERPOLATE TIME FIELD !!!!!!!!!!
+              ! use these coefficients to just get the velocity at n
+              !timeInterpOrder = 1
+              !timeCoeff(1) =1.0_RKIND
+              ! use these coefficients to just get the velocity at n+1
+              !timeInterpOrder = 2
+              !timeCoeff(1) =0.0_RKIND
+              !timeCoeff(2) =1.0_RKIND
+              ! get interpolation coefficients for linear interpolation in time
+              timeInterpOrder = 2
+              timeCoeff(1) = tSubStep / dtSim
+              timeCoeff(2) = 1.0_RKIND - timeCoeff(1)
+
+              ! ensure that buoyancy is fixed for each run
+              buoyancyInterp = buoyancyParticle
+              ! return interpolated horizontal velocity "particleVelocity" and vertical velocity "particleVelocityVert"
+
+#ifdef MPAS_DEBUG
+              call mpas_timer_start("velocity_time_interpolationLPT", .false., timerVelTimeInterp)
+#endif
+              call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
+                diagnosticsPool, lagrPartTrackFieldsPool, &
+                timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
+                verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
+                xSubStep, zSubStep, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, meshPool, areaBArray)
+#ifdef MPAS_DEBUG
+              call mpas_timer_stop("velocity_time_interpolationLPT", timerVelTimeInterp)
+#endif
+
+              !!!!!!!!!! FORM INTEGRATION WEIGHTS kj !!!!!!!!!!
+              kCoeff(:,subStep+1) = dt * particleVelocity
+              kCoeffVert(subStep+1) = dt * particleVelocityVert
+            end do
+
+            !!!!!!!!!! UPDATE PARTICLE POSITIONS !!!!!!!!!!
+            !!!!!!!!!! HORIZONTAL AND VERTICAL CONSIDERED SEPARATELY !!!!!!!!!!
+            diffParticlePosition = 0.0_RKIND
+            diffParticlePositionVert = 0.0_RKIND
+            do subStep = 1, subStepOrder
+              ! first complete particle integration
+              diffParticlePosition = diffParticlePosition + kWeightX(:,subStep) * kCoeff(:,subStep+1)
+              diffParticlePositionVert = diffParticlePositionVert + kWeightXVert(subStep) * kCoeffVert(subStep+1)
+            end do
+            ! now, make sure particle position is still on same spherical shell as before
+#ifdef MPAS_DEBUG
+            call mpas_timer_start("particle_horizontal_movementLPT", .false., timerHorizMovement)
+#endif
+            call particle_horizontal_movement(particlePosition, diffParticlePosition, onSphere)
+#ifdef MPAS_DEBUG
+            call mpas_timer_stop("particle_horizontal_movementLPT", timerHorizMovement)
+#endif
+            ! now can do any vertical movements independent of the horizontal movement
+            ! that was just calculated ( probably need to have more output from the vertical_treatment
+            ! and aggregate here
+            zLevelParticle = zLevelParticle + diffParticlePositionVert
+
+          end do !}}}
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("time_step_LPT", timerTimeStepLPT)
+#endif
+          !}}}
+
+          !!!!!!!!!! PERFORM SAMPLING (VELOCITY, TEMP, SALINITY, ETC) !!!!!!!!!!
+          ! this could be done just before the output anyway
+
+          ! need iCell computed for final position
+          ! need scalar values interpolated in time to yield single value
+          ! probably need to store zMid too, including flipping it
+          ! get updated cell location
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("get_validated_cell_idLPT", .false., timerValidatedCell_out)
+          write(stderrUnit,*) 'do sampling'
+#endif
+          call get_validated_cell_id(nCells, xCell,yCell,zCell , xVertex,yVertex,zVertex, &
+            particlePosition(1),particlePosition(2),particlePosition(3), onSphere, &
+            nCellVerticesArray, verticesOnCell, iCell, nCellVertices, cellsOnCell)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("get_validated_cell_idLPT", timerValidatedCell_out)
+#endif
+
+          if(verticalTreatment == 4) then  !('buoyancySurface') !{{{
+            !! determine index level (don't need validated version because that will "fix" values which we may not want
+            !! however, if the particle's target buoyancy surface doesn't exist then we will need to
+            !! ensure that vertical location is valid, placing particles outside of range of zMid back inside
+            !! we don't validate this because we want the code to fail, at least initially, in the case that
+            !! the particle is in a cell that does not have the proper buoyancy target because this implies
+            !! that the buoyancy tracking mode has completely failed.
+            !! need to make sure it is validated for buoyancy particles
+#ifdef MPAS_DEBUG
+            !call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+            !iLevelBuoyancy = mpas_get_vertical_id(maxLevelCell(iCell), buoyancyInterp, buoyancyTimeInterp(:,iCell))
+#ifdef MPAS_DEBUG
+            !call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+#endif
+            !! interpolate the scalars now (assumes that scalar value is constant within a particular cell)
+            !call interp_cell_scalars(iLevelBuoyancy, maxLevelCell(iCell), buoyancyInterp, buoyancyTimeInterp(:,iCell), &
+            !  zMid(:,iCell), zLevelParticle)
+            !deallocate(buoyancyTimeInterp)
+            !!}}}
+          else
+            ! make sure final zLevelParticle is ok so that it can't extent past zMid range
+#ifdef MPAS_DEBUG
+            call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+            iLevel = mpas_get_vertical_id(maxLevelCell(iCell), zLevelParticle, zMid(:,iCell))
+#ifdef MPAS_DEBUG
+            call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+#endif
+          end if
+
+          ! compute necessary information for autocorrelation !{{{
+          ! get the updated velocity
+          ! ensure that buoyancy is fixed for each run
+          buoyancyInterp = buoyancyParticle
+          ! we just need the last part of the velocity field interpolation because we are at the end of the timestep
+          timeInterpOrder = 2
+          timeCoeff(1) = 0.0_RKIND
+          timeCoeff(2) = 1.0_RKIND
+          ! return interpolated horizontal velocity "particleVelocity" and vertical velocity "particleVelocityVert"
+          ! noting we use the final positions
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("velocity_time_interpolationLPT", .false., timerVelTimeInterp_out)
+#endif
+          call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
+            diagnosticsPool, lagrPartTrackFieldsPool, &
+            timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
+            verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
+            particlePosition, zLevelParticle, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, &
+            meshPool, areaBArray)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("velocity_time_interpolationLPT", timerVelTimeInterp_out)
+#endif
+          ! convert horizontal velocity to lat/lon velocity
+
+          ! store velocity for use in computing normalized autocorrelation offline
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("mpas_convert_xyz_velocity_to_latlonLPT", .false., timerConvertXYZLatLon)
+#endif
+          call mpas_convert_xyz_velocity_to_latlon(lonVel, latVel, particlePosition, particleVelocity)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("mpas_convert_xyz_velocity_to_latlonLPT", timerConvertXYZLatLon)
+#endif
+
+          ! now store components needed to compute integral timescale
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("storeSingleParticleStats", .false., timerSinglePartStats)
+#endif
+          sumU = sumU + lonVel
+          sumV = sumV + latVel
+          sumUU = sumUU + lonVel*lonVel
+          sumUV = sumUV + lonVel*latVel
+          sumVV = sumVV + latVel*latVel
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("storeSingleParticleStats", timerSinglePartStats)
+#endif
+          !}}}
+
+          ! properly store particle position (because we can't store arrays directly for particles and must
+          ! work entirely in vectors
+          xParticle = particlePosition(1)
+          yParticle = particlePosition(2)
+          zParticle = particlePosition(3)
+
+          !!!!!!!!!! PASS PARTICLES FROM PROCESSOR TO PROCESSOR !!!!!!!!!!
+          !{{{
+          ! 1. determine if iCell is on halo (just set each particle's currentBlock to the correct currentBlock
+          ! 2. determine owning block in halo, update particle's currentBlock
+
+          ! determine currentBlock ownership of iCell
+          ! and set cellOwnerBlock to be current block
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("particleAssignments", .false., timerParticleAssignment)
+#endif
+          ! update halo fields
+          call mpas_particle_list_update_computational_halos(domain, block, particle, 'lagrPartTrackCells', iCell, arrayIndex, ioProcRecvList, g_ioProcNeighs)
+#ifdef MPAS_DEBUG
+            call mpas_timer_stop("particleAssignments", timerParticleAssignment)
+#endif
+          !}}}
+
+          ! get next particle to process on the list
+          particlelist => particlelist % next
+        end do !}}}
+
+        ! get next block
+        block => block % next
+      end do !}}}
+
+      !!!!!!!!!! PASS PARTICLES FROM PROCESSOR TO PROCESSOR !!!!!!!!!!
+      ! MPI calls
+      ! 3. place particle on temporary list to be sent to processor, removing particle from present list
+      ! 4. pass list of particles to owning block (outside block loop so that all blocks can be processed)
+      ! 5. delete all particles on the temporary lists (potentially if on different proc)
+      !    because they have been permenantly moved to block owning the halo
+      !
+      ! Items 3-5 should be able to be described in terms of current code
+      ! noting that the most important thing is to ensure that the particle's currentBlock is
+      ! updated.  Then, a routine can be called to make sure particles are placed on their appropriate
+      ! currentBlocks
+
+      ! particle transfer can then occur from computational processor to computational processor
+#ifdef MPAS_DEBUG
+      call mpas_timer_start("trans_from_block_to_blockLPT", .false., timerTransferParticles)
+#endif
+      call mpas_particle_list_transfer_particles_from_block_to_named_block(domain, err, .True., .False., 'currentBlock', &
+        g_ProcNeighs)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("trans_from_block_to_blockLPT", timerTransferParticles)
+      call mpas_timer_start("update_io_haloLPT", .false., timerUpdateIOHalo)
+#endif
+      call mpas_particle_list_update_io_halos(domain, err, g_ioProcNeighs, ioProcSendList, ioProcRecvList)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("update_io_haloLPT",timerUpdateIOHalo)
+#endif
+      deallocate(ioProcSendList, ioProcRecvList)
+
+      ! do IO communications if this is an output time step
+      if (mpas_stream_mgr_ringing_alarms(domain % streamManager, streamID='lagrPartTrackOutput', direction=MPAS_STREAM_OUTPUT, ierr=err)) then
+        call write_lagrangian_particle_tracking(domain, err)
+      end if
+
+      call mpas_timer_stop("computeLPT", timerCompute)
+      call mpas_timer_stop("totalLPT", timerTotalLPT)
+
+      write(stderrUnit,*) 'finished computing Lagrangian Particle Tracking'
+
+   end subroutine ocn_compute_lagrangian_particle_tracking!}}}
+
+!***********************************************************************
+!
+!  routine ocn_restart_lagrangian_particle_tracking
+!
+!> \brief   Save restart for MPAS-Ocean analysis member
+!> \author  Phillip J. Wolfram
+!> \date    02/20/14 and 07/23/15
+!> \details
+!>  This routine conducts computation required to save a restart state
+!>  for the MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_restart_lagrangian_particle_tracking(domain, err)!{{{
+
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      call mpas_timer_start("totalLPT", .false., timerTotalLPT)
+      call mpas_timer_start("restartLPT", .false., timerRestart)
+
+      ! do restart if this is a restart step
+      if (mpas_stream_mgr_ringing_alarms(domain % streamManager, streamID='lagrPartTrackRestart', direction=MPAS_STREAM_OUTPUT, ierr=err)) then
+        call mpas_timer_start("restartLPT", .false., timerRestart)
+
+      write(stderrUnit,*) 'start ocn_restart_lagrangian_particle_tracking'
+      ! transfer particles to their appropriate blocks (ioBlock) via MPI
+      ! note, don't necessarily need to have g_ionSend and g_ionRecv comeout
+      call mpas_particle_list_transfer_particles_from_block_to_named_block(domain, err, .True., .True., 'ioBlock', &
+        g_ioProcNeighs)
+
+      ! write out all the data, sorting to make sure that shuffled particles
+      ! are ouptut correctly (done separately in each function, could be
+      ! pulled out as an optimization)
+      ! write halo data out, but don't need nonhalo data because it is
+      ! computed for output (diagnostic, not prognostic)
+      call mpas_particle_list_write_halo_data(domain, err)
+      !call mpas_particle_list_write_nonhalo_data(domain, err)
+
+      ! need to now remove the io particles (remove particles that don't have the
+      ! correct currentBlock)
+      call mpas_particle_list_remove_particles_not_on_current_block(domain,err)
+
+      write(stderrUnit,*) 'end ocn_restart_lagrangian_particle_tracking'
+      call mpas_timer_stop("restartLPT", timerRestart)
+      end if
+
+      call mpas_timer_stop("totalLPT", timerTotalLPT)
+
+   end subroutine ocn_restart_lagrangian_particle_tracking!}}}
+
+!***********************************************************************
+!
+!  routine write_lagrangian_particle_tracking
+!
+!> \brief   Driver for MPAS-Ocean analysis output
+!> \author  Phillip Wolfram
+!> \date    02/20/14
+!> \details
+!>  This routine writes all output for this MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine write_lagrangian_particle_tracking(domain, err)!{{{
+
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+
+      write(stderrUnit,*) 'start write_lagrangian_particle_tracking'
+      call mpas_timer_start("totalLPT", .false., timerTotalLPT)
+      call mpas_timer_start("writeLPT", .false., timerWrite)
+
+      !call mpas_particle_list_test_num_current_particlelist(domain)
+
+      ! transfer particles to their appropriate blocks (ioBlock) via MPI
+      ! note, don't necessarily need to have g_ionSend and g_ionRecv comeout
+      !write(stderrUnit,*) 'g_ioProcNeighs = ', g_ioProcNeighs
+#ifdef MPAS_DEBUG
+      call mpas_timer_start("trans_from_block_to_blockLPT", .false., timerTransferParticles_write)
+#endif
+      ! depreciated (can just use update_halo_io to keep g_ioProcNeighs up to date)
+      !! get "MPI halos" for IO communication during write and restart steps (currentBlock to ioBlock)
+      !call mpas_particle_list_build_io_halos(domain, err, 'ioBlock', g_ioProcNeighs)
+      ! transfer the data
+      call mpas_particle_list_transfer_particles_from_block_to_named_block(domain, err, .False., .True., 'ioBlock', &
+        g_ioProcNeighs)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("trans_from_block_to_blockLPT", timerTransferParticles_write)
+#endif
+
+      ! write out all the data, sorting to make sure that shuffled particles
+      ! are ouptut correctly (done separately in each function, could be
+      ! pulled out as an optimization)
+      call mpas_particle_list_write_halo_data(domain, err)
+      call mpas_particle_list_write_nonhalo_data(domain, err)
+
+#ifdef MPAS_DEBUG
+      call mpas_particle_list_test_num_current_particlelist(domain)
+#endif
+      ! need to now remove the io particles (remove particles that don't have the
+      ! correct currentBlock)
+      call mpas_particle_list_remove_particles_not_on_current_block(domain,err)
+
+#ifdef MPAS_DEBUG
+      call mpas_particle_list_test_num_current_particlelist(domain)
+#endif
+      write(stderrUnit,*) 'end write_lagrangian_particle_tracking'
+      call mpas_timer_stop("writeLPT", timerWrite)
+      call mpas_timer_stop("totalLPT", timerTotalLPT)
+
+
+   end subroutine write_lagrangian_particle_tracking!}}}
+
+!***********************************************************************
+!
+!  routine ocn_finalize_lagrangian_particle_tracking
+!
+!> \brief   Finalize MPAS-Ocean analysis member
+!> \author  Phillip J. Wolfram
+!> \date    02/20/14
+!> \details
+!>  This routine conducts all finalizations required for this
+!>  MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_finalize_lagrangian_particle_tracking(domain, err)!{{{
+
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type (block_type), pointer :: block
+      integer :: timeLev
+
+      call mpas_timer_start("totalLPT", .false., timerTotalLPT)
+      call mpas_timer_start("finalizeLPT", .false., timerFinalize)
+      err = 0
+
+      write(stderrUnit,*) 'start ocn_finalize_lagrangian_particle_tracking'
+      block => domain % blocklist
+      do while (associated(block))
+        call mpas_particle_list_destroy_particle_list(block % particlelist)
+        block => block %  next
+      end do
+
+      deallocate(g_ProcNeighs, g_ioProcNeighs)
+      ! these following ones should be deallocated once rest of the code is sketched in
+      !deallocate(g_nPartSend, g_nPartRecv, g_ionSend, g_ionRecv)
+
+      write(stderrUnit,*) 'end ocn_finalize_lagrangian_particle_tracking'
+      call mpas_timer_stop("finalizeLPT", timerFinalize)
+      call mpas_timer_stop("totalLPT", timerTotalLPT)
+
+   end subroutine ocn_finalize_lagrangian_particle_tracking!}}}
+
+!-----------------------------------------------------------------------
+!
+! PRIVATE SUBROUTINES
+!
+!-----------------------------------------------------------------------
+!{{{
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! SUBROUTINE GET_VALIDATED_CELL_ID
+   !
+   ! Computes the validated cell ID for a particular location base on proximity to point.
+   ! Phillip Wolfram 06/18/2014
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   subroutine get_validated_cell_id(nCells, xCell,yCell,zCell , xVertex,yVertex,zVertex, &
+       xSubStep,ySubStep,zSubStep, onSphere, nCellVerticesArray, verticesOnCell, &
+       iCell, nCellVertices, cellsOnCell)
+
+     implicit none
+
+     ! intent (in)
+     integer, intent(in) :: nCells  !< number of cells
+     integer, dimension(:,:), pointer, intent(in) :: verticesOnCell   !< vertex indices on cell
+     integer, dimension(:), pointer, intent(in) :: nCellVerticesArray
+     real (kind=RKIND), dimension(:), intent(in) :: xCell,yCell,zCell  !< spatial location of cell centers
+     real (kind=RKIND), dimension(:), intent(in) :: xVertex,yVertex,zVertex  !< spatial location of cell vertices
+     real (kind=RKIND), intent(in) :: xSubStep,ySubStep,zSubStep
+     logical, intent(in) :: onSphere
+     integer, dimension(:,:), intent(in) :: cellsOnCell       ! cell connectivity
+
+     !intent (out)
+     integer, intent(inout) :: iCell
+     integer, intent(out) :: nCellVertices
+
+
+     ! get cell index
+!#ifdef MPAS_DEBUG
+!     iCell = -1
+!#endif
+     call mpas_get_nearby_cell_index(nCells, xCell,yCell,zCell ,  &
+       xSubStep,ySubStep,zSubStep, onSphere, iCell, cellsOnCell, nCellVerticesArray)
+
+     nCellVertices = nCellVerticesArray(iCell)
+
+#ifdef MPAS_DEBUG
+     ! check to make sure the horizontal location is valid, otherwise report an error
+     !write(stderrUnit,*) 'max verticesOnCell = ', maxval(verticesOnCell(:,iCell)), 'nVertices = ', size(xVertex)
+     if(.not. point_in_cell(nCellVertices, &
+       xVertex(verticesOnCell(1:nCellVertices,iCell)), &
+       yVertex(verticesOnCell(1:nCellVertices,iCell)), &
+       zVertex(verticesOnCell(1:nCellVertices,iCell)), &
+       xSubStep,ySubStep,zSubStep , onSphere)) then
+       write(stderrUnit,*) 'Point (', xSubStep,ySubStep,zSubStep ,') is horizontally outside cell ', iCell
+       write(stderrUnit,*) 'Cell  (',&
+         xCell(iCell),yCell(iCell),zCell(iCell), ') with index ' , iCell
+       write(stderrUnit,*) 'xVertex = ', xVertex(verticesOnCell(1:nCellVertices,iCell))
+       write(stderrUnit,*) 'yVertex = ', yVertex(verticesOnCell(1:nCellVertices,iCell))
+       write(stderrUnit,*) 'zVertex = ', zVertex(verticesOnCell(1:nCellVertices,iCell))
+     end if
+#endif
+
+   end subroutine get_validated_cell_id
+
+#ifdef MPAS_DEBUG
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! FUNCTION POINT_IN_CELL
+   !
+   ! Check to make sure point (xp,yp,zp) is within cell iCell (implicit via xv,yv,zv)
+   ! Phillip Wolfram 05/01/2014
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   logical function point_in_cell(nVertices, xv,yv,zv , xp,yp,zp, on_a_sphere) !{{{
+     implicit none
+
+     integer, intent(in) :: nVertices                         ! number of vertices for cell
+     real (kind=RKIND), dimension(:), intent(in) :: xv,yv,zv  ! cell vertex locations
+     real (kind=RKIND), intent(in) :: xp,yp,zp                ! point location
+     logical, intent(in) :: on_a_sphere                       ! flag designating if we are on a sphere
+
+     integer :: aPoint, v1, v0
+     real (kind=RKIND) :: pointRadius   ! magnitude of a point radius
+     real (kind=RKIND), dimension(3) :: pPoint                    ! point vector
+     real (kind=RKIND), dimension(3, nVertices) :: pVertices      ! vertices vectors
+     real (kind=RKIND), dimension(3) :: vec1, vec2, crossProd     ! temporary vectors
+     integer, dimension(nVertices+1) :: cyclePlusOne
+
+     ! normalize locations to same spherical shell (unit) for direct comparison
+     if (on_a_sphere) then
+       pointRadius = sqrt(xp*xp + yp*yp + zp*zp)
+       pPoint = (/ xp/pointRadius , yp/pointRadius , zp/pointRadius /)
+       do aPoint = 1, nVertices
+         pointRadius = sqrt(xv(aPoint)*xv(aPoint) + yv(aPoint)*yv(aPoint) + zv(aPoint)*zv(aPoint))
+         pVertices(:,aPoint) = (/ xv(aPoint), yv(aPoint), zv(aPoint) /) / pointRadius
+       end do
+     else
+       pPoint = (/ xp,yp,zp /)
+       do aPoint = 1, nVertices
+         pVertices(:, aPoint) = (/ xv(aPoint), yv(aPoint), zv(aPoint) /)
+       end do
+     end if
+
+     ! build up vertex cycle for the cell
+     do aPoint = 1, nVertices-1
+       cyclePlusOne(aPoint) = aPoint + 1
+     end do
+     cyclePlusOne(nVertices) = 1
+
+     ! check, using cross-products, that point is within the cell, assuming it is to start
+     point_in_cell = .true.
+     do aPoint = 1, nVertices
+       ! get indices of points
+       v0 = aPoint
+       v1 = cyclePlusOne(aPoint)
+
+       ! compute the local vectors
+       vec1 = pVertices(:,v1) - pVertices(:,v0)
+       vec2 = pPoint - pVertices(:,v0)
+
+       ! compute the cross product and dot with normal, if negative we are outside cell
+       ! we only need to fail on a single test!
+       call mpas_cross_product_in_r3(vec1,vec2,crossProd)
+       if(sum(crossProd*pVertices(:,v0)) < 0) then
+         point_in_cell = .false.
+       end if
+
+     end do
+
+   end function point_in_cell!}}}
+#endif
+
+!***********************************************************************
+!
+!  routine initalize_fields
+!
+!> \brief   Initialize fields
+!> \author  Phillip Wolfram
+!> \date    05/22/2014
+!> \details
+!>  This routine inializes the fields necessary for particle tracking
+!
+!-----------------------------------------------------------------------
+   subroutine initalize_fields(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: statePool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: diagnosticsPool
+      type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackScratchPool, lagrPartTrackCellsPool
+      real(kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
+      integer :: timeLev
+      integer, pointer :: filterNum
+      type (field2DReal), pointer :: uVV, vVV, wVV
+      real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
+
+      !write(stderrUnit,*) 'inialize_vertex_velocity start'
+
+      call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_filter_number', filterNum)
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! setup pointers / get block
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
+        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+
+        !! initialize field for RBF (needed depending upon calling pattern of analysis member)
+        !call mpas_initialize_vectors(meshPool)
+        !call mpas_init_reconstruct(meshPool)
+
+        ! initialize fresh memory for both levels
+        do timeLev = 1, 2
+          ! connect variables to pointer array
+          call mpas_pool_get_field(lagrPartTrackFieldsPool, 'uVertexVelocity', uVV, timeLevel=timeLev)
+          call mpas_pool_get_field(lagrPartTrackFieldsPool, 'vVertexVelocity', vVV, timeLevel=timeLev)
+          call mpas_pool_get_field(lagrPartTrackFieldsPool, 'wVertexVelocity', wVV, timeLevel=timeLev)
+
+          ! initialize, but could potentially remove these lines
+          uVV % array = 0.0_RKIND
+          vVV % array = 0.0_RKIND
+          wVV % array = 0.0_RKIND
+
+         ! make sure memory has been allocated
+#ifdef MPAS_DEBUG
+         if(.not.associated(uVV) .or. &
+            .not.associated(vVV) .or. &
+            .not.associated(wVV)) then
+            write(stderrUnit,*) '[u,v,w]VertexVelocity memory not allocated!'
+          end if
+#endif
+
+          call mpas_pool_get_subpool(block % structs, 'state', statePool)
+          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel=timeLev)
+          call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel=timeLev)
+
+          ! get new time level velocity (linear RBF)
+          !write(stderrUnit,*) 'uVV= ', uVV % array
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("init_reconst_filter_LPT", .false., timerReconstFilter_init)
+#endif
+          call ocn_vertex_reconstruction(filterNum, meshPool, lagrPartTrackScratchPool, lagrPartTrackCellsPool, &
+            layerThickness, normalVelocity, uVV, vVV, wVV)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("init_reconst_filter_LPT", timerReconstFilter_init)
+#endif
+
+        end do
+
+        block => block %  next
+      end do
+      !write(stderrUnit,*) 'inialize_vertex_velocity end'
+
+   end subroutine initalize_fields!}}}
+
+!***********************************************************************
+!
+!  routine initalize_wachspress_coefficients
+!
+!> \brief   Initialize Wachspress coefficients
+!> \author  Phillip Wolfram
+!> \date    01/26/2015
+!> \details
+!>  This routine inializes the B_i Wachspress coefficients which are
+!>  static in time
+!
+!-----------------------------------------------------------------------
+   subroutine intialize_wachspress_coefficients(domain, err) !{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: lagrPartTrackCellsPool
+      type (mpas_pool_type), pointer :: meshPool
+      integer  :: nVertices, iCell, i, im1, i0, ip1
+      integer, pointer :: nCells
+      real (kind=RKIND), dimension(:), allocatable :: xv,yv,zv
+      real (kind=RKIND), pointer :: radiusLocal
+      integer, dimension(:,:), pointer :: verticesOnCell
+      integer, dimension(:), pointer :: nCellVerticesArray
+      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+      real (kind=RKIND), dimension(:,:), pointer :: areaBArray
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! setup pointers / get block
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nCellVerticesArray)
+        call mpas_pool_get_config(meshPool, 'sphere_radius', radiusLocal)
+        call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
+        call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+        call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+        call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'wachspressAreaB', areaBArray)
+
+        ! compute B_i coefficients
+        areaBArray = 0.0_RKIND
+        do iCell = 1, nCells
+          nVertices = nCellVerticesArray(iCell)
+          allocate(xv(nVertices), yv(nVertices), zv(nVertices))
+          xv = xVertex(verticesOnCell(:,iCell))
+          yv = yVertex(verticesOnCell(:,iCell))
+          zv = zVertex(verticesOnCell(:,iCell))
+          do i = 1, nVertices
+            ! compute first area B_i
+            ! get vertex indices
+            im1 = mod(nVertices + i - 2, nVertices) + 1
+            i0  = mod(nVertices + i - 1, nVertices) + 1
+            ip1 = mod(nVertices + i    , nVertices) + 1
+
+            ! precompute B_i areas
+            ! always the same because B_i independent of xp,yp,zp
+            areaBArray(iCell, i) = mpas_triangle_signed_area( (/ xv(im1),yv(im1),zv(im1) /) , &
+              (/ xv(i0),yv(i0),zv(i0) /) , &
+              (/ xv(ip1),yv(ip1),zv(ip1) /) , meshPool)
+          end do
+          deallocate(xv, yv, zv)
+
+        end do
+
+
+        block => block %  next
+      end do
+
+   end subroutine intialize_wachspress_coefficients !}}}
+
+!***********************************************************************
+!
+!  routine compute_velocity_on_potentialdensity_surface
+!
+!> \brief   compute_velocity_on_potentialdensity_surface
+!> \author  Phillip Wolfram
+!> \date    09/15/2014
+!> \details
+!>  This routine interpolates the velocity field onto the potential
+!>  density surface
+!
+!-----------------------------------------------------------------------
+  subroutine compute_velocity_on_potentialdensity_surface(domain,err,aTimeLevel) !{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+      integer, intent(in) :: aTimeLevel
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: meshPool, diagnosticsPool, lagrPartTrackCellsPool
+      real (kind=RKIND), dimension(:,:), pointer :: zonVel, merVel, depth, normalVelocityMer, normalVelocityZon
+      real (kind=RKIND), dimension(:), pointer :: buoyancySurfaceValues
+      integer, pointer :: nBuoyancySurfaces, nCells
+      real (kind=RKIND), dimension(:,:), pointer :: buoyancy, zMid
+      integer :: iLevel, aBuoyancySurface, iCell
+      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND) :: phiInterp                       !< location to interpolate
+      real (kind=RKIND) :: alpha
+      integer :: iHigh, iLow, aval
+      real (kind=RKIND) :: eps=1e-14_RKIND
+
+      !write(stderrUnit,*) 'compute_velocity_on_potentialdensity_surface start'
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! get pools
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
+        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+        ! connect variables to pointer array
+        call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', normalVelocityMer)
+        call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', normalVelocityZon)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceVelocityZonal', zonVel)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceVelocityMeridional', merVel)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceDepth', depth)
+        call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancy)
+        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_dimension(meshPool, 'nBuoyancySurfaces', nBuoyancySurfaces)
+        call mpas_pool_get_array(lagrPartTrackCellsPool,'buoyancySurfaceValues', buoyancySurfaceValues)
+        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+        !write(stderrUnit,*) 'nBuoyancySurfaces  =', nBuoyancySurfaces
+        !write(stderrUnit,*) 'buoyancySurfaceValues=', buoyancySurfaceValues
+        !write(stderrUnit,*) 'size(buoyancy)=',size(buoyancy)
+        !write(stderrUnit,*) 'shape(buoyancy)=',shape(buoyancy)
+        zonVel = -9999.0_RKIND
+        merVel = -9999.0_RKIND
+        ! for each buoyancy surface
+        do aBuoyancySurface = 1, nBuoyancySurfaces
+          ! for each cell
+          do iCell = 1, nCells
+
+            phiInterp = buoyancySurfaceValues(aBuoyancySurface)
+
+            ! get correct vertical levels
+
+#ifdef MPAS_DEBUG
+            !call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+            iLevel = mpas_get_vertical_id(maxLevelCell(iCell), phiInterp, buoyancy(:,iCell))
+#ifdef MPAS_DEBUG
+            !call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+#endif
+
+            if(iLevel < 1) then
+              ! top level
+              if (iLevel == 0) then
+                aval = maxloc(buoyancy(1:maxLevelCell(iCell),iCell),1)
+                ! bottom level
+              else if (iLevel == -1) then
+                aval = minloc(buoyancy(1:maxLevelCell(iCell),iCell),1)
+              end if
+              zonVel(aBuoyancySurface, iCell) = normalVelocityZon(aval,iCell)
+              merVel(aBuoyancySurface, iCell) = normalVelocityMer(aval,iCell)
+              depth(aBuoyancySurface, iCell)  = zMid(aval,iCell)
+            else
+              ! perform the interpolation
+              call get_bounding_indices(iLow, iHigh, phiInterp, buoyancy(:,iCell), iLevel, maxLevelCell(iCell))
+              ! get alpha between points
+              if(abs(buoyancy(iHigh,iCell) - buoyancy(iLow,iCell)) < eps) then
+                ! we really can't distinguish between each of these points numerically, just take the
+                ! average of both
+                alpha = 0.5_RKIND
+              else
+                alpha = (phiInterp - buoyancy(iLow,iCell))/(buoyancy(iHigh,iCell) - buoyancy(iLow,iCell))
+              end if
+
+              ! interpolate to the correct surface
+              zonVel(aBuoyancySurface, iCell) = alpha * normalVelocityZon(iHigh, iCell) + &
+                                  (1.0_RKIND - alpha) * normalVelocityZon(iLow, iCell)
+              merVel(aBuoyancySurface, iCell) = alpha * normalVelocityMer(iHigh, iCell) + &
+                                  (1.0_RKIND - alpha) * normalVelocityMer(iLow, iCell)
+              depth(aBuoyancySurface, iCell)  = alpha * zMid(iHigh, iCell) + &
+                                  (1.0_RKIND - alpha) * zMid(iLow, iCell)
+            end if
+
+          end do
+
+        end do
+
+        block => block %  next
+      end do
+      !write(stderrUnit,*) 'compute_velocity_on_potentialdensity_surface end'
+
+   end subroutine compute_velocity_on_potentialdensity_surface !}}}
+
+!***********************************************************************
+!
+!  routine initialize_particle_properties
+!
+!> \brief   Initialize particle properties
+!> \author  Phillip Wolfram
+!> \date    09/24/2014
+!> \details
+!>  This routine initializes particle data for
+!>  MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine initialize_particle_properties(domain, timeLevel, err)!{{{
+
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: timeLevel
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type (dm_info) :: dminfo
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: statePool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: scratchPool
+      type (mpas_pool_type), pointer :: diagnosticsPool
+      type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackCellsPool, lagrPartTrackScratchPool
+      integer, dimension(:), pointer :: cellOwnerBlock
+      integer, pointer :: currentBlock, ioBlock, indexToParticleID, transfered
+      integer :: currentProc, ioProc
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (mpas_particle_type), pointer :: particle
+
+      real (kind=RKIND), dimension(3) :: particlePosition, particleVelocity
+      real (kind=RKIND), pointer :: xParticle, yParticle, zParticle, lonVel, latVel, buoyancyParticle, sumU, sumV, sumUU, sumUV, sumVV
+      real (kind=RKIND), dimension(3) :: xSubStep, diffSubStep, diffParticlePosition
+      real (kind=RKIND), pointer :: zLevelParticle
+      real (kind=RKIND), dimension(:,:), pointer :: zTop, vertVelocityTop, zMid, areaBArray
+      real (kind=RKIND), dimension(:), pointer :: bottomDepth
+      type (field2DReal), pointer :: normalVelocity, uVertexVelocity, vVertexVelocity, wVertexVelocity, layerThickness
+
+      real (kind=RKIND), dimension(:,:), pointer :: uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, buoyancy, buoyancyTimeInterp, potentialDensity
+
+      real(kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
+      real(kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+
+      integer, dimension(:,:), pointer :: verticesOnCell, boundaryVertex
+      integer, dimension(:), pointer :: maxLevelCell
+
+      integer theVertex, iLevel, iLevelBuoyancy, aVertex, &
+        nSteps, timeStep, subStep, subStepOrder, timeInterpOrder, aTimeLevel, nCellVertices, blockProc, arrayIndex
+      integer, pointer :: nCells, nVertLevels
+      integer, dimension(:), pointer :: nCellVerticesArray
+      integer, dimension(:,:), pointer :: cellsOnCell
+      logical, dimension(:,:), pointer :: ioProcRecvList
+      logical, dimension(:), pointer :: ioProcSendList
+      logical, pointer :: onSphere
+
+      real (kind=RKIND), dimension(4) :: kWeightK, kWeightKVert
+      real (kind=RKIND), dimension(3,4) :: kWeightX
+      real (kind=RKIND), dimension(4) :: kWeightXVert
+      real (kind=RKIND), dimension(4) :: kWeightT, kWeightTVert
+      real (kind=RKIND), dimension(3,5) :: kCoeff
+      real (kind=RKIND), dimension(5) :: kCoeffVert
+      real (kind=RKIND), dimension(2) :: timeCoeff
+      real (kind=RKIND) :: dt, dtSim, tSubStep
+      real (kind=RKIND), pointer :: dtParticle
+      real (kind=RKIND) :: zSubStep
+      real (kind=RKIND) :: diffSubStepVert, diffParticlePositionVert, particleVelocityVert, verticalVelocityInterp
+      real (kind=RKIND) :: buoyancyInterp
+      real (kind=RKIND), pointer :: sphereRadius
+      integer, pointer :: verticalTreatment, vertexReconstMethod, timeIntegration, indexLevel, filterNum, iCell
+
+      err = 0
+
+      dminfo = domain % dminfo
+
+      block => domain % blocklist
+      do while (associated(block)) !{{{
+        ! allocate scratch memory / setup pointers / get block
+        call mpas_pool_get_subpool(block % structs, 'state', statePool)
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
+
+        ! particlelist should be stored in the structs pool probably (need to seriously rework the code!)
+        particlelist => block % particlelist
+
+        call mpas_pool_get_array(meshPool, 'xCell', xCell)
+        call mpas_pool_get_array(meshPool, 'yCell', yCell)
+        call mpas_pool_get_array(meshPool, 'zCell', zCell)
+        call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+        call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+        call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+        call mpas_pool_get_array(lagrPartTrackCellsPool, 'wachspressAreaB', areaBArray)
+        call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
+        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+        call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
+
+        call mpas_pool_get_field(statePool, 'normalVelocity', normalVelocity, timeLevel=timeLevel)
+        call mpas_dmpar_exch_halo_field(normalVelocity)
+        call mpas_pool_get_field(statePool, 'layerThickness', layerThickness, timeLevel=timeLevel)
+
+        call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
+        call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+        call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+        call mpas_pool_get_array(meshPool, 'boundaryVertex', boundaryVertex)
+        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+        call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nCellVerticesArray)
+
+        call mpas_pool_get_config(meshPool, 'on_a_sphere', onSphere)
+        call mpas_pool_get_config(meshPool, 'sphere_radius', sphereRadius)
+
+        !!!!!!!!!! LOOP OVER PARTICLES !!!!!!!!!!
+        ! update the particle position (just from initialized value for now)
+        ! this is a loop over particle list and its datastructures
+        do while(associated(particlelist)) !{{{
+          ! get pointers / option values
+          particle => particlelist % particle
+
+          ! get values {{{
+          call mpas_pool_get_array(particle % haloDataPool, 'xParticle', xParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'yParticle', yParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'zParticle', zParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'currentCell', iCell)
+          particlePosition(1) = xParticle
+          particlePosition(2) = yParticle
+          particlePosition(3) = zParticle
+
+          call mpas_pool_get_array(particle % haloDataPool, 'zLevelParticle', zLevelParticle)
+
+          call mpas_pool_get_array(particle % haloDataPool, 'verticalTreatment', verticalTreatment)
+          call mpas_pool_get_array(particle % haloDataPool, 'vertexReconstMethod', vertexReconstMethod)
+          call mpas_pool_get_array(particle % haloDataPool, 'indexLevel', indexLevel)
+          call mpas_pool_get_array(particle % haloDataPool, 'timeIntegration', timeIntegration)
+          call mpas_pool_get_array(particle % haloDataPool, 'dtParticle', dtParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'buoyancyParticle', buoyancyParticle)
+          call mpas_pool_get_array(particle % haloDataPool, 'indexToParticleID', indexToParticleID)
+
+          call mpas_pool_get_array(particle % haloDataPool, 'lonVel', lonVel)
+          call mpas_pool_get_array(particle % haloDataPool, 'latVel', latVel)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumU', sumU)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumV', sumV)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumUU', sumUU)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumUV', sumUV)
+          call mpas_pool_get_array(particle % haloDataPool, 'sumVV', sumVV)
+
+          !}}}
+
+          !!!!!!!!!! PERFORM SAMPLING (VELOCITY, TEMP, SALINITY, ETC) !!!!!!!!!!
+          ! this could be done just before the output anyway
+
+          ! need iCell computed for final position
+          ! need scalar values interpolated in time to yield single value
+          ! probably need to store zMid too, including flipping it
+          ! get updated cell location
+#ifdef MPAS_DEBUG
+          call mpas_timer_start("get_validated_cell_idLPT", .false., timerValidatedCell_init)
+          write(stderrUnit,*) 'sampling initialization'
+#endif
+          call get_validated_cell_id(nCells, xCell,yCell,zCell , xVertex,yVertex,zVertex, &
+            particlePosition(1),particlePosition(2),particlePosition(3), onSphere, &
+            nCellVerticesArray, verticesOnCell, iCell, nCellVertices, cellsOnCell)
+#ifdef MPAS_DEBUG
+          call mpas_timer_stop("get_validated_cell_idLPT", timerValidatedCell_init)
+#endif
+
+          if(verticalTreatment == 4) then  !('buoyancySurface') !{{{
+            ! pass
+          else
+            ! make sure final zLevelParticle is ok so that it can't extent past zMid range
+
+#ifdef MPAS_DEBUG
+            !call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+            iLevel = mpas_get_vertical_id(maxLevelCell(iCell), zLevelParticle, zMid(:,iCell))
+#ifdef MPAS_DEBUG
+            !call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+#endif
+          end if
+
+          ! compute necessary information for autocorrelation !{{{
+          ! get the updated velocity
+          ! ensure that buoyancy is fixed for each run
+          buoyancyInterp = buoyancyParticle
+          ! we just need the last part of the velocity field interpolation because we are at the end of the timestep
+          timeInterpOrder = 1
+          timeCoeff(1) = 1.0_RKIND
+          timeCoeff(2) = 0.0_RKIND
+          ! return interpolated horizontal velocity "particleVelocity" and vertical velocity "particleVelocityVert"
+          ! noting we use the final positions
+          call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
+            diagnosticsPool, lagrPartTrackFieldsPool, &
+            timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
+            verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
+            particlePosition, zLevelParticle, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex,  &
+            meshPool, areaBArray)
+          ! convert horizontal velocity to lat/lon velocity
+
+          !write(stderrUnit,*) iLevel, particleVelocity
+
+          ! store velocity for use in computing normalized autocorrelation offline
+#ifdef MPAS_DEBUG
+          !call mpas_timer_start("mpas_convert_xyz_velocity_to_latlonLPT", .false., timerConvertXYZLatLon)
+#endif
+
+          call mpas_convert_xyz_velocity_to_latlon(lonVel, latVel, particlePosition, particleVelocity)
+
+#ifdef MPAS_DEBUG
+          !call mpas_timer_stop("mpas_convert_xyz_velocity_to_latlonLPT", timerConvertXYZLatLon)
+#endif
+
+          !}}}
+
+          ! get next particle to process on the list
+          particlelist => particlelist % next
+        end do !}}}
+
+        ! get next block
+        block => block % next !}}}
+      end do !}}}
+
+   end subroutine initialize_particle_properties !}}}
+
+!***********************************************************************
+!
+!  routine particle_vertical_treatment
+!
+!> \brief   Vertical treatment to obtain correct horizontal velocity field
+!> \author  Phillip Wolfram
+!> \date    03/31/2014
+!> \details
+!>  This routine returns the vertex values which will be used in the
+!>  Wachspress interoplant (uvCell) based on
+!>  vertex velocities uVertexVelocity, vVertexVelocity, wVertexVelocity
+!>  for a given cell which has nCellVertices which are determined from
+!>  the list verticesOnCell.
+!>  The routine collapses the vertical to a scalar.
+!
+!-----------------------------------------------------------------------
+   subroutine particle_vertical_treatment(verticalTreatment, indexLevel, nCellVertices, verticesOnCell, & !{{{
+       uVertexVelocity, vVertexVelocity, wVertexVelocity, &
+       uvCell, boundaryVertex, iLevel, nVertLevels, &
+       zLoc, zMid, zTop, phiInterp, phiMid, vertVelocityTop, vertVelocityInterp)
+
+      implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(in) :: &
+       uVertexVelocity, vVertexVelocity, wVertexVelocity              !< vertex velocities
+     integer, dimension(:), intent(in) :: verticesOnCell              !< list of vertex indices on cell
+     integer, intent(in) :: nCellVertices                             !< current cell and the number of cell vertices
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of zLoc
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     integer, intent(in) :: verticalTreatment                         !< vertical treatment encoded as int
+     integer, intent(in) :: indexLevel                                !< value of index for fixed index space
+     integer, dimension(:), intent(in) :: boundaryVertex              !< boundary vertices for particular level
+     real (kind=RKIND), intent(in) :: zLoc                            !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: zTop              !< elevation of cell top
+     real (kind=RKIND), dimension(:), intent(in) :: zMid              !< elevation of cell middle
+     real (kind=RKIND), intent(in) :: phiInterp                       !< buoyancy value to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiMid            !< buoyancy values at cell mid points
+     real (kind=RKIND), dimension(:), intent(in) :: vertVelocityTop   !< velocity at top of cell
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(out) :: uvCell  !< components of vertex velocity (vertically selected)
+     real (kind=RKIND), intent(out) :: vertVelocityInterp                         ! vertically interpolated velocity
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     integer :: aVertex, theVertex
+
+     vertVelocityInterp = 0.0_RKIND
+
+     verticalTreatmentCase: select case (verticalTreatment)
+
+       case (1) verticalTreatmentCase !('indexLevel') !{{{
+         ! get vertically interpolanted values for vertexes in cell
+         ! and form polygon vertex values
+         do aVertex = 1, nCellVertices
+           theVertex = verticesOnCell(aVertex)
+           ! assume that we only care about the top level for a surface drifter
+           ! assumes that velocity is constant in top half of the cell
+           uvCell(1,aVertex) = uVertexVelocity(indexLevel,theVertex)
+           uvCell(2,aVertex) = vVertexVelocity(indexLevel,theVertex)
+           uvCell(3,aVertex) = wVertexVelocity(indexLevel,theVertex)
+         end do
+
+         !! ensure that the boundary condition is enforced
+         !call zero_boundary_nodal_values(nCellVertices, verticesOnCell, &
+         !  boundaryVertex, uvUcell, uvVcell, uvWcell)
+
+         ! no vertical motion, just horizontal motion
+         return
+         !}}}
+
+       case (2) verticalTreatmentCase !('fixedZLevel') !{{{
+
+         ! interpolate the horizontal velocity based on z-levels
+         call interp_nodal_vectors(ncellvertices, verticesoncell, &
+           ilevel, nVertLevels, zLoc, zmid,  &
+           uvertexvelocity, vvertexvelocity, wvertexvelocity, uvCell)
+
+         !! ensure that there is zero nodal velocity on the boundary
+         !call zero_boundary_nodal_values(nCellVertices, verticesOnCell, &
+         !  boundaryVertex, uvUcell, uvVcell, uvWcell)
+
+         ! no vertical motion, just horizontal motion
+         return
+         !}}}
+
+       case (3) verticalTreatmentCase !('passiveFloat') !{{{
+
+         ! interpolate the vertical velocity
+         vertVelocityInterp = interp_vert_velocity_to_zlevel( &
+           iLevel, zLoc, zTop, vertVelocityTop)
+
+         ! interpolate the horizontal velocity based on z-levels
+         call interp_nodal_vectors(ncellvertices, verticesoncell, &
+           ilevel, nVertLevels, zLoc, zmid, &
+           uvertexvelocity, vvertexvelocity, wvertexvelocity, uvCell)
+
+         !! ensure that there is zero nodal velocity on the boundary
+         !call zero_boundary_nodal_values(nCellVertices, verticesOnCell, &
+         !  boundaryVertex, uvUcell, uvVcell, uvWcell)
+
+         return
+         !}}}
+
+       case (4) verticalTreatmentCase !('buoyancySurface') !{{{
+         ! no vertical velocity required because there is not vertical integration for position
+
+         ! interpolate the horizontal velocity
+         call interp_nodal_vectors(ncellvertices, verticesoncell, &
+           ilevel, nVertLevels, phiInterp, phiMid, &
+           uvertexvelocity, vvertexvelocity, wvertexvelocity, uvCell)
+
+         ! ensure that there is zero nodal velocity on the boundary
+         !call zero_boundary_nodal_values(nCellVertices, verticesOnCell, &
+         !  boundaryVertex, uvUcell, uvVcell, uvWcell)
+
+         ! no vertical motion, just horizontal motion
+         return
+         !}}}
+
+       case (5) verticalTreatmentCase !('argoFloat')  !{{{
+
+
+         !}}}
+
+       case default verticalTreatmentCase !{{{
+         write(stderrUnit,*) 'Vertical treatment for particle integration unknwon (', verticalTreatment, ')!'
+         return
+         !}}}
+
+     end select verticalTreatmentCase
+
+   end subroutine particle_vertical_treatment!}}}
+
+!***********************************************************************
+!
+!  routine velocity_time_interpolation
+!
+!> \brief   Compute velocity interpolations, including in time
+!> \author  Phillip Wolfram
+!> \date    09/12/2014
+!> \details
+!>  This routine interpolates velocity in time and space to a particular
+!>  location xSubStep
+!
+!-----------------------------------------------------------------------
+  subroutine velocity_time_interpolation(particleVelocity, particleVelocityVert, &
+      diagnosticsPool,  lagrPartTrackFieldsPool, &
+      timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
+      verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
+      xSubStep, zSubStep, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, meshPool, areaBArray) !{{{
+    implicit none
+
+    !-----------------------------------------------------------------
+    ! input variables
+    !-----------------------------------------------------------------
+    type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool, lagrPartTrackFieldsPool
+    integer, intent(in) :: timeInterpOrder
+    real (kind=RKIND), dimension(2), intent(in) :: timeCoeff
+    integer, intent(in) :: iCell
+    integer, dimension(:), intent(in) :: maxLevelCell
+    integer, intent(in) :: verticalTreatment
+    integer, pointer, intent(in) :: indexLevel
+    integer, intent(in) :: nCellVertices
+    integer, dimension(:,:), intent(in) :: verticesOnCell
+    integer, dimension(:,:), intent(in) :: boundaryVertex
+    real (kind=RKIND), intent(in) :: zSubStep
+    real (kind=RKIND), dimension(:,:), intent(in) :: zMid
+    real (kind=RKIND), dimension(:,:), intent(in) :: zTop
+    real (kind=RKIND), dimension(:,:), intent(in) :: vertVelocityTop
+    real (kind=RKIND), dimension(:,:), intent(in) :: areaBArray
+    real (kind=RKIND), dimension(:), intent(in) :: xVertex, yVertex, zVertex
+    real (kind=RKIND), dimension(3), intent(in) :: xSubStep
+    type (mpas_pool_type), pointer, intent(in) :: meshPool
+
+    !-----------------------------------------------------------------
+    ! input/output variables
+    !-----------------------------------------------------------------
+    real (kind=RKIND), intent(in) :: buoyancyInterp
+    integer, intent(inout) :: iLevel
+
+    !-----------------------------------------------------------------
+    ! output variables
+    !-----------------------------------------------------------------
+    real (kind=RKIND), dimension(3), intent(out) :: particleVelocity
+    real (kind=RKIND), intent(out) :: particleVelocityVert
+
+    !-----------------------------------------------------------------
+    ! local variables
+    !-----------------------------------------------------------------
+    integer :: aVertex, aTimeLevel
+    real (kind=RKIND), dimension(:,:), pointer :: uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, buoyancy
+    real (kind=RKIND) :: verticalVelocityInterp
+    real(kind=RKIND), dimension(:), allocatable :: areaB
+    real(kind=RKIND), dimension(:,:), allocatable :: vertCoords
+    real(kind=RKIND), dimension(:,:), allocatable :: uvCell
+#ifdef MPAS_DEBUG
+    call mpas_timer_start("velocity_time_interpolationLPT", .false., timerVelTimeInterp)
+#endif
+
+    ! allocations for particular cell !{{{
+    allocate(vertCoords(3,nCellVertices), uvCell(3,nCellVertices), areaB(nCellVertices))
+    !}}}
+
+    ! get horizontal vertex locations (noting that there may be a
+    ! bit of error because the particle could be at the top
+    ! of the cell or at the bottom of the cell)
+    do aVertex = 1, nCellVertices
+      vertCoords(1,aVertex) = xVertex(verticesOnCell(aVertex,iCell))
+      vertCoords(2,aVertex) = yVertex(verticesOnCell(aVertex,iCell))
+      vertCoords(3,aVertex) = zVertex(verticesOnCell(aVertex,iCell))
+      areaB(aVertex) = areaBArray(iCell, aVertex)
+    end do
+
+    ! initialize velocities to 0
+    particleVelocity = 0.0_RKIND
+    particleVelocityVert = 0.0_RKIND
+
+    ! general interpolation for the velocity field
+    do aTimeLevel = 1, timeInterpOrder
+
+      ! define arrays!{{{
+      call mpas_pool_get_array(lagrPartTrackFieldsPool, 'uVertexVelocity', uVertexVelocityArray, timeLevel=aTimeLevel)
+      call mpas_pool_get_array(lagrPartTrackFieldsPool, 'vVertexVelocity', vVertexVelocityArray, timeLevel=aTimeLevel)
+      call mpas_pool_get_array(lagrPartTrackFieldsPool, 'wVertexVelocity', wVertexVelocityArray, timeLevel=aTimeLevel)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancy)
+      !}}}
+
+      ! get final, interpolated particle velocity at this point (collapse to point)
+      if (verticalTreatment == 4) then
+        ! buoyancy case (not using zSubStep for interpolation / iLevel)
+        ! use existing code noting we need to flip the order to get the right iLevel
+
+#ifdef MPAS_DEBUG
+        !call mpas_timer_start("mpas_get_vertical_idLPT", .false., timerVerticalID)
+#endif
+        iLevel = mpas_get_vertical_id(maxLevelCell(iCell), buoyancyInterp, buoyancy(:,iCell))
+#ifdef MPAS_DEBUG
+        !call mpas_timer_stop("mpas_get_vertical_idLPT", timerVerticalID)
+        write(stderrUnit,*) 'iLevel=',iLevel
+#endif
+        ! note, if buoyancyInterp out of range this will try to reorient the particle to the top / bottom but there
+        ! will definitely be some error with this type of computation because the buoyancy is not available at this location
+        ! the time interpolation, as a consequency, can mix velocities from different buoyancy surfaces in order to advect
+        ! the particle
+        !write(stderrUnit,*) 'iLevel = ', iLevel
+      end if
+
+      call particle_vertical_treatment(verticalTreatment, indexLevel, nCellVertices, verticesOnCell(:,iCell), &
+        uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, uvCell, boundaryVertex(iLevel,:), &
+        iLevel, maxLevelCell(iCell), zSubStep, zMid(:,iCell), zTop(:,iCell), buoyancyInterp, buoyancy(:,iCell), &
+        vertVelocityTop(:,iCell), verticalVelocityInterp)
+
+      ! vertical
+      particleVelocityVert = particleVelocityVert + &
+        timeCoeff(aTimeLevel) * verticalVelocityInterp
+
+      ! horizontal
+      ! timer commented out because it is used in more than just compute...
+#ifdef MPAS_DEBUG
+      call mpas_timer_start("part_horiz_interpLPT", .false., timerHorizVelInterp)
+      write(stderrUnit,*) 'particleVelocityVert=',particleVelocityVert
+#endif
+      particleVelocity = particleVelocity + &
+        timeCoeff(aTimeLevel) * particle_horizontal_interpolation(nCellVertices, vertCoords, &
+        xSubStep, uvCell, meshPool, areaB)
+#ifdef MPAS_DEBUG
+      call mpas_timer_stop("part_horiz_interpLPT", timerHorizVelInterp)
+      write(stderrUnit,*) 'particleVelocity=',particleVelocity
+#endif
+
+
+    end do
+
+    ! deallocations of temp memory
+    deallocate(vertCoords, uvCell, areaB)
+
+#ifdef MPAS_DEBUG
+    call mpas_timer_stop("velocity_time_interpolationLPT", timerVelTimeInterp)
+#endif
+
+  end subroutine velocity_time_interpolation !}}}
+
+  subroutine zero_autocorrelation_sums(domain) !{{{
+    implicit none
+
+    ! input/output variables
+    type (domain_type), intent(inout) :: domain
+    ! local
+    type (block_type), pointer :: block
+    type (mpas_particle_list_type), pointer :: particlelist
+    type (mpas_particle_type), pointer :: particle
+    ! output variables (per particle)
+    real (kind=RKIND), pointer :: sumU, sumV, sumUU, sumUV, sumVV
+    integer, pointer :: currentCell
+
+    ! get the appropriate pools
+      block => domain % blocklist
+      do while (associated(block)) !{{{
+        particlelist => block % particlelist
+        do while(associated(particlelist)) !{{{
+          ! get pointers / option values
+          particle => particlelist % particle
+
+          ! get values (may want a flag for reinitialization in the future)
+          !call mpas_pool_get_array(particle % haloDataPool, 'sumU', sumU)
+          !call mpas_pool_get_array(particle % haloDataPool, 'sumV', sumV)
+          !call mpas_pool_get_array(particle % haloDataPool, 'sumUU', sumUU)
+          !call mpas_pool_get_array(particle % haloDataPool, 'sumUV', sumUV)
+          !call mpas_pool_get_array(particle % haloDataPool, 'sumVV', sumVV)
+          call mpas_pool_get_array(particle % haloDataPool, 'currentCell', currentCell)
+
+          ! initialize the values
+          !sumU = 0.0_RKIND
+          !sumV = 0.0_RKIND
+          !sumUU = 0.0_RKIND
+          !sumUV = 0.0_RKIND
+          !sumVV = 0.0_RKIND
+          currentCell = -1
+
+          ! get next particle to process on the list
+          particlelist => particlelist % next
+        end do !}}}
+
+        ! get next block
+        block => block % next
+      end do !}}}
+
+  end subroutine zero_autocorrelation_sums !}}}
+
+!***********************************************************************
+!
+!  routine particle_horizontal_interpolation
+!
+!> \brief   Horizontal treatment to obtain correct velocity field at point
+!> \author  Phillip Wolfram
+!> \date    03/31/2014
+!> \details
+!>  This routine returns the point values which will be used in the
+!>  particle interpolation time integration based on
+!>  vertex velocities uVertexVelocity, vVertexVelocity, wVertexVelocity
+!
+!-----------------------------------------------------------------------
+  function particle_horizontal_interpolation(nCellVertices, vertCoords, & !{{{
+       pointInterp, uVertex, meshPool, areaB)
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     integer, intent(in) :: nCellVertices
+     real (kind=RKIND), dimension(3, nCellVertices), intent(in) :: vertCoords
+     real (kind=RKIND), dimension(3), intent(in) :: pointInterp
+     real (kind=RKIND), dimension(3, nCellVertices), intent(in) :: uVertex
+     real (kind=RKIND), dimension(nCellVertices), intent(in) :: areaB
+     type (mpas_pool_type), pointer :: meshPool
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(nCellVertices) :: lambda
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(3) :: particle_horizontal_interpolation
+
+
+     ! get lambda coordinate for particle
+     lambda = mpas_wachspress_coordinates(nCellVertices, vertCoords , &
+       pointInterp, meshPool, areaB)
+!#ifdef MPAS_DEBUG
+!write(stderrUnit,*) 'lambda=',lambda
+!write(stderrUnit,*) 'uVertex=',uVertex(1,:)
+!write(stderrUnit,*) 'vVertex=',uVertex(2,:)
+!write(stderrUnit,*) 'wVertex=',uVertex(3,:)
+!#endif
+
+     ! update particle velocities via horizontal interpolation
+     particle_horizontal_interpolation(1) = mpas_wachspress_interpolate(lambda, uVertex(1,:))
+     particle_horizontal_interpolation(2) = mpas_wachspress_interpolate(lambda, uVertex(2,:))
+     particle_horizontal_interpolation(3) = mpas_wachspress_interpolate(lambda, uVertex(3,:))
+
+   end function particle_horizontal_interpolation !}}}
+
+!***********************************************************************
+!
+!  routine particle_horizontal_movement
+!
+!> \brief   Compute horizontal movement for particle so particle stays
+!>          in spherical shell
+!> \author  Phillip Wolfram
+!> \date    05/20/2014
+!> \details
+!>  This routine returns the particle position pParticle corresponding
+!>  to an initial particle position pParticle for a Cartesian movemnt
+!>  dpParticle.  If the calculation is onSphere, then the distance
+!>  |dpParticle| must be along the great circle route of pParticle
+!>  and the projection of pParticle + dpParticle on the spherical
+!>  shell corresponding to pParticle.
+!
+!-----------------------------------------------------------------------
+  subroutine particle_horizontal_movement(pParticle, dpParticle, onSphere) !{{{
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:), intent(in) :: dpParticle
+     logical, intent(in) :: onSphere
+
+     !-----------------------------------------------------------------
+     ! input / output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:), intent(inout) :: pParticle
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND) :: lenPath, arcLen
+     real (kind=RKIND) :: radiusShell
+     real (kind=RKIND), dimension(size(pParticle)) :: pParticleTemp
+     real (kind=RKIND), dimension(size(pParticle)) :: pParticleInterp
+     real (kind=RKIND) :: alpha
+     real (kind=RKIND), parameter :: eps=1e-10_RKIND
+     ! choosen based on the parameters, note that we loose about 6 - 7 units of precision because R is so large!
+     ! therefore, eps = 1e-10 is conservative, if not too high!  this just helps with numerical stability
+     !dpParticle    =   -4.2428037617887103E-011   4.3076544298828060E-011   5.0760704444480953E-011
+     !pParticle     =    4444887.2990309987       -891565.00525021972        4476665.3916420965
+     !pParticleTemp =    4444887.2990309987       -891565.00525021972        4476665.3916420965
+     !mpas_arc_length =    0.0000000000000000      lenPath =    7.8945399869363434E-011
+
+
+     ! may need a condition to determine if we need to project back to the sphere
+     if(onSphere) then
+       ! need to make sure new point is on the spherical shell
+
+       ! get path length
+       !write(stderrUnit, *) 'dpParticle = ', dpParticle
+       lenPath = sqrt(sum(dpParticle*dpParticle))
+
+       ! consider case of particle not moving (need to have this code here in general)
+       !if (lenPath < eps) then
+       ! this is ok because this is only the case if the points are the same.  If there is a
+       ! numerical instability it probably should be handled differently.
+       if (lenPath < eps) then
+         return
+       end if
+
+       ! get radius of particle's horizontal shell
+       radiusShell = sqrt(sum(pParticle*pParticle))
+
+       ! project endpoint to spherical shell containing pParticle
+       pParticleTemp = pParticle + dpParticle
+       pParticleTemp = ( radiusShell / sqrt(sum(pParticleTemp*pParticleTemp)) ) * pParticleTemp
+
+       ! compute alpha parameter for spherical interpolant / extrapolant
+       !write(stderrUnit,*) 'dpParticle    = ', dpParticle
+       !write(stderrUnit,*) 'pParticle     = ', pParticle
+       !write(stderrUnit,*) 'pParticleTemp = ', pParticleTemp
+       !write(stderrUnit,*) 'mpas_arc_length = ',  mpas_arc_length(pParticle(1),pParticle(2),pParticle(3) , pParticleTemp(1), pParticleTemp(2), pParticleTemp(3)), 'lenPath = ', lenPath
+       arcLen = mpas_arc_length(pParticle(1),pParticle(2),pParticle(3) , pParticleTemp(1),pParticleTemp(2),pParticleTemp(3))
+       if (arcLen > eps) then
+         alpha = lenPath / arcLen
+       else
+         return
+       endif
+
+       ! compute final position based on spherical interpolant
+       call mpas_spherical_linear_interp(pParticleInterp, pParticle, pParticleTemp, alpha)
+       pParticle = pParticleInterp
+     else
+       ! we are just on a plane so there is no need for spherical interpolation to keep
+       ! the new particle location on a spherical shell
+       pParticle = pParticle + dpParticle
+     endif
+
+
+   end subroutine particle_horizontal_movement!}}}
+
+!***********************************************************************
+!
+!  routine interp_cell_scalars
+!
+!> \brief   Interpolate cell scalar vector based on a criteria (z-level, buoyancy, etc)
+!> \author  Phillip Wolfram
+!> \date    06/18/2014
+!> \details
+!>  This routine interpolates cell scalar vector to a particular scalar value
+!>  depending upon a criteria such as z-level, buoyancy, etc.
+!
+!-----------------------------------------------------------------------
+   subroutine interp_cell_scalars(iLevel, nVertLevels, zInterp, zVals, & !{{{
+       phiVals, phiInterp)
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:), intent(in) :: zVals             !< scalar values (x) on cell for interpolant
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of phiInterp
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     real (kind=RKIND), intent(in) :: zInterp                       !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiVals           !< values at elevation of cell middle (where vertex velocities are defined)
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), intent(out) :: phiInterp        !< interpolated cell scalar
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND) :: alpha
+     integer :: aVertex, theVertex, iHigh, iLow
+     real (kind=RKIND) :: eps=1e-14
+
+     call get_bounding_indices(iLow, iHigh, zInterp, zVals, iLevel, nVertLevels)
+
+     ! interpolate to vertical level now
+     if(abs(zVals(iHigh) - zVals(iLow)) < eps) then
+       ! we really can't distinguish between each of these points numerically, just take the
+       ! average of both
+       alpha = 0.5_RKIND
+     else
+       ! interpolate to vertical level now
+       alpha = (zInterp - zVals(iLow))/(zVals(iHigh) - zVals(iLow))
+     end if
+
+     ! interpolate to the vertical level
+     phiInterp = alpha * phiVals(iHigh) + (1.0_RKIND - alpha) * phiVals(iLow)
+
+   end subroutine interp_cell_scalars!}}}
+
+!***********************************************************************
+!
+!  routine interp_nodal_scalars
+!
+!> \brief   Interpolate nodal scalar vector based on a criteria (z-level, buoyancy, etc)
+!> \author  Phillip Wolfram
+!> \date    05/27/2014
+!> \details
+!>  This routine interpolates nodal scalar vector to a particular scalar value
+!>  depending upon a criteria such as z-level, buoyancy, etc.
+!
+!-----------------------------------------------------------------------
+   subroutine interp_nodal_scalars(nCellVertices, verticesOnCell, & !{{{
+       iLevel, nVertLevels, phiInterp, phiVals, &
+       scalarVec, vertexScalar)
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(in) :: scalarVec       !< vertex scalar
+     integer, dimension(:), intent(in) :: verticesOnCell              !< list of vertex indices on cell
+     integer, intent(in) :: nCellVertices                             !< number of cell vertices
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of phiInterp
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     real (kind=RKIND), intent(in) :: phiInterp                       !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiVals           !< values at elevation of cell middle (where vertex velocities are defined)
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:), intent(out) :: vertexScalar      !< components of vertex scalar (interpolated)
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND) :: alpha
+     integer :: aVertex, theVertex, iHigh, iLow
+
+     call get_bounding_indices(iLow, iHigh, phiInterp, phiVals, iLevel, nVertLevels)
+
+     ! interpolate to vertical level now
+     alpha = (phiInterp - phiVals(iLow))/(phiVals(iHigh) - phiVals(iLow))
+
+     ! interpolate to the vertical level
+     do aVertex = 1, nCellVertices
+       theVertex = verticesOnCell(aVertex)
+       ! assume for now that we only care about the top level for a surface drifter
+       vertexScalar(aVertex) = alpha * scalarVec(iHigh, theVertex) + (1.0_RKIND - alpha) * scalarVec(iLow, theVertex)
+     end do
+
+   end subroutine interp_nodal_scalars!}}}
+
+!***********************************************************************
+!
+!  routine interp_nodal_vectors
+!
+!> \brief   Interpolate nodal vector to scalar based on a criteria (z-level, buoyancy, etc)
+!> \author  Phillip Wolfram
+!> \date    05/27/2014
+!> \details
+!>  This routine interpolates nodal vectors to a particular scalar value
+!>  depending upon a criteria such as z-level, buoyancy, etc.
+!
+!-----------------------------------------------------------------------
+   subroutine interp_nodal_vectors(nCellVertices, verticesOnCell, & !{{{
+       iLevel, nVertLevels, phiInterp, phiVals, &
+       uVertexVelocity, vVertexVelocity, wVertexVelocity, uvCell)
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(in) :: &
+       uVertexVelocity, vVertexVelocity, wVertexVelocity              !< vertex velocities
+     integer, dimension(:), intent(in) :: verticesOnCell              !< list of vertex indices on cell
+     integer, intent(in) :: nCellVertices                             !< number of cell vertices
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of phiInterp
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     real (kind=RKIND), intent(in) :: phiInterp                       !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiVals           !< values at elevation of cell middle (where vertex velocities are defined)
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(out) :: uvCell !< components of vertex velocity (vertically selected)
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND) :: alpha
+     integer :: aVertex, theVertex, iHigh, iLow
+     real (kind=RKIND) :: eps=1e-14_RKIND
+
+     uvCell = 0.0_RKIND
+
+     !write(stderrUnit,*) 'interp'
+     if(iLevel < 1) then
+       if(iLevel == 0) then
+         !write(stderrUnit,*) 'nCellVertices = ', nCellVertices, 'buoyancyInterp= ', phiInterp
+         do aVertex = 1, nCellVertices
+           theVertex = verticesOnCell(aVertex)
+           !write(stderrUnit,*) maxloc(phiVals,1), phiVals(1:nVertLevels), uVertexVelocity(1:nVertLevels,theVertex)
+           uvCell(1,aVertex) = uVertexVelocity(maxloc(phiVals(1:nVertLevels),1), theVertex)
+           uvCell(2,aVertex) = vVertexVelocity(maxloc(phiVals(1:nVertLevels),1), theVertex)
+           uvCell(3,aVertex) = wVertexVelocity(maxloc(phiVals(1:nVertLevels),1), theVertex)
+         end do
+       else if(iLevel == -1) then
+         do aVertex = 1, nCellVertices
+           theVertex = verticesOnCell(aVertex)
+           uvCell(1,aVertex) = uVertexVelocity(minloc(phiVals(1:nVertLevels),1), theVertex)
+           uvCell(2,aVertex) = vVertexVelocity(minloc(phiVals(1:nVertLevels),1), theVertex)
+           uvCell(3,aVertex) = wVertexVelocity(minloc(phiVals(1:nVertLevels),1), theVertex)
+         end do
+       end if
+     else
+       call get_bounding_indices(iLow, iHigh, phiInterp, phiVals, iLevel, nVertLevels)
+
+       ! interpolate to vertical level now
+       if(abs(phiVals(iHigh) - phiVals(iLow)) < eps) then
+         ! we really can't distinguish between each of these points numerically, just take the
+         ! average of both
+         alpha = 0.5_RKIND
+       else
+         alpha = (phiInterp - phiVals(iLow))/(phiVals(iHigh) - phiVals(iLow))
+       end if
+
+       ! interpolate to the vertical level
+       do aVertex = 1, nCellVertices
+         theVertex = verticesOnCell(aVertex)
+         ! assume for now that we only care about the top level for a surface drifter
+         uvCell(1,aVertex) = alpha * uVertexVelocity(iHigh, theVertex) + &
+           (1.0_RKIND - alpha) * uVertexVelocity(iLow, theVertex)
+         uvCell(2,aVertex) = alpha * vVertexVelocity(iHigh, theVertex) + &
+           (1.0_RKIND - alpha) * vVertexVelocity(iLow, theVertex)
+         uvCell(3,aVertex) = alpha * wVertexVelocity(iHigh, theVertex) + &
+           (1.0_RKIND - alpha) * wVertexVelocity(iLow, theVertex)
+       end do
+     end if
+
+   end subroutine interp_nodal_vectors!}}}
+
+!***********************************************************************
+!
+!  routine zero_boundary_nodal_values
+!
+!> \brief   Enfore boundary condition for nodal value, setting to 0
+!> \author  Phillip Wolfram
+!> \date    05/27/2014
+!> \details
+!>  This routine ensures zero Dirchilet boundary conditions
+!>  (commonly for the nodal velocity)
+!
+!-----------------------------------------------------------------------
+   subroutine zero_boundary_nodal_values(nCellVertices, verticesOnCell, & !{{{
+       boundaryVertex, uvCell)
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     integer, dimension(:), intent(in) :: verticesOnCell              !< list of vertex indices on cell
+     integer, intent(in) :: nCellVertices                             !< number of cell vertices
+     integer, dimension(:), intent(in) :: boundaryVertex              !< boundary vertices for particular level
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:,:), intent(out) :: uvCell  !< components of vertex velocity (vertically selected)
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     integer :: aVertex, theVertex
+
+     ! make sure to mask all boundary vertexes to be zero to enforce boundary conditions
+     do aVertex = 1, nCellVertices
+       theVertex = verticesOnCell(aVertex)
+       !write(stderrUnit,*) boundaryVertex(theVertex)
+       ! make all the boundary values be zero to prevent particle from horizontally leaving cell
+       uvCell(1,aVertex) = uvCell(1,aVertex) * (1-boundaryVertex(theVertex))
+       uvCell(2,aVertex) = uvCell(2,aVertex) * (1-boundaryVertex(theVertex))
+       uvCell(3,aVertex) = uvCell(3,aVertex) * (1-boundaryVertex(theVertex))
+     end do
+
+   end subroutine zero_boundary_nodal_values!}}}
+
+!***********************************************************************
+!
+!  routine get_bounding_indices
+!
+!> \brief   Get indices for high and low values for interpolation
+!> \author  Phillip Wolfram
+!> \date    05/28/2014
+!> \details
+!>  This routine returns the indices (iLow, iHigh) on either side of phiInterp
+!
+!-----------------------------------------------------------------------
+   subroutine get_bounding_indices(iLow, iHigh, phiInterp, phiVals, iLevel, nVertLevels) !{{{
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of phiInterp
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     real (kind=RKIND), intent(in) :: phiInterp                       !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiVals           !< values at elevation of cell middle (where vertex velocities are defined)
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     integer, intent(out) :: iLow, iHigh                              !< interpolation indices
+
+     ! assumes increasing index is in decreasing phi space, and phiInterp in range of phiVals
+     !write(stderrUnit,*) 'phiInterp = ', phiInterp, 'phiVals = ', phiVals, 'nVertLevels = ', nVertLevels, 'iLevel = ', iLevel
+     if(phiInterp > phiVals(iLevel)) then
+       iHigh = iLevel + 1
+       iLow  = iLevel
+     else
+       iHigh = iLevel
+       iLow  = iLevel + 1
+     end if
+
+     ! check to make sure points are in range
+     ! optimization point: smarter algorithm won't have to call this ever
+     if(.not.((phiInterp <= phiVals(iHigh)) .and. (phiInterp >= phiVals(iLow)))) then
+       !write(stderrUnit,*) 'fast interpolation failed, trying general, brute force search for interpolation bounds'
+       !write(stderrUnit,*) 'iLow = ', iLow, ' iHigh = ', iHigh
+       !write(stderrUnit,*) 'phiInterp = ', phiInterp , ' phiLow =',  phiVals(iLow), ' phiHigh = ', phiVals(iHigh)
+       call get_bounding_indices_brute_force(nVertLevels, phiInterp, phiVals, iLow, iHigh)
+     end if
+
+   end subroutine get_bounding_indices !}}}
+
+!***********************************************************************
+!
+!  routine get_bounding_indices_brute_force
+!
+!> \brief   Get the interpolation bounds via brute force
+!> \author  Phillip Wolfram
+!> \date    05/27/2014
+!> \details
+!>  This routine finds the interpolation bounds directly (brute force).
+!
+!-----------------------------------------------------------------------
+   subroutine get_bounding_indices_brute_force(nVertLevels, phiInterp, phiVals, iLow, iHigh) !{{{
+
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     integer, intent(in) :: nVertLevels                               !< number of vertical levels
+     real (kind=RKIND), intent(in) :: phiInterp                       !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: phiVals           !< values at elevation of cell middle (where vertex velocities are defined)
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     integer, intent(out) :: iLow, iHigh                          !< indexes for the high and low components for the interpolant
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     integer :: aLevel
+
+     ! make no assumptions
+     do aLevel = 1, nVertLevels-1
+       if(phiVals(aLevel) <= phiInterp .and. phiInterp <= phiVals(aLevel+1)) then
+         iLow  = aLevel
+         iHigh = aLevel+1
+         exit
+       else if (phiVals(aLevel+1) <= phiInterp .and. phiInterp <= phiVals(aLevel)) then
+         iLow  = aLevel+1
+         iHigh = aLevel
+         exit
+       end if
+     end do
+
+#ifdef MPAS_DEBUG
+     if(phiVals(iLow) <= phiInterp .and. phiInterp <= phiVals(iHigh)) then
+       ! we are ok
+       !write(stderrUnit,*) 'brute force interpolation successful'
+       !write(stderrUnit,*) 'iLow = ', iLow, ' iHigh = ', iHigh
+       !write(stderrUnit,*) 'phiInterp = ', phiInterp , ' phiLow =',  phiVals(iLow), ' phiHigh = ', phiVals(iHigh)
+     else
+       write(stderrUnit,*) 'brute force interpolation failed with phiInterp = ', phiInterp, ' phiLow = ', phiVals(iLow), ' phiHigh = ', phiVals(iHigh)
+       !write(stderrUnit,*) ' phiVals = ', phiVals(1:nVertLevels)
+     end if
+
+     write(stderrUnit,*) 'Warning!: brute force interpolation used, boundary condition may be wrong!'
+#endif
+
+   end subroutine get_bounding_indices_brute_force!}}}
+
+!***********************************************************************
+!
+!  routine interp_vert_velocity_to_zlevel
+!
+!> \brief   Interpolate the vertical velcity to a z level
+!> \author  Phillip Wolfram
+!> \date    05/08/2014
+!> \details
+!>  This routine interpolates the vertical velocity to a particular
+!>  z-level.
+!
+!-----------------------------------------------------------------------
+   real (kind=RKIND) function interp_vert_velocity_to_zlevel( & !{{{
+       iLevel, zSubStep, zTop, vertVelocityTop)
+
+      implicit none
+     !-----------------------------------------------------------------
+     ! input variables
+     !-----------------------------------------------------------------
+     integer, intent(in) :: iLevel                                    !< vertical level / cell of zSubStep
+     real (kind=RKIND), intent(in) :: zSubStep                        !< location to interpolate
+     real (kind=RKIND), dimension(:), intent(in) :: zTop              !< elevation of cell top
+     real (kind=RKIND), dimension(:), intent(in) :: vertVelocityTop   !< vertical velocity at top of cell
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     !real (kind=RKIND), intent(out) :: interp_vert_velocity_to_zlevel
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     real (kind=RKIND) :: alpha
+
+     if(iLevel < 1) then
+       if(iLevel == 0) then
+         interp_vert_velocity_to_zlevel = vertVelocityTop(maxloc(zTop,1))
+       else if(iLevel == -1) then
+         interp_vert_velocity_to_zlevel = vertVelocityTop(minloc(zTop,1))
+       end if
+     else
+       ! interpolate the velocity [assumes zTop(iLevel+1) <= zSubStep <= zTop(iLevel)]
+       if (zTop(iLevel+1) <= zSubStep .and. zSubStep <= zTop(iLevel)) then
+         alpha = (zSubStep - zTop(iLevel+1))/(zTop(iLevel)- zTop(iLevel+1))
+       else if (zTop(iLevel) <= zSubStep .and. zSubStep <= zTop(iLevel+1)) then
+         alpha = (zSubStep - zTop(iLevel))/(zTop(iLevel+1)- zTop(iLevel))
+#ifdef MPAS_DEBUG
+       else
+         write(stderrUnit,*) 'Error with vertical velocity interpolation!'
+#endif
+       end if
+       interp_vert_velocity_to_zlevel = alpha * vertVelocityTop(iLevel)+ (1.0_RKIND - alpha) * vertVelocityTop(iLevel+1)
+     end if
+
+    end function interp_vert_velocity_to_zlevel!}}}
+
+!***********************************************************************
+!
+!  routine time_interp_field
+!
+!> \brief   Interpolate a field in time
+!> \author  Phillip Wolfram
+!> \date    07/16/2014
+!> \details
+!>  This routine interpolates a field in time over multiple levels.
+!
+!-----------------------------------------------------------------------
+   subroutine time_interp_field(basePool, timeInterpOrder, timeCoeff, field, fieldname) !{{{
+     implicit none
+
+     type (mpas_pool_type), pointer, intent(in) :: basePool
+     integer, intent(in) :: timeInterpOrder
+     real (kind=RKIND), dimension(:), intent(in) :: timeCoeff
+     real (kind=RKIND), dimension(:,:), pointer, intent(out) :: field
+     character(len=*), intent(in) :: fieldname
+
+     real (kind=RKIND), dimension(:,:), pointer :: tempfield
+     integer :: aTimeLevel
+
+     field = 0.0_RKIND
+     do aTimeLevel = 1, timeInterpOrder
+       call mpas_pool_get_array(basePool, trim(fieldname), tempfield, timeLevel=aTimeLevel)
+       field = field + timeCoeff(aTimeLevel) * tempfield
+     end do
+
+   end subroutine time_interp_field !}}}
+!}}}
+
+end module ocn_lagrangian_particle_tracking
+
+! vim: foldmethod=marker

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
@@ -1,0 +1,616 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!***********************************************************************
+!
+!  ocn_lagrangian_particle_tracking_interpolations
+!
+!> \brief   LIGHT Vector reconstruction and filtering module
+!> \author  Phillip J. Wolfram
+!> \date    07/21/2015
+!> \details 
+!> This module provides routines for performing vector interpolations 
+!> and spatial filtering.
+!
+!-----------------------------------------------------------------------
+module ocn_lagrangian_particle_tracking_interpolations
+
+  use mpas_derived_types
+  use mpas_constants
+  use mpas_rbf_interpolation
+  use mpas_geometry_utils
+  use mpas_vector_reconstruction
+
+  implicit none
+
+  contains
+
+!***********************************************************************
+!
+!  routine ocn_vertex_reconstruction
+!
+!> \brief   Reconstruct vertex velocity driver / interface
+!> \author  Phillip Wolfram
+!> \date    03/27/2014
+!> \details 
+!>  Purpose: reconstruct vector field at vertex locations based on 
+!>           particular choice of reconstruction method
+!>  Input: mesh meta data and vector component data residing at cell edges
+!>         initialize_weights logical is to determine if weights should be initialized
+!>  Output: reconstructed vector field (measured in X,Y,Z) located at vertices
+!-----------------------------------------------------------------------
+  subroutine ocn_vertex_reconstruction(filterNum, meshPool, scratchPool, particleCellPool, layerThickness, u, uvReconstructX, uvReconstructY, uvReconstructZ )!{{{
+
+    implicit none
+
+    type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
+    type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: Scratch variables 
+    type (mpas_pool_type), pointer, intent(in) :: particleCellPool !< Input: particlefield variables 
+    integer, intent(in) :: filterNum  ! filtering strength employed
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: layerThickness !< Input: layerThickness on cells
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: u !< Input: Velocity field on edges (normalVelocity)
+    type (field2DReal), pointer, intent(out) :: uvReconstructX !< Output: X Component of velocity reconstructed to vertices
+    type (field2DReal), pointer, intent(out) :: uvReconstructY !< Output: Y Component of velocity reconstructed to vertices
+    type (field2DReal), pointer, intent(out) :: uvReconstructZ !< Output: Z Component of velocity reconstructed to vertices
+
+    ! could add additional reconstruction techniques here with switch if desired
+
+    ! assumption is made that mpas_init_reconstruct was previously called
+    call ocn_RBFvertex(meshPool, filterNum, layerThickness, u, uvReconstructX, uvReconstructY, uvReconstructZ, .false., scratchPool, particleCellPool)
+
+  end subroutine ocn_vertex_reconstruction!}}}
+
+!***********************************************************************
+!
+!  routine ocn_RBFvertex
+!
+!> \brief   Reconstruct vertex velocity using linear interpolation of 
+!>          RBFs reconstruction at cell centers
+!> \author  Phillip Wolfram, Todd Ringler
+!> \date    03/26/2014
+!> \details 
+!>  Purpose: reconstruct vector field at vertex locations based on radial basis functions
+!>  Input: mesh meta data and vector component data residing at cell edges
+!>         initialize_weights logical is to determine if weights should be initialized
+!>  Output: reconstructed vector field (measured in X,Y,Z) located at vertices
+!-----------------------------------------------------------------------
+  subroutine ocn_RBFvertex(meshPool, filterNum, layerThickness, u, uvReconstructX, uvReconstructY, uvReconstructZ, initialize_weights, scratchPool, particleCellPool)!{{{
+
+    implicit none
+
+    ! inputs
+    type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
+    type (mpas_pool_type), pointer, intent(in) :: scratchPool
+    type (mpas_pool_type), pointer, intent(in) :: particleCellPool !< Input: particlefield variables 
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: u !< Input: Velocity field on edges
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: layerThickness !< Input: layerThickness on cells
+    integer, intent(in) :: filterNum  !< number of times to filter
+    logical, intent(in) :: initialize_weights !< Input: Determine if weights for RBF should be pre-computed
+   
+    ! outputs
+    type (field2DReal), pointer, intent(out) :: uvReconstructX !< Output: X Component of velocity reconstructed to vertices
+    type (field2DReal), pointer, intent(out) :: uvReconstructY !< Output: Y Component of velocity reconstructed to vertices
+    type (field2DReal), pointer, intent(out) :: uvReconstructZ !< Output: Z Component of velocity reconstructed to vertices
+
+    ! local / temporary arrays needed in the compute procedure
+    type (field2DReal), pointer :: &
+      ucReconstructX, ucReconstructY, ucReconstructZ, ucReconstructZonal, ucReconstructMeridional ! cell center values
+    type (field2DReal), pointer :: ucStore, vcStore, wcStore
+    type (field2DInteger), pointer :: boundaryVertex, boundaryCell, boundaryCellGlobal, boundaryVertexGlobal
+
+    ! get pointers
+    call mpas_pool_get_field(scratchPool, 'ucReconstructX', ucReconstructX)
+    call mpas_pool_get_field(scratchPool, 'ucReconstructY', ucReconstructY)
+    call mpas_pool_get_field(scratchPool, 'ucReconstructZ', ucReconstructZ)
+    call mpas_pool_get_field(scratchPool, 'ucReconstructZonal', ucReconstructZonal)
+    call mpas_pool_get_field(scratchPool, 'ucReconstructMeridional', ucReconstructMeridional)
+    call mpas_pool_get_field(scratchPool, 'boundaryVertexGlobal', boundaryVertexGlobal)
+
+    ! allocate memory
+    call mpas_allocate_scratch_field(ucReconstructX, .True.)
+    call mpas_allocate_scratch_field(ucReconstructY, .True.)
+    call mpas_allocate_scratch_field(ucReconstructZ, .True.)
+    call mpas_allocate_scratch_field(ucReconstructZonal, .True.)
+    call mpas_allocate_scratch_field(ucReconstructMeridional, .True.)
+    call mpas_allocate_scratch_field(boundaryVertexGlobal, .True.)
+    
+    ucReconstructX % array = 0.0_RKIND
+    ucReconstructY % array = 0.0_RKIND
+    ucReconstructZ % array = 0.0_RKIND
+
+    ! initialize weights (should be pre-initialized)
+    if (initialize_weights) then
+      call mpas_init_reconstruct(meshPool)
+    end if
+
+    ! get cell center reconstructed RBF values
+    call mpas_reconstruct(meshPool, u, ucReconstructX % array, ucReconstructY % array, ucReconstructZ % array, &
+      ucReconstructZonal % array, ucReconstructMeridional % array)
+
+    ! need to do exchange for uc components (we don't use Zonal / Meridional for this calculation)
+    call mpas_dmpar_exch_halo_field(ucReconstructX)
+    call mpas_dmpar_exch_halo_field(ucReconstructY)
+    call mpas_dmpar_exch_halo_field(ucReconstructZ)
+    
+    ! get boundaries
+    call mpas_pool_get_field(meshPool,'boundaryVertex', boundaryVertex)
+    call mpas_pool_get_field(meshPool,'boundaryCell', boundaryCell)
+
+
+    if (filternum > 0) then 
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      ! filter the cell velocity field
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      call ocn_second_order_shapiro_filter_ops(filterNum, meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        layerThickness, ucReconstructX, ucReconstructY, ucReconstructZ) 
+
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      ! store filter data &
+      ! write data to file for output
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      call mpas_pool_get_field(particleCellPool, 'filteredVelocityU', ucStore)
+      call mpas_pool_get_field(particleCellPool, 'filteredVelocityV', vcStore)
+      call mpas_pool_get_field(particleCellPool, 'filteredVelocityW', wcStore)
+      ucStore % array = ucReconstructX % array
+      vcStore % array = ucReconstructY % array
+      wcStore % array = ucReconstructZ % array
+
+    end if
+
+    ! interpolate to vertex locations for use in Wachspress
+    call ocn_vector_cell_center_to_vertex(meshPool, boundaryVertex % array, boundaryCell % array, &
+      ucReconstructX % array, ucReconstructY % array, ucReconstructZ % array, & 
+      uvReconstructX % array, uvReconstructY % array, uvReconstructZ % array)
+
+    ! handle boundary vertices (should be zero).  Can potentially remove if mpas_init_block initializes to 0 vs -1e34
+    boundaryVertexGlobal % array = boundaryVertex % array
+    call mpas_dmpar_exch_halo_field(boundaryVertexGlobal)
+    ! definite change between these fields!
+    uvReconstructX % array = uvReconstructX % array * (1.0_RKIND - boundaryVertexGlobal % array)
+    uvReconstructY % array = uvReconstructY % array * (1.0_RKIND - boundaryVertexGlobal % array)
+    uvReconstructZ % array = uvReconstructZ % array * (1.0_RKIND - boundaryVertexGlobal % array)
+    
+    ! do halo exchanges
+    call mpas_dmpar_exch_halo_field(uvReconstructX)
+    call mpas_dmpar_exch_halo_field(uvReconstructY)
+    call mpas_dmpar_exch_halo_field(uvReconstructZ)
+
+    ! deallocate memory
+    call mpas_deallocate_scratch_field(ucReconstructX, .True.)
+    call mpas_deallocate_scratch_field(ucReconstructY, .True.)
+    call mpas_deallocate_scratch_field(ucReconstructZ, .True.)
+    call mpas_deallocate_scratch_field(ucReconstructZonal, .True.)
+    call mpas_deallocate_scratch_field(ucReconstructMeridional, .True.)
+    call mpas_deallocate_scratch_field(boundaryVertexGlobal, .True.)
+
+  end subroutine ocn_RBFvertex!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vector_cell_center_to_vertex
+!
+!> \brief   Interpolate cell center values to vertex values
+!> \author  Phillip Wolfram
+!> \date    05/27/2014
+!> \details 
+!>  Purpose: interpolate vector field at vertex locations from cell center values
+!>           using Barycentric (via Wachspress) interpolation
+!>  Input: cell center data and mesh information
+!>  Output: interpolated vertex values 
+!-----------------------------------------------------------------------
+  subroutine ocn_vector_cell_center_to_vertex(meshPool, boundaryVertex, boundaryCell, & !{{{
+      ucReconstructX, ucReconstructY, ucReconstructZ, &
+      uvReconstructX, uvReconstructY, uvReconstructZ)
+
+    implicit none
+
+    ! input variables
+    type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: ucReconstructX, ucReconstructY, ucReconstructZ   !< Input: Cell center values
+    integer, dimension(:,:), pointer, intent(in) :: boundaryVertex, boundaryCell !< Input: Boundary flags
+
+    ! output variables
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: uvReconstructX !< Output: X Component of velocity reconstructed to vertices
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: uvReconstructY !< Output: Y Component of velocity reconstructed to vertices
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: uvReconstructZ !< Output: Z Component of velocity reconstructed to vertices
+
+    ! local variables
+    integer, pointer :: nVerticesSolve, nCells, vertexDegree, nVertLevels
+    integer :: aVertex, aCell, aLevel
+    integer, dimension(:,:), pointer :: cellsOnVertex
+    real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell, xVertex, yVertex, zVertex
+    real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+    ! temporary arrays needed in the (to be constructed) init procedure
+    ! note that lambda is going to be constant for this and could be cached
+    real (kind=RKIND), dimension(:), allocatable :: lambda
+    real (kind=RKIND), dimension(:,:), allocatable :: pointVertex
+    real (kind=RKIND), dimension(3) :: pointInterp
+    real (kind=RKIND) :: xp,yp,zp , sumArea, kiteArea
+
+    uvReconstructX = 0.0_RKIND
+    uvReconstructY = 0.0_RKIND
+    uvReconstructZ = 0.0_RKIND
+
+    call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
+
+    allocate(lambda(vertexDegree), pointVertex(3,vertexDegree))
+
+    ! setup pointers
+    call mpas_pool_get_dimension(meshPool, 'nVerticesSolve', nVerticesSolve)
+    call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+    call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+    call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
+    
+    call mpas_pool_get_array(meshPool, 'xCell', xCell)
+    call mpas_pool_get_array(meshPool, 'yCell', yCell)
+    call mpas_pool_get_array(meshPool, 'zCell', zCell)
+    
+    call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+    call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+    call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+    
+    call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', kiteAreasOnVertex)
+
+    ! loop over all vertices
+    do aVertex = 1, nVerticesSolve
+      ! could precompute the list as an optimization
+      ! really, condition is any boundaryVertex in column greater than 0
+      if(any(boundaryVertex(:,aVertex) < 1)) then
+        ! get vertex location and cell center locations
+        do aCell = 1, vertexDegree
+          pointVertex(1,aCell) = xCell(cellsOnVertex(aCell, aVertex))
+          pointVertex(2,aCell) = yCell(cellsOnVertex(aCell, aVertex))
+          pointVertex(3,aCell) = zCell(cellsOnVertex(aCell, aVertex))
+        end do
+        ! vertex point for reconstruction
+        pointInterp(1) = xVertex(aVertex)
+        pointInterp(2) = yVertex(aVertex)
+        pointInterp(3) = zVertex(aVertex)
+        ! get interpolation constants (could be cached)
+        lambda = mpas_wachspress_coordinates(vertexDegree, pointVertex , pointInterp, meshPool)
+      else 
+        lambda = 0.0_RKIND
+      end if 
+
+      do aLevel = 1, nVertLevels
+        if(boundaryVertex(aLevel,aVertex) < 1) then
+          ! perform interpolation
+          uvReconstructX(aLevel,aVertex) = sum(ucReconstructX(aLevel,cellsOnVertex(:,aVertex)) * lambda)
+          uvReconstructY(aLevel,aVertex) = sum(ucReconstructY(aLevel,cellsOnVertex(:,aVertex)) * lambda)
+          uvReconstructZ(aLevel,aVertex) = sum(ucReconstructZ(aLevel,cellsOnVertex(:,aVertex)) * lambda)
+        end if
+      end do
+
+      ! need to specify boundary conditions for the vertexes (outside this subroutine)
+     
+    end do
+
+    deallocate(lambda, pointVertex)
+
+  end subroutine ocn_vector_cell_center_to_vertex!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vector_vertex_to_cell_center
+!
+!> \brief   Interpolate vertex values to cell center 
+!> \author  Phillip Wolfram
+!> \date    08/01/2014
+!> \details 
+!>  Purpose: interpolate vector field at cell center locations from vertex values
+!>           using Wachspress interpolation
+!>  Input: vertex vector data and mesh information
+!>  Output: interpolated cell values 
+!-----------------------------------------------------------------------
+  subroutine ocn_vector_vertex_to_cell_center(meshPool, & !{{{
+      uvReconstructX, uvReconstructY, uvReconstructZ, &
+      ucReconstructX, ucReconstructY, ucReconstructZ)
+
+    implicit none
+
+    ! input variables
+    type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
+    real (kind=RKIND), dimension(:,:), pointer, intent(in) :: uvReconstructX, uvReconstructY, uvReconstructZ   !< Input: Vertex values
+
+    ! output variables
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: ucReconstructX !< Output: X Component of velocity reconstructed to cells 
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: ucReconstructY !< Output: Y Component of velocity reconstructed to cells
+    real (kind=RKIND), dimension(:,:), pointer, intent(out) :: ucReconstructZ !< Output: Z Component of velocity reconstructed to cells 
+
+    ! local variables
+    integer, pointer :: nCellsSolve, nVertLevels
+    integer, dimension(:), pointer :: nEdgesOnCell
+    integer :: aVertex, aCell, aLevel, nLocalVertices
+    integer, dimension(:,:), pointer :: verticesOnCell
+    real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell, xVertex, yVertex, zVertex
+    ! temporary arrays needed in the (to be constructed) init procedure
+    ! note that lambda is going to be constant for this and could be cached
+    real (kind=RKIND), dimension(:), allocatable :: lambda
+    real (kind=RKIND), dimension(3) :: pointInterp
+    real (kind=RKIND), dimension(:,:), allocatable :: pointVertex
+    real (kind=RKIND) :: xp,yp,zp 
+
+    ucReconstructX = 0.0_RKIND
+    ucReconstructY = 0.0_RKIND
+    ucReconstructZ = 0.0_RKIND
+
+    ! setup pointers
+    call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+    call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+    call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
+    call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+    
+    call mpas_pool_get_array(meshPool, 'xCell', xCell)
+    call mpas_pool_get_array(meshPool, 'yCell', yCell)
+    call mpas_pool_get_array(meshPool, 'zCell', zCell)
+    
+    call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+    call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+    call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+    
+
+    ! loop over all vertices
+    do aCell = 1, nCellsSolve
+      ! could precompute the list as an optimization to
+      ! remove the following lines !{{{
+      nLocalVertices = nEdgesOnCell(aCell)
+      ! really, condition is any boundaryVertex in column greater than 0
+      allocate(lambda(nLocalVertices), pointVertex(3,nLocalVertices))
+      ! get vertex location and cell center locations
+      do aVertex = 1, nLocalVertices
+        pointVertex(1,aVertex) = xVertex(verticesOnCell(aVertex, aCell))
+        pointVertex(2,aVertex) = yVertex(verticesOnCell(aVertex, aCell))
+        pointVertex(3,aVertex) = zVertex(verticesOnCell(aVertex, aCell))
+      end do
+      ! vertex point for reconstruction
+      pointInterp(1) = xCell(aCell)
+      pointInterp(2) = yCell(aCell)
+      pointInterp(3) = zCell(aCell)
+      ! get interpolation constants (should be cached as an optimization!)
+      lambda = mpas_wachspress_coordinates(nLocalVertices, pointVertex , pointInterp, meshPool)
+      !}}}
+
+      do aLevel = 1, nVertLevels
+          ! perform interpolation
+          ucReconstructX(aLevel,aCell) = sum(uvReconstructX(aLevel,verticesOnCell(1:nLocalVertices,aCell)) * lambda)
+          ucReconstructY(aLevel,aCell) = sum(uvReconstructY(aLevel,verticesOnCell(1:nLocalVertices,aCell)) * lambda)
+          ucReconstructZ(aLevel,aCell) = sum(uvReconstructZ(aLevel,verticesOnCell(1:nLocalVertices,aCell)) * lambda)
+      end do
+
+      deallocate(lambda, pointVertex)
+    end do
+
+  end subroutine ocn_vector_vertex_to_cell_center !}}}
+
+!***********************************************************************
+!
+!  routine ocn_second_order_shapiro_filter_ops
+!
+!> \brief   Do Ntimes simple shapiro filtering operations, but make 
+!>          higher order 
+!> \author  Phillip Wolfram
+!> \date    08/01/2014
+!> \details 
+!>  Purpose: multiple applications of digital shapiro filter (discrete Laplacian)
+!>  Input: cell centered data and mesh information
+!>  Output: filtered cell values 
+!-----------------------------------------------------------------------
+  subroutine ocn_second_order_shapiro_filter_ops(Ntimes, meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        layerThickness, ucReconstructX, ucReconstructY, ucReconstructZ) !{{{
+      implicit none
+
+      type (mpas_pool_type), pointer, intent(in) :: meshPool, scratchPool
+      type (field2DInteger), pointer, intent(in) :: boundaryVertex, boundaryCell
+      type (field2DReal), pointer, intent(inout) :: ucReconstructX, ucReconstructY, ucReconstructZ ! cell center values
+      integer, intent(in) :: Ntimes  ! number of filter applications
+      real (kind=RKIND), dimension(:,:), pointer, intent(in) :: layerThickness
+
+      type (field2DReal), pointer :: ucStore, vcStore, wcStore
+
+      call mpas_pool_get_field(scratchPool,'ucX',ucStore)
+      call mpas_pool_get_field(scratchPool,'ucY',vcStore)
+      call mpas_pool_get_field(scratchPool,'ucZ',wcStore)
+      call mpas_allocate_scratch_field(ucStore,.True.)
+      call mpas_allocate_scratch_field(vcStore,.True.)
+      call mpas_allocate_scratch_field(wcStore,.True.)
+
+
+      call ocn_multiple_vector_shapiro_filter_ops(Ntimes, meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        layerThickness, ucReconstructX, ucReconstructY, ucReconstructZ) 
+      ucStore % array = 2.0_RKIND*ucReconstructX % array
+      vcStore % array = 2.0_RKIND*ucReconstructY % array
+      wcStore % array = 2.0_RKIND*ucReconstructZ % array
+      call ocn_multiple_vector_shapiro_filter_ops(Ntimes, meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        layerThickness, ucReconstructX, ucReconstructY, ucReconstructZ) 
+      ucStore % array = ucStore % array - ucReconstructX % array
+      vcStore % array = vcStore % array - ucReconstructY % array
+      wcStore % array = wcStore % array - ucReconstructZ % array
+
+      ! move temporary storage into final storage
+      ucReconstructX % array = ucStore % array
+      ucReconstructY % array = vcStore % array
+      ucReconstructZ % array = wcStore % array
+
+      ! deallocate temporary memory
+      call mpas_deallocate_scratch_field(ucStore,.True.)
+      call mpas_deallocate_scratch_field(vcStore,.True.)
+      call mpas_deallocate_scratch_field(wcStore,.True.)
+
+    end subroutine ocn_second_order_shapiro_filter_ops !}}}
+
+!***********************************************************************
+!
+!  routine ocn_multiple_vector_shapiro_filter_ops
+!
+!> \brief   Do Ntimes simple shapiro filtering operations
+!> \author  Phillip Wolfram
+!> \date    08/01/2014
+!> \details 
+!>  Purpose: multiple applications of digital shapiro filter (discrete Laplacian)
+!>  Input: cell centered data and mesh information
+!>  Output: filtered cell values 
+!-----------------------------------------------------------------------
+  subroutine ocn_multiple_vector_shapiro_filter_ops(Ntimes, meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        layerThickness, ucReconstructX, ucReconstructY, ucReconstructZ) !{{{
+      implicit none
+
+      type (mpas_pool_type), pointer, intent(in) :: meshPool, scratchPool
+      type (field2DInteger), pointer, intent(in) :: boundaryVertex, boundaryCell
+      type (field2DReal), pointer, intent(inout) :: ucReconstructX, ucReconstructY, ucReconstructZ ! cell center values
+      real (kind=RKIND), dimension(:,:), pointer, intent(in) :: layerThickness  
+      integer, intent(in) :: Ntimes  ! number of filter applications
+
+      ! local variables
+      integer atime
+
+      do atime = 1,Ntimes
+        !call ocn_simple_vector_shapiro_filter(meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        !  ucReconstructX, ucReconstructY, ucReconstructZ) 
+        call ocn_simple_vector_laplacian_filter(meshPool, scratchPool, boundaryCell % array, layerThickness, ucReconstructX % array)
+        call ocn_simple_vector_laplacian_filter(meshPool, scratchPool, boundaryCell % array, layerThickness, ucReconstructY % array)
+        call ocn_simple_vector_laplacian_filter(meshPool, scratchPool, boundaryCell % array, layerThickness, ucReconstructZ % array)
+
+      end do
+
+    end subroutine ocn_multiple_vector_shapiro_filter_ops !}}}
+
+!***********************************************************************
+!
+!  routine ocn_simple_vector_laplacian_filter
+!
+!> \brief   Do 1 pass of simple laplacian filter 
+!> \author  Phillip Wolfram
+!> \date    08/01/2014
+!> \details 
+!>  Purpose: one pass of digital shapiro filter (discrete Laplacian)
+!>  Input: cell centered data and mesh information
+!>  Output: filtered cell values 
+!-----------------------------------------------------------------------
+    subroutine ocn_simple_vector_laplacian_filter(meshPool, scratchPool, boundaryCell, layerThickness, ucReconstruct) !{{{
+      implicit none
+     
+      type (mpas_pool_type), pointer, intent(in) :: meshPool, scratchPool
+      integer, dimension(:,:), pointer, intent(in) :: boundaryCell
+      real (kind=RKIND), dimension(:,:), pointer, intent(inout) :: ucReconstruct
+      real (kind=RKIND), dimension(:,:), pointer, intent(in) ::  layerThickness
+     
+      ! local variables
+      type (field2DReal), pointer :: ucTemp
+      integer :: aCell, aNeigh, aLevel
+      integer, pointer :: nCellsSolve, nVertLevels
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      real (kind=RKIND) :: volSum, cellVol
+
+      ! allocate scratch memory
+      call mpas_pool_get_field(scratchPool, 'ucTemp', ucTemp)
+      call mpas_allocate_scratch_field(ucTemp,.True.)
+    
+      ! get values from pools
+      call mpas_pool_get_dimension(meshPool,'nCellsSolve',nCellsSolve)
+      call mpas_pool_get_dimension(meshPool,'nVertLevels',nVertLevels)
+      call mpas_pool_get_array(meshPool,'nEdgesOnCell',nEdgesOnCell)
+      call mpas_pool_get_array(meshPool,'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool,'areaCell',areaCell)
+
+      ucTemp % array = 0.0_RKIND
+
+      ! perform laplacian filtering
+      do aCell = 1, nCellsSolve
+        do aLevel = 1, nVertLevels
+          volSum = nEdgesOnCell(aCell) * layerThickness(aLevel,aCell) * areaCell(aCell) * (1-boundaryCell(aLevel,aCell))
+          ucTemp % array(aLevel, aCell) = ucReconstruct(aLevel, aCell) * volSum
+          if (volSum /= 0 ) then
+            ! loop over all neighbors
+            do aNeigh = 1, nEdgesOnCell(aCell)
+              cellVol = layerThickness(aLevel,cellsOnCell(aNeigh,aCell)) * areaCell(cellsOnCell(aNeigh,aCell)) &
+                * (1-boundaryCell(aLevel, cellsOnCell(aNeigh,aCell)))
+              volSum = volSum + cellVol
+              ucTemp % array(aLevel, aCell) = ucTemp % array(aLevel, aCell) + ucReconstruct(aLevel,cellsOnCell(aNeigh,aCell))* cellVol 
+            end do
+            ucTemp % array(aLevel, aCell) = ucTemp % array(aLevel, aCell) / volSum
+          end if
+        end do
+      end do
+
+      ! exchange halo values
+      call mpas_dmpar_exch_halo_field(ucTemp)
+
+      ! replace input values with filtered values
+      ucReconstruct = ucTemp % array
+
+      ! deallocate scratch memory
+      call mpas_deallocate_scratch_field(ucTemp , .True.)
+
+    end subroutine ocn_simple_vector_laplacian_filter !}}}
+
+!***********************************************************************
+!
+!  routine ocn_simple_vector_shapiro_filter
+!
+!> \brief   Do 1 pass of simple shapiro filter 
+!> \author  Phillip Wolfram
+!> \date    08/01/2014
+!> \details 
+!>  Purpose: one pass of digital shapiro filter to vertexes, back to cells
+!>  Input: cell centered data and mesh information
+!>  Output: filtered cell values 
+!-----------------------------------------------------------------------
+    subroutine ocn_simple_vector_shapiro_filter(meshPool, scratchPool, boundaryVertex, boundaryCell, &
+        ucReconstructX, ucReconstructY, ucReconstructZ) !{{{
+      implicit none
+     
+      type (mpas_pool_type), pointer, intent(in) :: meshPool, scratchPool
+      type (field2DInteger), pointer, intent(in) :: boundaryVertex, boundaryCell
+      type (field2DReal), pointer, intent(inout) :: ucReconstructX, ucReconstructY, ucReconstructZ ! cell center values
+     
+      ! local variables
+      type (field2DReal), pointer :: uvX , uvY, uvZ ! cell center values
+     
+      ! allocate scratch memory
+      call mpas_pool_get_field(scratchPool, 'uvX', uvX)
+      call mpas_pool_get_field(scratchPool, 'uvY', uvY)
+      call mpas_pool_get_field(scratchPool, 'uvZ', uvZ)
+      call mpas_allocate_scratch_field(uvX,.True.)
+      call mpas_allocate_scratch_field(uvY,.True.)
+      call mpas_allocate_scratch_field(uvZ,.True.)
+
+      uvX % array = 0.0_RKIND
+      uvY % array = 0.0_RKIND
+      uvZ % array = 0.0_RKIND
+
+      ! perform filtering
+
+      ! CC -> vertices
+      call ocn_vector_cell_center_to_vertex(meshPool, boundaryVertex % array, boundaryCell % array, &
+        ucReconstructX % array, ucReconstructY % array, ucReconstructZ % array, & 
+        uvX % array, uvY % array, uvZ % array)
+      ! do halo exchanges
+      call mpas_dmpar_exch_halo_field(uvX)
+      call mpas_dmpar_exch_halo_field(uvY)
+      call mpas_dmpar_exch_halo_field(uvZ)
+      ! vertices -> CC
+      call ocn_vector_vertex_to_cell_center(meshPool, &
+        uvX % array, uvY % array, uvZ % array, &
+        ucReconstructX % array, ucReconstructY % array, ucReconstructZ % array)
+      ! do halo exchanges
+      call mpas_dmpar_exch_halo_field(ucReconstructX)
+      call mpas_dmpar_exch_halo_field(ucReconstructY)
+      call mpas_dmpar_exch_halo_field(ucReconstructZ)
+      
+      ! N.B., effect of forgetting halo exchange may be subtle for a single pass 
+      
+      ! deallocate scratch memory
+      call mpas_deallocate_scratch_field(uvX , .True.)
+      call mpas_deallocate_scratch_field(uvY , .True.)
+      call mpas_deallocate_scratch_field(uvZ , .True.)
+
+    end subroutine ocn_simple_vector_shapiro_filter !}}}
+
+end module ocn_lagrangian_particle_tracking_interpolations
+

--- a/src/core_ocean/analysis_members/mpas_ocn_particle_list.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_particle_list.F
@@ -1,0 +1,3986 @@
+! Copyright (c) 2014,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_particle_list
+!
+!> \brief Particle framework
+!> \author Phillip Wolfram
+!> \date   04/10/2014
+!> \details
+!>  This module contains a general definition of particles which can be
+!>  used in implementation of Lagrangian Particles Tracking.
+!-----------------------------------------------------------------------
+
+module ocn_particle_list
+
+  ! declare general packages used
+#ifdef _MPI
+  use mpi
+#endif
+  use mpas_kind_types
+  use mpas_io_units
+  use mpas_derived_types
+  use mpas_dmpar
+  use mpas_block_decomp
+  use mpas_pool_routines
+
+  ! blanket statments to restrict implicit module's scope
+  implicit none
+  private
+  
+  ! mpi defines
+#ifdef _MPI
+   integer, parameter :: MPI_INTEGERKIND = MPI_INTEGER
+   integer, parameter :: MPI_2INTEGERKIND = MPI_2INTEGER
+
+#ifdef SINGLE_PRECISION
+   integer, parameter :: MPI_REALKIND = MPI_REAL
+   integer, parameter :: MPI_2REALKIND = MPI_2REAL
+#else
+   integer, parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+   integer, parameter :: MPI_2REALKIND = MPI_2DOUBLE_PRECISION
+#endif
+#endif
+
+  ! custom structures defined in mpas_grid_types
+
+  ! define private interfaces
+
+  ! add routines
+  interface add_halo_data_to_particle_list
+    !(particlelist, dataName, data)
+    module procedure add_halo_data_to_particle_list_1Dreal
+    module procedure add_halo_data_to_particle_list_1Dint
+  end interface
+
+  interface add_halo_data_to_particle_list_array
+    module procedure add_halo_data_to_particle_list_1Dreal_array
+    module procedure add_halo_data_to_particle_list_1Dint_array
+  end interface
+
+  interface add_nonhalo_data_to_particle_list
+    !(particlelist, dataName, data)
+    module procedure add_nonhalo_data_to_particle_list_1Dreal
+    module procedure add_nonhalo_data_to_particle_list_1Dint
+  end interface
+
+  interface add_nonhalo_data_to_particle_list_array
+    module procedure add_nonhalo_data_to_particle_list_1Dreal_array
+    module procedure add_nonhalo_data_to_particle_list_1Dint_array
+  end interface
+
+  ! get routines
+  interface get_halo_data_from_particle_list
+    !(particlelist, dataName, data)
+    module procedure get_halo_data_from_particle_list_1Dreal
+    module procedure get_halo_data_from_particle_list_1Dint
+  end interface
+
+  interface get_halo_data_from_particle_list_array
+    module procedure get_halo_data_from_particle_list_1Dreal_array
+    module procedure get_halo_data_from_particle_list_1Dint_array
+  end interface
+
+  interface get_nonhalo_data_from_particle_list
+    !(particlelist, dataName, data)
+    module procedure  get_nonhalo_data_from_particle_list_1Dreal
+    module procedure  get_nonhalo_data_from_particle_list_1Dint
+  end interface
+
+  interface get_nonhalo_data_from_particle_list_array
+    !(particlelist, dataName, data)
+    module procedure  get_nonhalo_data_from_particle_list_1Dreal_array
+    module procedure  get_nonhalo_data_from_particle_list_1Dint_array
+  end interface
+
+  !-----------------------------------------------------------------
+  ! public routines and interfaces
+  !-----------------------------------------------------------------
+  ! define publically accessible subroutines, functions, interfaces
+  public :: mpas_particle_list_build_and_assign_particle_list
+  public :: mpas_particle_list_destroy_particle_list, mpas_particle_list_remove_particles_not_on_current_block
+  public :: mpas_particle_list_build_computation_halos, mpas_particle_list_build_io_halos
+  public :: mpas_particle_list_update_computational_halos, mpas_particle_list_update_io_halos
+  public :: mpas_particle_list_transfer_particles_from_block_to_named_block
+  public :: mpas_particle_list_write_halo_data, mpas_particle_list_write_nonhalo_data
+  public :: mpas_particle_list_test_neighscalc, mpas_particle_list_test_numparticles_to_neighprocs, mpas_particle_list_test_num_current_particlelist
+
+  ! subroutine / function definition
+contains
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_build_and_assign_particle_list
+!
+!> \brief   Allocates particles for initialization
+!> \author  Phillip Wolfram
+!> \date    07/01/2014
+!> \details
+!>  This routine builds and allocates particlces following initalization
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_build_and_assign_particle_list(domain,err) !{{{
+     implicit none
+
+     !-----------------------------------------------------------------
+     !
+     ! input variables
+     !
+     !-----------------------------------------------------------------
+
+     !-----------------------------------------------------------------
+     !
+     ! input/output variables
+     !
+     !-----------------------------------------------------------------
+
+     type (domain_type), intent(in) :: domain
+
+     !-----------------------------------------------------------------
+     !
+     ! output variables
+     !
+     !-----------------------------------------------------------------
+
+     integer, intent(out) :: err !< Output: error flag
+
+     err = 0
+     ! build / allocate the listPLSend, setting ioProc (currentBlock read in as haloData)
+     call build_block_particlelists(domain, err)
+
+
+     ! read in data from netCDF-injected data structures
+     ! nonhalo-data is diagnostic
+     call read_haloData(domain, err)
+
+     ! note that nonhalo data is just initialized with 0
+     ! values are not imported from netCDF input file
+     call read_nonhaloData(domain, err)
+
+#ifdef MPAS_DEBUG
+     call mpas_particle_list_test_num_current_particlelist(domain)
+#endif
+     !! test to make sure deallocation is ok before transfer...!{{{
+#ifdef MPAS_DEBUG
+     write(stderrUnit,*) '    Trying to clear particlelist memory on blocks'
+     call clear_block_particlelists(domain,err)
+     call build_block_particlelists(domain, err)
+     call read_haloData(domain, err)
+     call read_nonhaloData(domain, err)
+     call mpas_particle_list_test_num_current_particlelist(domain)
+     call test_currentBlock(domain)
+     write(stderrUnit,*) '    Rebuilt data structures-- ok'
+#endif
+     !}}}
+   end subroutine mpas_particle_list_build_and_assign_particle_list !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_particle_list_destroy_particle_list
+!
+!> \brief MPAS destroy particlelist
+!> \author Phillip Wolfram
+!> \date   06/27/2014
+!> \details
+!>  This routine destroys a particlelist, deallocating its memory
+!>  including that of all pointers it contains
+!
+!-----------------------------------------------------------------------
+subroutine mpas_particle_list_destroy_particle_list(particlelist) !{{{
+  type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+  type (mpas_particle_list_type), pointer :: pLCurr, pLCurrTemp
+
+  if(associated(particlelist)) then
+    plCurr => particlelist
+    do while(associated(plCurr))
+      pLCurrTemp => pLCurr
+      pLCurr => pLCurr % next
+      ! destroy the particle too
+      if(associated(pLCurrTemp % particle)) then
+        call destroy_particle(pLCurrTemp % particle)
+      end if
+      deallocate(pLCurrTemp)
+    end do
+  end if
+
+end subroutine mpas_particle_list_destroy_particle_list !}}}
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_remove_particles_not_on_current_block
+!
+!> \brief   Remove particles on block % particlelist that are not on currentBlock
+!> \author  Phillip Wolfram
+!> \date    07/03/2014
+!> \details
+!>  This routine removes particles that were transfered strictly for IO.
+!>  If the particle's currentBlock is not the same as the current block,
+!>  the particle is removed.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_remove_particles_not_on_current_block(domain, err) !{{{
+     implicit none
+
+     !-----------------------------------------------------------------
+     !
+     ! input variables
+     !
+     !-----------------------------------------------------------------
+
+     !-----------------------------------------------------------------
+     !
+     ! input/output variables
+     !
+     !-----------------------------------------------------------------
+
+     type (domain_type), intent(in) :: domain
+
+     !-----------------------------------------------------------------
+     !
+     ! output variables
+     !
+     !-----------------------------------------------------------------
+
+     integer, intent(out) :: err !< Output: error flag
+
+     !-----------------------------------------------------------------
+     !
+     ! local variables
+     !
+     !-----------------------------------------------------------------
+     type (block_type), pointer :: block
+     type (mpas_particle_list_type), pointer :: particlelist, particlelisttemp, particlelisttemp2
+     integer :: thisBlock
+     integer, pointer :: particleBlock
+     integer :: arrayIndex
+     !type (mpas_pool_type), pointer :: lagrPartTrackPool
+     type (mpas_particle_type), pointer :: particle
+
+     err = 0
+
+     block => domain % blocklist
+     do while(associated(block))
+       ! for each particle on each block
+       particlelist => block % particlelist
+       do while(associated(particlelist))
+         particle => particlelist % particle
+         call mpas_pool_get_array(particle % haloDataPool, 'currentBlock', particleBlock)
+
+         if(particleBlock /= block % blockID) then
+           ! REMOVE PARTICLE FROM EXISTING PARTICLELIST
+           ! remove particle and particle reference from existing particle list
+           ! 3 cases: head, middle, tail
+
+           call destroy_particle(particle)
+
+           if(associated(particlelist % prev)) then
+             particlelisttemp => particlelist % prev
+             if (associated(particlelist % next)) then
+               ! case of the middle
+               particlelisttemp % next => particlelist % next
+               particlelisttemp2 => particlelisttemp
+               ! want to keep particle memory intact because their pointers were passed previously,
+               ! so just empty the list, don't destroy it and its contents
+               particlelisttemp => particlelist % next
+               particlelisttemp % prev => particlelisttemp2
+               ! just need to remove the single link, particle memory needs to stay intact
+               !deallocate(particlelist % particle)
+               deallocate(particlelist)
+               ! get next pointer
+               particlelist => particlelisttemp
+             else
+               ! case of tail
+               nullify(particlelisttemp % next)
+               !deallocate(particlelist % particle)
+               deallocate(particlelist)
+               ! set back to final
+             end if
+           else
+             if(associated(particlelist % next)) then
+               ! case of head, set new head (assumes more than one particle)
+               particlelisttemp => particlelist % next
+               nullify(particlelisttemp % prev)
+               block % particlelist => particlelisttemp
+               !deallocate(particlelist % particle)
+               deallocate(particlelist)
+               particlelist => particlelisttemp
+             else
+               ! case of single link / particle
+               !deallocate(particlelist % particle)
+               deallocate(particlelist)
+               nullify(block % particlelist)
+             end if
+           end if
+         else
+           particlelist => particlelist % next
+         end if
+       end do
+
+       ! this is done for each block because we want processor - processor communication
+       block => block % next
+     end do
+
+   end subroutine mpas_particle_list_remove_particles_not_on_current_block !}}}
+
+!***********************************************************************
+!
+!  routine  mpas_particle_list_build_computation_halos
+!
+!> \brief   Build up necessary info for communication of particle in
+!>          halo to neighboring cell during computation step.
+!> \author  Phillip Wolfram
+!> \date    07/02/2014
+!> \details
+!>  This routine builds g_ProcNeighs which is the neighboring processor
+!>  list needed to process MPI communication, assuming a list of
+!>  particlelists is built up corresponding to the processors in this
+!>  array.  The end result is that g_ProcNeighs is populated.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_build_computation_halos(domain, err, procNeighs) !{{{
+     implicit none
+
+     !-----------------------------------------------------------------
+     !
+     ! input variables
+     !
+     !-----------------------------------------------------------------
+
+     !-----------------------------------------------------------------
+     !
+     ! input/output variables
+     !
+     !-----------------------------------------------------------------
+
+     type (domain_type), intent(inout) :: domain
+
+     !-----------------------------------------------------------------
+     !
+     ! output variables
+     !
+     !-----------------------------------------------------------------
+
+     integer, intent(out) :: err !< Output: error flag
+     integer, dimension(:), pointer :: procNeighs
+
+     err = 0
+
+     ! compute the cellOwnerBlock for cells
+     ! owning processor can be obtained from
+     ! mpas_get_owning_proc in mpas_block_decomp (src/framework)
+     call compute_cellOwnerBlock(domain, err)
+
+     ! in order to mediate MPI exchanges, need to determine
+     ! 1. list of blockNeighs (global)
+     ! stored in block % blockNeighs
+     ! basically Neighs are processors who own the halo including itself
+     call compute_blockNeighs(domain, err)
+
+     ! 2. list of procNeighs (extracted from blockNeighs, also global)
+     ! this information is necessary in order to know where to send data
+     ! (this is like a block exchange list for particles)
+     ! stored in block % procNeighs
+     ! this is just the list of processors who own blockNeighs
+     call compute_block_procNeighs(domain, err)
+
+     ! need to aggregate procNeighs to be global for the processor (over each block on the
+     ! processor), total number of neighboring processors to a particular processor
+     call compute_procNeighs(domain, err, procNeighs)
+
+   end subroutine mpas_particle_list_build_computation_halos !}}}
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_build_io_halos
+!
+!> \brief   Build the IO halo information to transmit particles from their
+!>          initial host IO processor to the appropriate currentBlock
+!>          processor.
+!> \author  Phillip Wolfram
+!> \date    07/02/2014
+!> \details
+!>  This routine builds the IO halo information to transmit  particles
+!>  from their initial host IO processor to the appropriate currentBlock
+!>  processor.  The end result is that g_ioProcNeighs is populated.
+!
+!-----------------------------------------------------------------------
+    subroutine mpas_particle_list_build_io_halos(domain, err, namedBlock, ioProcNeighs) !{{{
+      !{{{ initialization
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      character(len=*), intent(in) :: namedBlock
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, dimension(:), pointer, intent(out) :: ioProcNeighs
+      integer, intent(out) :: err !< Output: error flag
+
+      !}}}
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      integer, dimension(:), pointer :: currentBlocks, tempInt
+      integer :: i, nBlocks, nTotProcs, mpi_ierr
+      logical, dimension(:), pointer :: sendNeigh, recvNeigh
+
+      err = 0
+
+      ! get unique list of currentBlock to determine all currentProcs
+      ! that the particles must be communicated to
+      ! determine complete set of ioProcs, which are assigned based on the
+      ! way that PIO decomposes the nParticle dimension.
+      ! at this point, processors owning the particle (at read-in) are
+      ! assumed to be the ioProcessor
+      call compute_all_particle_values_unique_int(domain, err, namedBlock, currentBlocks)
+
+      nTotProcs = domain % dminfo % nprocs
+      allocate(sendNeigh(nTotProcs))
+      allocate(recvNeigh(nTotProcs))
+      sendNeigh = .false.
+      recvNeigh = .false.
+
+      ! Get processors for currentBlocks. Note, however, this is one-sided because
+      ! only the IO processors know their send location, the receivers don't know
+      ! their sending processors
+      if(associated(currentBlocks)) then
+        nBlocks = size(currentBlocks)
+        !write(stderrUnit,*) 'nBlocks = ', nBlocks, ' currentBlocks = ', currentBlocks
+        allocate(ioProcNeighs(nBlocks))
+        do i=1, nBlocks
+          call mpas_get_owning_proc(domain % dminfo, currentBlocks(i), ioProcNeighs(i))
+        end do
+
+        ! note, each ioProc knows where it is sending data.  However, those processors
+        ! do not know they should receive data (their halos are empty).  The halos
+        ! are not symmetric and the communication cannot occur unless this is fixed.
+        ! this is fixed via an all-to-all communication (only at initialization, otherwise
+        ! parallelism can be broken)
+        ! set counter for connectivity
+        do i=1,size(ioProcNeighs)
+          sendNeigh(ioProcNeighs(i)+1) = .true.
+        end do
+        deallocate(ioProcNeighs)
+      end if
+
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'sendNeigh = ', sendNeigh
+      write(stderrUnit,*) 'recvNeigh= ', recvNeigh
+#endif
+#ifdef _MPI
+      !call MPI_Barrier(domain % dminfo % comm, mpi_ierr)
+#endif
+      ! send with MPI all to update in recvNeigh (should only have to be done once)
+#ifdef _MPI
+      call MPI_Alltoall(sendNeigh, 1, MPI_LOGICAL, recvNeigh, 1, MPI_LOGICAL, domain % dminfo % comm, mpi_ierr)
+#endif
+#ifdef _MPI
+      !call MPI_Barrier(domain % dminfo % comm, err)
+#endif
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'Finished all to all with mpi_ierr = ', mpi_ierr
+      write(stderrUnit,*) 'sendNeigh = ', sendNeigh
+      write(stderrUnit,*) 'recvNeigh= ', recvNeigh
+      write(stderrUnit,*) 'communicate = ', sendNeigh .or. recvNeigh
+#endif
+
+      ! could possibly optimize here by keeping track of send / recv lists separately
+      ! however, if there is nothing to be sent the only message that is sent
+      ! is the number of particles to be transferred...
+      ! update ioProcNeighs from logical lists
+      ! "add" the lists
+      recvNeigh = recvNeigh .or. sendNeigh
+      allocate(tempInt(nTotProcs))
+      ! this can artificially create a problem if there isn't a single block to a processor
+      tempInt = domain % dminfo % my_proc_id
+      do i=1,nTotProcs
+        if (recvNeigh(i))   tempInt(i) = i-1
+      end do
+      deallocate(sendNeigh)
+      deallocate(recvNeigh)
+
+      ! get a complete list of the processors (including itself)
+      call uniqueIntegerList(tempInt,ioProcNeighs)
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'ioProcNeighs = ', ioProcNeighs
+#endif
+      deallocate(tempInt)
+
+    end subroutine mpas_particle_list_build_io_halos !}}}
+
+!***********************************************************************
+!
+!  routine  mpas_particle_list_update_io_halos
+!
+!> \brief   Updates halo processor for io communication, noting that
+!>          the receiving processors must be informed of changes
+!> \author  Phillip Wolfram
+!> \date    07/08/2014
+!> \details
+!>  This routine transmits a logical list of processors that will
+!>  transmit data for each ioProc.  On the ioProcs, these lists must
+!>  be aggregated to build out the full list of processors from
+!>  which data will be received.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_update_io_halos(domain, err, ioProcNeighs, ioProcSendList, ioProcRecvList) !{{{
+      implicit none
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      logical, dimension(:,:), intent(in) :: ioProcRecvList !< x: ioProcNeighs for send. y: each receiving processors on x denoted by true
+      logical, dimension(:), pointer, intent(inout) :: ioProcSendList   !< location of true indicates processors to send data to
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, dimension(:), pointer, intent(inout)   :: ioProcNeighs !< list of io halo processors
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: i, nioProcNeighs, nProcs
+      logical, dimension(:), pointer :: completeList, recvList
+      integer, dimension(:), pointer :: intArray
+      integer, dimension(:), pointer :: sendRequestID, recvRequestID
+      integer :: mpi_ierr
+      logical :: firstTime
+
+      err = 0
+
+      ! compute send list now that all particles reside on correct block (processor) 'currentBlock'
+      ! didn't show up with serial IO because all computational processors sent data to proc 0
+      call compute_particle_send_list(domain, ioProcSendList)
+
+#ifdef MPAS_DEBUG
+      ! need to update IO processors as to the change also so that they know where to get data from!!!
+      ! should uncomment for testing when multiple ioProcs are utilized (parallel IO)
+      write(stderrUnit,*) 'ioProcSendList = ', ioProcSendList
+      write(stderrUnit,*) 'ioProcRecvList = ', ioProcRecvList
+#endif
+
+      ! proceed to update the halo
+      nProcs = domain % dminfo % nprocs
+      nioProcNeighs = size(ioProcNeighs)
+      allocate(completeList(nProcs), recvList(nProcs))
+      allocate(sendRequestID(nioProcNeighs), recvRequestID(nioProcNeighs))
+
+      completeList = .False.
+      ! for each ioProc, send logical array information
+      do i = 1, nioProcNeighs
+#ifdef _MPI
+        call MPI_ISend(ioProcRecvList(i,:), nProcs, MPI_LOGICAL, ioProcNeighs(i), domain % dminfo % my_proc_id, &
+          domain % dminfo % comm, sendRequestID(i), mpi_ierr)
+#endif
+      end do
+
+      ! for each ioProc, listen for logical array
+      do i = 1, nioProcNeighs
+        ! send the data
+#ifdef _MPI
+        call MPI_IRecv(recvList, nProcs, MPI_LOGICAL, ioProcNeighs(i), ioProcNeighs(i), &
+          domain % dminfo % comm, recvRequestID(i), mpi_ierr)
+#endif
+
+        ! wait until the data is in the buffer
+#ifdef _MPI
+        call MPI_Wait(recvRequestID(i), MPI_STATUS_IGNORE, mpi_ierr)
+#endif
+
+        ! aggregate results after wait, making sure that we have the most
+        ! comprehensive list of ioProcs for receiving
+        completeList = completeList .or. recvList
+        !write(stderrUnit,*) 'recvList= ', recvList
+        !write(stderrUnit,*) 'completeList = ', completeList
+      end do
+
+      ! wait to make sure (just in case) that all sends have completed
+#ifdef _MPI
+      call MPI_WaitAll(nioProcNeighs, sendRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+
+      ! "add" receiving and sending lists into a complete list
+      completeList = completeList .or. ioProcSendList
+      !write(stderrUnit,*) 'completeList = ', completeList
+
+      ! convert complete list into a unique list of processor numbers
+      allocate(intArray(nProcs))
+      firstTime = .True.
+      do i = 1, nProcs
+        if (completeList(i)) then
+          if (firstTime) then
+            intArray = i - 1
+            firstTime = .False.
+          else
+            intArray(i) = i - 1
+          end if
+        end if
+      end do
+
+      ! now get the desired integer halo list
+      deallocate(ioProcNeighs)
+      call uniqueIntegerList(intArray, ioProcNeighs)
+
+      deallocate(intArray, completeList, sendRequestID, recvRequestID)
+
+   end subroutine mpas_particle_list_update_io_halos !}}}
+
+!***********************************************************************
+!
+!  routine  mpas_particle_list_transfer_particles_from_block_to_named_block
+!
+!> \brief   Move particles to the appropriate currentBlock
+!> \author  Phillip Wolfram
+!> \date    07/01/2014
+!> \details
+!>  This routine uses MPI communication to ensure particles end up
+!>  on their appropriate currentBlock.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_transfer_particles_from_block_to_named_block(domain, err, & !{{{
+       haloOnly, copyOnly, namedBlock, procNeighs)
+     implicit none
+     !-----------------------------------------------------------------
+     !
+     ! input variables
+     !
+     !-----------------------------------------------------------------
+     integer, dimension(:), pointer, intent(in) :: procNeighs
+     character(len=*), intent(in) :: namedBlock
+     logical, intent(in) :: copyOnly, haloOnly
+
+     !-----------------------------------------------------------------
+     !
+     ! input/output variables
+     !
+     !-----------------------------------------------------------------
+
+     type (domain_type), intent(in) :: domain
+
+     !-----------------------------------------------------------------
+     !
+     ! output variables
+     !
+     !-----------------------------------------------------------------
+
+     integer, intent(out) :: err !< Output: error flag
+     !-----------------------------------------------------------------
+     !
+     ! local variables
+     !
+     !-----------------------------------------------------------------
+     integer, dimension(:), pointer :: nPartSend => NULL(), nPartRecv => NULL()
+     type (block_type), pointer :: block
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     type (mpas_list_of_particle_list_type), dimension(:), pointer :: listPLSend => NULL(), listPLRecv => NULL()
+
+     err = 0
+
+     ! allocate particle list in terms of its communication dimesion to other processors
+     allocate(listPLSend(size(procNeighs)),listPLRecv(size(procNeighs)))
+     allocate(nPartSend(size(procNeighs)),nPartRecv(size(procNeighs)))
+
+     ! if statement inside each of the group's subroutines needs removed for parallel IO which
+     ! assumes a high-level nParticle decomposition which will allocate IO blocks via the
+     ! decomposition
+
+
+     ! this is the communication list and it needs to be a bi-directional graph so that
+     ! sending processors have their receiving processor listening, even if there is no
+     ! data transfer required
+
+     ! presently don't distribute particles from each block to correct, owning blocks
+     !1. communicating from block to block (basically like make_proc_to_proc_particlelists but for blocks)
+     ! this is all done locally and all it will do is affect the particlelists on each block, forming temporary lists,
+     ! and then appending particles on these temporary lists back to block % particlelist
+     !this doesn't have to be tested unless there is more than one block per processor,
+     !which presently is not how things are done
+     ! this takes the block % particlelist on the first block and makes sure
+     ! it is appropriately distributed on other blocks on the same processor
+     ! call make_block_to_block_particlelists(domain)
+
+
+     ! 1. Make temporary particle lists for transfers based on currentBock of cells in halo.
+     !    These lists live on each block and correspond to other
+     !    blocks that the list must be moved to.  The particle must end up on its currentBlock specified.
+     ! convention on particles lists is that g_ProcNeighs specifies the processor neighbor numbers
+     ! corresponding to each index in the particlelists pointer array.  Should use linked-list
+     ! because processor neighbors are typically going to be somewhere less than 10
+     ! (perfect partitioning of plane gives hexagons with 6 cell neighbors, for instance).
+     ! strategy is to make linked list corresponding to each gProcNeigh and then append
+     ! particles beloning to the list on the list
+#ifdef MPAS_DEBUG
+     write(stderrUnit,*) 'before make_proc_to_proc_particlelists'
+     call mpas_particle_list_test_numparticles_to_neighprocs(domain % dminfo % my_proc_id, procNeighs, procNeighs)
+#endif
+     call make_proc_to_proc_particlelists(domain, copyOnly, namedBlock, listPLSend, procNeighs, err)
+#ifdef MPAS_DEBUG
+     write(stderrUnit,*) 'after make_proc_to_proc_particlelists'
+     call mpas_particle_list_test_numparticles_to_neighprocs(domain % dminfo % my_proc_id, procNeighs, procNeighs)
+#endif
+#ifdef MPAS_DEBUG
+     write(stderrunit,*) 'finished make_proc_to_proc_particlelists'
+      call mpas_particle_list_test_num_current_particlelist(domain)
+      call test_num_particles_on_particlelist(listPLSend, size(procNeighs))
+#endif
+
+     ! now move data from one proc to another, assuming that data is move to 1st block
+     ! on foreign processor
+     ! tell other processors how many particles are going to be communicated to them
+     call get_num_particlelists(listPLSend, size(procNeighs), nPartSend)
+#ifdef MPAS_DEBUG
+     write(stderrunit,*) 'finished get_num_particlelists'
+     write(stderrunit,*) 'proc id=', domain % dminfo % my_proc_id, ' comm=', domain % dminfo % comm
+#endif
+     call communicate_num_particles_send_recv(domain, procNeighs, nPartSend, nPartRecv)
+#ifdef MPAS_DEBUG
+     write(stderrunit,*) 'finished communicate_num_particles_send_recv'
+#endif
+
+     !2. communicating from processor to processor
+     ! make appropriate list
+     call allocate_list_particlelists(nPartRecv, listPLRecv)
+
+     ! communicate data (assumes that each processor has knowledge about construction of the pool lagrPartTrackPoolHalo,
+     ! from the registry.  If this changes, this will break this member...  It also assumes the code is deterministic
+     ! and that pools are built and computed the exact same way on each processor.
+     call communicate_particle_halo_data(domain, procNeighs, nPartSend, nPartRecv, listPLSend, listPLRecv)
+#ifdef MPAS_DEBUG
+     write(stderrunit,*) 'finished communicate_particle_halo_data'
+#endif
+
+     if(haloOnly) then
+       ! need to also allocate the nonHalo data somehow, it just needs initialized so that it can be "filled in" when
+       ! necessary for output
+       ! can utilize empty 0'd fields for the nonhalo data portion to initialize the field for all the processors
+       call allocate_list_nonHalo_data(domain, listPLRecv)
+     else
+       call communicate_particle_nonhalo_data(domain, procNeighs, nPartSend, nPartRecv, listPLSend, listPLRecv)
+     end if
+
+     ! now there should be the complete particles on listPLRecv.  These, however, need moved to the blocks of the processor
+     ! for use in calculations
+     !3. communicating from block to block
+     call distribute_particlelist_to_blocks(domain, namedBlock, listPLRecv)
+
+#ifdef MPAS_DEBUG
+     write(stderrUnit,*) 'finished distributing particlelist'
+     write(stderrUnit,*) 'halo procs = ', procNeighs
+     write(stderrUnit,*) 'nSend = ', nPartSend, ' nRecv = ', nPartRecv
+#endif
+
+     ! deallocate listPLSend and listPLRecv
+     if (copyOnly) then
+       ! just empty the list without destroying the particle data
+       !write(stderrUnit,*) 'just emptying the particlelist'
+       call empty_list_particlelists(listPLSend)
+     else
+       ! remove list of particles as well as particle data because it was just sent to the other processors
+       call destory_list_particlelists(listPLSend)
+     endif
+     ! just empty the list without destroying the particle data (because we need particles that were just transferred!)
+     call empty_list_particlelists(listPLRecv)
+
+     deallocate(nPartSend, nPartRecv)
+
+     !write(stderrUnit,*) 'finished '
+
+   end subroutine mpas_particle_list_transfer_particles_from_block_to_named_block !}}}
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_write_halo_data
+!
+!> \brief   Writes haloData to struct arrays for output
+!> \author  Phillip Wolfram
+!> \date    06/03/2014
+!> \details
+!>  This routine writes haloData output for this MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_write_halo_data(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (mpas_pool_iterator_type) :: dimItr
+      type (field1DReal), pointer :: field1DRealPointer
+      type (field1DInteger), pointer :: field1DIntPointer
+      real (kind=RKIND), dimension(:), pointer :: Array1DRealPointer => NULL()
+      integer, dimension(:), pointer :: Array1DIntPointer => NULL()
+      integer, dimension(:), pointer :: indexToParticleIDOriginal => NULL(), indexToParticleIDNew => NULL(), orderingVector => NULL()
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! particle related pointers
+        particlelist => block % particlelist
+        ! iterate over each member of the pool and make the relevant assignment
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+        ! need to compute the ordering matrices
+        call mpas_pool_get_array(lagrPartTrackPool, 'indexToParticleID', indexToParticleIDOriginal)
+        call get_halo_data_from_particle_list_array(particlelist, 'indexToParticleID', indexToParticleIDNew)
+        ! note: orderingVector can be a subset of indexToParticleIDNew because this index can include compute as well as IO particles
+        ! however, it must be of the same size as indexToParticleIDOriginal
+        call compute_ordering_vector(indexToParticleIDOriginal, indexToParticleIDNew, orderingVector)
+
+        ! iterate over contents of pool and transfer
+        call mpas_pool_begin_iteration(lagrPartTrackPool)
+        do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+          ! determine the type of data
+          if (dimItr % memberType == MPAS_POOL_FIELD) then
+            if (dimItr % dataType == MPAS_POOL_REAL) then
+              ! get data and place it in appropriate array
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DRealPointer)
+                !{{{
+#ifdef MPAS_DEBUG
+              write(stderrUnit,*) 'write halo data'
+              write(stderrUnit,*) 'member name =', trim(dimItr % memberName)
+              write(stderrUnit,*) 'particlelistSize= ', count_particlelist(particlelist)
+              write(stderrUnit,*) 'memory arraysize= ', size(field1DRealPointer % array)
+#endif
+              !}}}
+              allocate(Array1DRealPointer(count_particlelist(particlelist)))
+              call get_halo_data_from_particle_list_array(particlelist, dimItr % memberName, Array1DRealPointer)
+              ! reorder
+              field1DRealPointer % array = Array1DRealPointer(orderingVector)
+              deallocate(Array1DRealPointer)
+            elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+              ! get data and place it in appropriate array
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DIntPointer)
+              allocate(Array1DIntPointer(count_particlelist(particlelist)))
+              call get_halo_data_from_particle_list_array(particlelist, dimItr % memberName, Array1DIntPointer)
+              ! reorder
+              field1DIntPointer % array = Array1DIntPointer(orderingVector)
+              deallocate(Array1DIntPointer)
+            else
+              !write(stderrunit,*) "Different field type than implemented in nonHalo write!"
+            end if
+          elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+            ! ignore dimensions for now and have this code so they aren't printed as an error message
+          else
+            !write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in nonHalo data for write, don't know what to do!"
+          end if
+        end do
+
+        ! free memory for the next loop
+        deallocate(indexToParticleIDNew)
+        deallocate(orderingVector)
+
+        block => block % next
+      end do
+
+   end subroutine mpas_particle_list_write_halo_data!}}}
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_write_nonhalo_data
+!
+!> \brief   Writes nonhaloData to struct arrays for output
+!> \author  Phillip Wolfram
+!> \date    06/03/2014
+!> \details
+!>  This routine writes nonhaloData output for this MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_write_nonhalo_data(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (mpas_pool_iterator_type) :: dimItr
+      type (field1DReal), pointer :: field1DRealPointer
+      type (field1DInteger), pointer :: field1DIntPointer
+      real (kind=RKIND), dimension(:), pointer :: Array1DRealPointer => NULL()
+      integer, dimension(:), pointer :: Array1DIntPointer => NULL()
+      integer, dimension(:), pointer :: indexToParticleIDOriginal => NULL(), indexToParticleIDNew => NULL(), orderingVector =>NULL()
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! particle related pointers
+        particlelist => block % particlelist
+        ! iterate over each member of the pool and make the relevant assignment
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+        ! need to compute the ordering matrices
+        call mpas_pool_get_array(lagrPartTrackPool, 'indexToParticleID', indexToParticleIDOriginal)
+        call get_halo_data_from_particle_list_array(particlelist, 'indexToParticleID', indexToParticleIDNew)
+        ! note: orderingVector can be a subset of indexToParticleIDNew because this index can include compute as well as IO particles
+        ! however, it must be of the same size as indexToParticleIDOriginal
+        call compute_ordering_vector(indexToParticleIDOriginal, indexToParticleIDNew, orderingVector)
+
+        ! iterate over each member of the pool and make the relevant assignment
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackNonHalo', lagrPartTrackPool)
+        call mpas_pool_begin_iteration(lagrPartTrackPool)
+        do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+          ! determine the type of data
+          if (dimItr % memberType == MPAS_POOL_FIELD) then
+            if (dimItr % dataType == MPAS_POOL_REAL) then
+              ! get data and place it in appropriate array
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DRealPointer)
+                !{{{
+#ifdef MPAS_DEBUG
+              write(stderrUnit,*) 'write nonhalo data'
+              write(stderrUnit,*) 'member name =', dimItr % memberName
+              write(stderrUnit,*) 'particlelistSize= ', count_particlelist(particlelist)
+              write(stderrUnit,*) 'memory arraysize= ', size(field1DRealPointer % array)
+#endif
+              !}}}
+              allocate(Array1DRealPointer(count_particlelist(particlelist)))
+              call get_nonhalo_data_from_particle_list_array(particlelist, dimItr % memberName, Array1DRealPointer)
+              ! reorder
+              field1DRealPointer % array = Array1DRealPointer(orderingVector)
+              deallocate(Array1DRealPointer)
+            elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+              write(stderrunit,*) "Integer type in registry for key ", dimItr % memberName, " in nonHalo data for write, not yet tested!"
+              ! get data and place it in appropriate array
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DIntPointer)
+              allocate(Array1DIntPointer(count_particlelist(particlelist)))
+              call get_nonhalo_data_from_particle_list_array(particlelist, dimItr % memberName, Array1DIntPointer)
+              ! reorder
+              field1DIntPointer % array = Array1DIntPointer(orderingVector)
+              deallocate(Array1DIntPointer)
+            else
+              !write(stderrunit,*) "Different field type than implemented in nonHalo write!"
+            end if
+          elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+            ! ignore dimensions for now and have this code so they aren't printed as an error message
+          else
+            !write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in nonHalo data for write, don't know what to do!"
+          end if
+        end do
+
+        ! free memory for the next loop
+        deallocate(indexToParticleIDNew)
+        deallocate(orderingVector)
+
+        block => block % next
+        end do
+
+   end subroutine mpas_particle_list_write_nonhalo_data!}}}
+
+!-----------------------------------------------------------------------
+!
+! PRIVATE SUBROUTINES
+!
+!-----------------------------------------------------------------------
+!{{{
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine append_particle_to_particlelist
+!
+!> \brief MPAS add particle to particlelist, starting new list if
+!>        not allocated
+!> \author Phillip Wolfram
+!> \date   06/26/2014
+!> \details
+!>  This routine takes a particle and places it on an existing particlelist,
+!>  or in the event of no list, initializes the list with the particle
+!
+!-----------------------------------------------------------------------
+subroutine append_particle_to_particlelist(particle, particlelist)!{{{
+  implicit none
+  type (mpas_particle_type), pointer, intent(in) :: particle
+  type (mpas_particle_list_type), pointer, intent(inout) :: particlelist
+  type (mpas_particle_list_type), pointer :: headPL=>NULL(), tempPL=>NULL()
+
+  ! case where particeList needs to be created and populated by particle
+  if(.not.associated(particlelist)) then
+    allocate(particlelist)
+    nullify(particlelist % next)
+    nullify(particlelist % prev)
+    particlelist % particle => particle
+  else
+    ! case where list exists get the head
+    headPL => particlelist
+    if (.not.associated(headPL % particle)) then
+      ! populate empty link
+      headPL % particle => particle
+    else
+      ! build new link
+      allocate(tempPL)
+      tempPL % particle => particle
+      nullify(tempPL % prev)
+      tempPL % next => headPL
+      ! connect to the list
+      headPL % prev => tempPL
+      particlelist => tempPL
+    end if
+  end if
+
+end subroutine append_particle_to_particlelist !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_halodata_to_particlelist_1Dreal_array
+!
+!> \brief MPAS get halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine reads 0D real arrays in each particle of the particlelist
+!>  and places the data into a 1D real field output.
+!
+!-----------------------------------------------------------------------
+subroutine get_halo_data_from_particle_list_1Dreal_array &  !{{{
+    (particlelist, dataName, array1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    real (kind=RKIND), dimension(:), pointer, intent(out) :: array1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! allocate the array if it isn't allocated
+    if(.not.associated(array1DRealPointer)) then
+      allocate(array1DRealPointer(count_particlelist(particlelist)))
+    end if
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      call mpas_pool_get_field(particlelistCurr % particle % haloDataPool, dataName, field0DRealPointer)
+      array1DRealPointer(dataNumber) = field0DRealPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_halo_data_from_particle_list_1Dreal_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_halodata_to_particlelist_1Dreal
+!
+!> \brief MPAS get halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine reads 0D real arrays in each particle of the particlelist
+!>  and places the data into a 1D real field output.
+!
+!-----------------------------------------------------------------------
+subroutine get_halo_data_from_particle_list_1Dreal &  !{{{
+    (particlelist, dataName, field1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DReal), pointer, intent(out) :: field1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      call mpas_pool_get_field(particlelistCurr % particle % haloDataPool, dataName, field0DRealPointer)
+      field1DRealPointer % array(dataNumber) = field0DRealPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_halo_data_from_particle_list_1Dreal !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_nonhalodata_to_particlelist_1Dint
+!
+!> \brief MPAS get nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/07/2014
+!> \details
+!
+!-----------------------------------------------------------------------
+subroutine get_nonhalo_data_from_particle_list_1Dint&  !{{{
+    (particlelist, dataName, field1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DInteger), pointer, intent(out) :: field1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+      call mpas_pool_get_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DIntPointer)
+      field1DIntPointer % array(dataNumber) = field0DIntPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_nonhalo_data_from_particle_list_1Dint !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_nonhalodata_to_particlelist_1Dint_array
+!
+!> \brief MPAS get nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/07/2014
+!> \details
+!
+!-----------------------------------------------------------------------
+subroutine get_nonhalo_data_from_particle_list_1Dint_array &  !{{{
+    (particlelist, dataName, array1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    integer, dimension(:), pointer, intent(out) :: array1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! allocate the array if it isn't allocated
+    if(.not.associated(array1DIntPointer)) then
+      allocate(array1DIntPointer(count_particlelist(particlelist)))
+    end if
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+      call mpas_pool_get_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DIntPointer)
+      array1DIntPointer(dataNumber) = field0DIntPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_nonhalo_data_from_particle_list_1Dint_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_nonhalodata_to_particlelist_1Dreal
+!
+!> \brief MPAS get nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/04/2014
+!> \details
+!
+!-----------------------------------------------------------------------
+subroutine get_nonhalo_data_from_particle_list_1Dreal &  !{{{
+    (particlelist, dataName, field1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DReal), pointer, intent(out) :: field1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+      call mpas_pool_get_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DRealPointer)
+      field1DRealPointer % array(dataNumber) = field0DRealPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_nonhalo_data_from_particle_list_1Dreal !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_nonhalodata_to_particlelist_1Dreal_array
+!
+!> \brief MPAS get nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/07/2014
+!> \details
+!
+!-----------------------------------------------------------------------
+subroutine get_nonhalo_data_from_particle_list_1Dreal_array &  !{{{
+    (particlelist, dataName, array1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    real (kind=RKIND), dimension(:), pointer, intent(out) :: array1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! allocate the array if it isn't allocated
+    if(.not.associated(array1DRealPointer)) then
+      allocate(array1DRealPointer(count_particlelist(particlelist)))
+    end if
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+      call mpas_pool_get_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DRealPointer)
+      array1DRealPointer(dataNumber) = field0DRealPointer % scalar
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_nonhalo_data_from_particle_list_1Dreal_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_nonhalodata_to_particlelist_2Dreal
+!
+!> \brief MPAS get nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   04/10/2014
+!> \details
+!>  This routine takes a an array of 1D real arrays and places the data into
+!>  the nonhaloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine get_nonhalo_data_from_particle_list_2Dreal &  !{{{
+    (particlelist, dataName, field2DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field2DReal), pointer, intent(out) :: field2DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field1DReal), pointer :: field1DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+      call mpas_pool_get_field(particlelistCurr % particle % nonhaloDataPool, dataName, field1DRealPointer)
+      field2DRealPointer % array(dataNumber, :) = field1DRealPointer % array(:)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine get_nonhalo_data_from_particle_list_2Dreal !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_halodata_to_particlelist_1Dint_array
+!
+!> \brief MPAS get halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   04/10/2014
+!> \details
+!>  This routine takes a an array of 1D int arrays and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine get_halo_data_from_particle_list_1Dint_array &  !{{{
+    (particlelist, dataName, array1DIntPointer)
+  ! input data
+  type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+  character(len=*), intent(in) :: dataName
+  integer, dimension(:), pointer, intent(out) :: array1DIntPointer
+
+  ! subroutine data
+  integer :: dataNumber
+  type (mpas_particle_list_type), pointer :: particlelistCurr
+  type (field0DInteger), pointer :: field0DIntPointer
+
+  ! allocate the array if it isn't allocated
+  if(.not.associated(array1DIntPointer)) then
+    allocate(array1DIntPointer(count_particlelist(particlelist)))
+  end if
+
+  ! loop over all elements of the list and insert the data
+  dataNumber = 1
+  particlelistCurr => particlelist
+  ! while we have a int link
+  do while(associated(particlelistCurr))
+    call mpas_pool_get_field(particlelistCurr % particle % haloDataPool, dataName, field0DIntPointer)
+    array1DIntPointer(dataNumber) = field0DIntPointer % scalar
+
+    ! increment for new dataNumber
+    dataNumber = dataNumber + 1
+    ! get next link
+    particlelistCurr => particlelistCurr % next
+  end do
+
+end subroutine get_halo_data_from_particle_list_1Dint_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_get_halodata_to_particlelist_1Dint
+!
+!> \brief MPAS get halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   04/10/2014
+!> \details
+!>  This routine takes a an array of 1D int arrays and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine get_halo_data_from_particle_list_1Dint &  !{{{
+    (particlelist, dataName, field1DIntPointer)
+  ! input data
+  type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+  character(len=*), intent(in) :: dataName
+  type (field1DInteger), pointer, intent(out) :: field1DIntPointer
+
+  ! subroutine data
+  integer :: dataNumber
+  type (mpas_particle_list_type), pointer :: particlelistCurr
+  type (field0DInteger), pointer :: field0DIntPointer
+
+  ! loop over all elements of the list and insert the data
+  dataNumber = 1
+  particlelistCurr => particlelist
+  ! while we have a int link
+  do while(associated(particlelistCurr))
+    call mpas_pool_get_field(particlelistCurr % particle % haloDataPool, dataName, field0DIntPointer)
+    field1DIntPointer % array(dataNumber) = field0DIntPointer % scalar
+
+    ! increment for new dataNumber
+    dataNumber = dataNumber + 1
+    ! get next link
+    particlelistCurr => particlelistCurr % next
+  end do
+
+end subroutine get_halo_data_from_particle_list_1Dint !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_halodata_to_particlelist_1Dreal_array
+!
+!> \brief MPAS add halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine takes a an array of real scalars and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_halo_data_to_particle_list_1Dreal_array & !{{{
+    (particlelist, dataName, array1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    real (kind=RKIND), dimension(:), pointer, intent(in) :: array1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DRealPointer)
+      field0DRealPointer % scalar = array1DRealPointer(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % haloDataPool, dataName, field0DRealPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_halo_data_to_particle_list_1Dreal_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_halodata_to_particlelist_1Dreal
+!
+!> \brief MPAS add halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine takes a an array of real scalars and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_halo_data_to_particle_list_1Dreal & !{{{
+    (particlelist, dataName, field1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DReal), pointer, intent(in) :: field1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DRealPointer)
+      field0DRealPointer % scalar = field1DRealPointer % array(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % haloDataPool, dataName, field0DRealPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_halo_data_to_particle_list_1Dreal !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_nonhalodata_to_particlelist_1Dreal_array
+!
+!> \brief MPAS add nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine takes a an array of real scalars and places the data into
+!>  the nonhaloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_nonhalo_data_to_particle_list_1Dreal_array & !{{{
+    (particlelist, dataName, array1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    real (kind=RKIND), dimension(:), pointer :: array1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DRealPointer)
+      field0DRealPointer % scalar = array1DRealPointer(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DRealPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_nonhalo_data_to_particle_list_1Dreal_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_nonhalodata_to_particlelist_1Dreal
+!
+!> \brief MPAS add nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine takes a an array of real scalars and places the data into
+!>  the nonhaloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_nonhalo_data_to_particle_list_1Dreal & !{{{
+    (particlelist, dataName, field1DRealPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DReal), pointer :: field1DRealPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DReal), pointer :: field0DRealPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a real link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DRealPointer)
+      field0DRealPointer % scalar = field1DRealPointer % array(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DRealPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_nonhalo_data_to_particle_list_1Dreal !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_halodata_to_particlelist_1Dint_array
+!
+!> \brief MPAS add halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine takes a an array of int scalars and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_halo_data_to_particle_list_1Dint_array & !{{{
+    (particlelist, dataName, array1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    integer, dimension(:), pointer, intent(in) :: array1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a int link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DIntPointer)
+      field0DIntPointer % scalar = array1DIntPointer(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % haloDataPool, dataName, field0DIntPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_halo_data_to_particle_list_1Dint_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_halodata_to_particlelist_1Dint
+!
+!> \brief MPAS add halodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine takes a an array of int scalars and places the data into
+!>  the haloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_halo_data_to_particle_list_1Dint & !{{{
+    (particlelist, dataName, field1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DInteger), pointer, intent(in) :: field1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a int link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DIntPointer)
+      field0DIntPointer % scalar = field1DIntPointer % array(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % haloDataPool, dataName, field0DIntPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_halo_data_to_particle_list_1Dint !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_nonhalodata_to_particlelist_1Dint_array
+!
+!> \brief MPAS add nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine takes a an array of int scalars and places the data into
+!>  the nonhaloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_nonhalo_data_to_particle_list_1Dint_array & !{{{
+    (particlelist, dataName, array1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    integer, dimension(:), pointer, intent(in) :: array1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a int link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DIntPointer)
+      field0DIntPointer % scalar = array1DIntPointer(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DIntPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_nonhalo_data_to_particle_list_1Dint_array !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine mpas_add_nonhalodata_to_particlelist_1Dint
+!
+!> \brief MPAS add nonhalodata to particle contained in a list
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine takes a an array of int scalars and places the data into
+!>  the nonhaloData pool of the particles in the list.  It is assumed
+!>  that the dimensionality of the field is reduced in order by one
+!>  on each particle.
+!
+!-----------------------------------------------------------------------
+subroutine add_nonhalo_data_to_particle_list_1Dint & !{{{
+    (particlelist, dataName, field1DIntPointer)
+    ! input data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+    character(len=*), intent(in) :: dataName
+    type (field1DInteger), pointer, intent(in) :: field1DIntPointer
+
+    ! subroutine data
+    integer :: dataNumber
+    type (mpas_particle_list_type), pointer :: particlelistCurr
+    type (field0DInteger), pointer :: field0DIntPointer
+
+    ! loop over all elements of the list and insert the data
+    dataNumber = 1
+    particlelistCurr => particlelist
+    ! while we have a int link
+    do while(associated(particlelistCurr))
+
+      allocate(field0DIntPointer)
+      field0DIntPointer % scalar = field1DIntPointer % array(dataNumber)
+      call mpas_pool_add_field(particlelistCurr % particle % nonhaloDataPool, dataName, field0DIntPointer)
+
+      ! increment for new dataNumber
+      dataNumber = dataNumber + 1
+      ! get next link
+      particlelistCurr => particlelistCurr % next
+    end do
+
+end subroutine add_nonhalo_data_to_particle_list_1Dint !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine count_particlelist_particles
+!
+!> \brief MPAS count particles in particlelist (must be allocated)
+!> \author Phillip Wolfram
+!> \date   04/14/2014
+!> \details
+!>  This routine counts number of particles in particlelist.
+!
+!-----------------------------------------------------------------------
+integer function count_particlelist_particles(particlelist) !{{{
+  implicit none
+    ! input/output data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+
+    ! subroutine data
+    type (mpas_particle_list_type), pointer :: ParticleLinkCurr
+
+    count_particlelist_particles = 0
+    !write(stderrUnit,*) 'count_particlelist'
+    !if(.not.associated(particlelist)) then
+    !  write(stdoutunit,*) 'particleLinkCurr not associated'
+    !  return
+    !end if
+
+    ! current link
+    particleLinkCurr => particlelist
+
+    do while (associated(particleLinkCurr))
+      ! increment the list
+      if (associated(particleLinkCurr % particle)) then
+        count_particlelist_particles = count_particlelist_particles + 1
+      end if
+      ! get next item on the list
+      particleLinkCurr => particleLinkCurr % next
+    end do
+
+    return
+
+end function count_particlelist_particles !}}}
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine build_new_particlelist
+!
+!> \brief MPAS build list of particles
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine builds up a list of empty particles ready to be populated.
+!>  This is just a raw constructor for a particle list.  This assumes
+!>  that a list is more than 1 link, such that nParticles >= 2.
+!
+!-----------------------------------------------------------------------
+subroutine build_new_particlelist(nParticles, particlelist, ioBlock) !{{{
+    ! input/output data
+    ! number of particles
+    integer, intent(in) :: nParticles
+    integer, intent(in), optional :: ioBlock
+    type (field0dInteger), pointer :: ioBlockfield
+    type (mpas_particle_list_type), pointer, intent(inout) :: particlelist
+    ! subroutine data
+    integer aParticle
+    type (mpas_particle_type), pointer :: particle
+    type (mpas_particle_list_type), pointer :: newParticleLink
+    type (mpas_particle_list_type), pointer :: ParticleLinkCurr
+
+    integer :: counter
+
+    if(nParticles == 0) then
+      return
+    end if
+
+    ! instantiate a list of empty particles of dimension nParticles
+    if(.not.associated(particlelist)) then
+      allocate(particlelist)
+    end if
+
+    ! allocate memory for the new particle
+    allocate(particle)
+    call mpas_pool_create_pool(particle % haloDataPool)
+    call mpas_pool_create_pool(particle % nonhaloDataPool)
+    if (present(ioBlock)) then
+      allocate(ioBlockfield)
+      ioBlockfield % scalar = ioBlock
+      call mpas_pool_add_field(particle % haloDataPool, 'ioBlock', ioBlockfield)
+    end if
+
+    !! allocate start of list link (this must have already been done!
+    ! assign allocated particle memory to link
+    particlelist % particle => particle
+
+    ! current link
+    particleLinkCurr => particlelist
+
+    ! add more links
+    do aParticle = 2, nParticles
+      ! allocate memory for the  new particle
+      allocate(particle)
+      call mpas_pool_create_pool(particle % haloDataPool)
+      call mpas_pool_create_pool(particle % nonhaloDataPool)
+      if(present(ioBlock)) then
+        allocate(ioBlockfield)
+        ioBlockfield % scalar = ioBlock
+        call mpas_pool_add_field(particle % haloDataPool, 'ioBlock', ioBlockfield)
+      end if
+      ! we already have one link so make a new one
+      allocate(newParticleLink)
+      ! place the particle in the list link
+      newParticleLink % particle => particle
+      nullify(newParticleLink % next)
+      ! connect new link to current link
+      newParticleLink % prev => particleLinkCurr
+      ! next  link is the new link
+      particleLinkCurr % next => newParticleLink
+      ! reset link to last link
+      particleLinkCurr => newParticleLink
+    end do
+
+end subroutine build_new_particlelist !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine count_particlelist
+!
+!> \brief MPAS count particles in particlelist
+!> \author Phillip Wolfram
+!> \date   04/14/2014
+!> \details
+!>  This routine counts number of particles in particlelist.
+!
+!-----------------------------------------------------------------------
+integer function count_particlelist(particlelist) !{{{
+  implicit none
+    ! input/output data
+    type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+
+    ! subroutine data
+    type (mpas_particle_list_type), pointer :: ParticleLinkCurr
+
+    count_particlelist = 0
+    !write(stderrUnit,*) 'count_particlelist'
+    !if(.not.associated(particlelist)) then
+    !  write(stdoutunit,*) 'particleLinkCurr not associated'
+    !  return
+    !end if
+
+    ! current link
+    particleLinkCurr => particlelist
+
+    do while (associated(particleLinkCurr))
+      ! increment the list
+      count_particlelist = count_particlelist + 1
+      !write(stderrUnit,*) 'count_particlelist = ', count_particlelist
+      ! get next item on the list
+      particleLinkCurr => particleLinkCurr % next
+    end do
+
+    return
+
+end function count_particlelist !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine destroy_particle
+!
+!> \brief MPAS destroy particle
+!> \author Phillip Wolfram
+!> \date   06/03/2014
+!> \details
+!>  This routine destroys a particle, deallocating its memory
+!
+!-----------------------------------------------------------------------
+subroutine destroy_particle(particle) !{{{
+  implicit none
+
+  type (mpas_particle_type), pointer, intent(inout) :: particle
+
+  if(associated(particle)) then
+    if(associated(particle % haloDataPool)) then
+      call mpas_pool_destroy_pool(particle % haloDataPool)
+    end if
+    if(associated(particle % nonhaloDataPool)) then
+      call mpas_pool_destroy_pool(particle % nonhaloDataPool)
+    end if
+    deallocate(particle)
+  end if
+
+end subroutine destroy_particle !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine empty_particlelist
+!
+!> \brief MPAS empty particlelist
+!> \author Phillip Wolfram
+!> \date   06/27/2014
+!> \details
+!>  This routine emptys a particlelist, deallocating its memory
+!>  but keeping memory of particles it contains intact
+!
+!-----------------------------------------------------------------------
+subroutine empty_particlelist(particlelist) !{{{
+  type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+  type (mpas_particle_list_type), pointer :: pLCurr, pLCurrTemp
+
+  plCurr => particlelist
+  do while(associated(plCurr))
+    pLCurrTemp => pLCurr
+    pLCurr => pLCurr % next
+    deallocate(pLCurrTemp)
+    ! N.B., particle contained in pLCurrTemp is not deallocated!!!
+  end do
+
+end subroutine empty_particlelist !}}}
+
+subroutine destory_list_particlelists(listParticleLists) !{{{
+  type (mpas_list_of_particle_list_type), dimension(:), pointer, intent(inout) :: listParticleLists
+  integer :: i, sizeList
+
+  if(associated(listParticleLists)) then
+    sizeList = size(listParticleLists)
+    do i=1,sizeList
+      call mpas_particle_list_destroy_particle_list(listParticleLists(i) % list)
+    end do
+    deallocate(listParticleLists)
+  end if
+
+end subroutine destory_list_particlelists !}}}
+
+subroutine empty_list_particlelists(listParticleLists) !{{{
+  type (mpas_list_of_particle_list_type), dimension(:), pointer, intent(inout) :: listParticleLists
+  integer :: i, sizeList
+
+  if(associated(listParticleLists)) then
+    sizeList = size(listParticleLists)
+    do i=1,sizeList
+      call empty_particlelist(listParticleLists(i) % list)
+    end do
+    deallocate(listParticleLists)
+  end if
+
+end subroutine empty_list_particlelists!}}}
+
+!***********************************************************************
+!
+!  routine compute_cellOwnerBlock(domain, err)
+!
+!> \brief   Compute owner block arrays to specify halo ownership
+!> \author  Phillip Wolfram
+!> \date    06/25/2014
+!> \details
+!>  This routine computes the cellOwnerBlock for all cells on a block,
+!>  diagnosing the block which owns each cell.  Could potentially be
+!>  generalized and put in framework (probably need package variables
+!>  if particles are used).
+!
+!-----------------------------------------------------------------------
+   subroutine compute_cellOwnerBlock(domain, err) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (field1DInteger), pointer :: cellOwnerBlock
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! get pool to access cellOwnerBlock
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackPool)
+        ! prepare cellOwnerBlock for use in determining blockID to
+        ! be passed from one processor to another
+        call mpas_pool_get_field(lagrPartTrackPool, 'cellOwnerBlock', cellOwnerBlock)
+        ! set cellOwnerBlock to be current block
+        cellOwnerBlock % array(:) = block % blockID
+
+        block => block % next
+      end do
+      ! exchange halos
+      call mpas_dmpar_exch_halo_field(cellOwnerBlock)
+
+   end subroutine compute_cellOwnerBlock !}}}
+
+!***********************************************************************
+!
+!  routine compute_blockNeighs(domain, err)
+!
+!> \brief   Compute neighboring blocks from owner block,
+!>          parsing the halo to get unique values
+!> \author  Phillip Wolfram
+!> \date    06/26/2014
+!> \details
+!>  This routine computes the neighboring blocks block % blockNeighs
+!>  for each block.  Note that the size of this is not predetermined
+!>  and depends on the partitioning (typically in graph.info.part.#)
+!
+!-----------------------------------------------------------------------
+   subroutine compute_blockNeighs(domain, err) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (field1DInteger), pointer :: cellOwnerBlock
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! get pool to access cellOwnerBlock
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackPool)
+        ! get cellOwnerBlock
+        call mpas_pool_get_field(lagrPartTrackPool, 'cellOwnerBlock', cellOwnerBlock)
+
+        ! compute unique list obtained from cellOwnerBlock
+        call uniqueIntegerList(cellOwnerBlock % array, block % blockNeighs)
+
+        block => block % next
+      end do
+
+   end subroutine compute_blockNeighs !}}}
+
+!***********************************************************************
+!
+!  routine compute_block_procNeighs(domain, err)
+!
+!> \brief   Compute neighboring processors from blockNeighs,
+!>          getting unique values on a block
+!> \author  Phillip Wolfram
+!> \date    06/26/2014
+!> \details
+!>  This routine computes the neighboring processors corresponding to
+!>  block % blockNeighs for each block.
+!
+!-----------------------------------------------------------------------
+   subroutine compute_block_procNeighs(domain, err) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      !type (mpas_pool_type), pointer :: lagrPartTrackPool
+      integer, dimension(:), pointer :: array
+      integer :: numBlockNeighs, i
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! convert blockNeighs to procNeighs array
+        numBlockNeighs = size(block % blockNeighs)
+        allocate(array(numBlockNeighs))
+        do i=1, numBlockNeighs
+          call mpas_get_owning_proc(domain % dminfo, block % blockNeighs(i), array(i))
+        end do
+        ! compute unique list for processor neighbors
+        call uniqueIntegerList(array, block % procNeighs)
+
+        ! free up temporary memory
+        deallocate(array)
+
+        ! get the next block
+        block => block % next
+      end do
+
+   end subroutine compute_block_procNeighs !}}}
+
+!***********************************************************************
+!
+!  routine compute_procNeighs(domain, err)
+!
+!> \brief   Compute neighboring processors from blockNeighs,
+!>          getting unique values across all blocks
+!> \author  Phillip Wolfram
+!> \date    06/26/2014
+!> \details
+!>  This routine computes the neighboring processors corresponding to
+!>  block % procNeighs for each block.
+!
+!-----------------------------------------------------------------------
+   subroutine compute_procNeighs(domain, err, procNeighs) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+      integer, dimension(:), pointer, intent(out) :: procNeighs
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      integer, dimension(:), pointer :: tempIntegerArray
+      integer :: localSize, totalSize, iStart
+
+      err = 0
+
+      totalSize = 0
+
+      block => domain % blocklist
+      do while(associated(block))
+        totalSize = totalSize + size(block % procNeighs)
+        block => block % next
+      end do
+
+      allocate(tempIntegerArray(totalSize))
+
+      block => domain % blocklist
+      iStart = 1
+      do while(associated(block))
+        localSize = size(block % procNeighs)
+        tempIntegerArray(iStart:iStart+localSize-1) = block % procNeighs
+        iStart = iStart + localSize
+        block => block % next
+      end do
+
+      ! get unique array for complete list
+      call uniqueIntegerList(tempIntegerArray, procNeighs)
+
+      deallocate(tempIntegerArray)
+
+   end subroutine compute_procNeighs !}}}
+
+!***********************************************************************
+!
+!  routine uniqueIntegerList(array, uniqueList)
+!
+!> \brief   Compute unique entries in array with output in uniqueList
+!> \author  Phillip Wolfram
+!> \date    06/26/2014
+!> \details
+!>  This routine computes the unique entries in an array using a
+!>  linked list for dynamic memory storage
+!
+!-----------------------------------------------------------------------
+   subroutine uniqueIntegerList(array, uniqueList) !{{{
+     implicit none
+     integer, dimension(:), pointer, intent(out) :: uniqueList
+     integer, dimension(:), pointer, intent(in) :: array
+
+      type simplelist
+        type (simplelist), pointer :: next => null()
+        integer :: num
+      end type simplelist
+
+      type (simplelist), pointer :: listhead, templist, currlist
+
+      integer :: nlist, i
+
+      ! parse the simple list, looking for unique values
+      ! algorithm will scale like Nblocks*NCells
+
+      if(.not.associated(array)) then
+        uniqueList => null()
+        return
+      end if
+
+      ! first entry
+      allocate(listhead)
+      listhead % num = array(1)
+      nlist = 1
+
+      do i = 2, size(array)
+        currlist => listhead
+        ! check to see if value is on list
+        do while(associated(currlist))
+          if(currlist % num == array(i)) then
+            exit
+          else
+            if(.not.associated(currlist % next)) then
+              ! we are on the end of the list, so we should add the entry
+              allocate(templist)
+              templist % num = array(i)
+              nlist = nlist + 1
+              currlist % next => templist
+            end if
+            currlist => currlist % next
+          end if
+        end do
+      end do
+
+      ! now we have a complete, unique list so store it
+      if(associated(uniqueList)) write(stderrunit,*) 'Trying to allocate uniqueList, which is already allocated!'
+      allocate(uniqueList(nlist))
+
+      currlist => listhead
+      i = 1
+      do while(associated(currlist))
+        uniqueList(i) = currlist % num
+        currlist => currlist % next
+        i = i + 1
+      end do
+
+      ! deallocate linked list
+      currlist => listhead
+      do while(associated(currlist))
+        templist => currlist % next
+        deallocate(currlist)
+        currlist => templist
+      end do
+
+   end subroutine uniqueIntegerList !}}}
+
+!***********************************************************************
+!
+!  routine  compute_all_particle_values_unique_int
+!
+!> \brief   Get a unique list of values across particlelists on all blocks
+!> \author  Phillip Wolfram
+!> \date    07/02/2014
+!> \details
+!>  This routine computes a unique list of values for all the particles
+!>  on the processor.
+!
+!-----------------------------------------------------------------------
+     subroutine compute_all_particle_values_unique_int(domain, err, attrName, attrData) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      character(len=*) :: attrName
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+      integer, dimension(:), pointer, intent(out) :: attrData
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      integer, dimension(:), pointer :: tempIntegerArray
+      integer :: localSize, totalSize, iStart, nPart
+
+      err = 0
+
+      ! need to get full set of attrData from each processor and form unique list
+
+      totalSize = 0
+
+      block => domain % blocklist
+      do while(associated(block))
+        nPart = count_particlelist(block % particlelist)
+        if (nPart > 0) then
+          allocate(attrData(nPart))
+          call get_halo_data_from_particle_list_array(block % particlelist, trim(attrName), attrData)
+          totalSize = totalSize + size(attrData)
+          deallocate(attrData)
+        end if
+        block => block % next
+      end do
+
+      if (totalSize > 0) allocate(tempIntegerArray(totalSize))
+
+      block => domain % blocklist
+      iStart = 1
+      do while(associated(block))
+        nPart = count_particlelist(block % particlelist)
+        if (nPart > 0) then
+          allocate(attrData(nPart))
+          call get_halo_data_from_particle_list_array(block % particlelist, trim(attrName), attrData)
+          localSize = size(attrData)
+          tempIntegerArray(iStart:iStart+localSize-1) = attrData
+          iStart = iStart + localSize
+          deallocate(attrData)
+        end if
+        block => block % next
+      end do
+
+      ! get unique array for complete list
+      !if(associated(tempIntegerArray)) write(stderrUnit,*) 'tempIntegerArray = ', tempIntegerArray
+      call uniqueIntegerList(tempIntegerArray, attrData)
+
+      if (associated(tempIntegerArray)) deallocate(tempIntegerArray)
+
+     end subroutine compute_all_particle_values_unique_int !}}}
+
+!***********************************************************************
+!
+!  routine make_proc_to_proc_particlelist(domain, err)
+!
+!> \brief   Compute neighboring processors from blockNeighs,
+!>          getting unique values across all blocks and forming the lists
+!> \author  Phillip Wolfram
+!> \date    06/26/2014
+!> \details
+!>  This routine computes the lists of neighboring processors
+!
+!-----------------------------------------------------------------------
+   subroutine make_proc_to_proc_particlelists(domain, copyOnly, blockSendToName, interProcPLArray, procNeighs, err) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      character(len=*), intent(in) :: blockSendToName
+      logical, intent(in) :: copyOnly
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: domain
+      integer, dimension(:), pointer, intent(in) :: procNeighs
+      type (mpas_list_of_particle_list_type), dimension(:), &
+                            pointer, intent(inout) :: interProcPLArray
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_particle_list_type), pointer :: particlelist, particlelisttemp, particlelisttemp2
+      integer :: thisBlock
+      integer, pointer :: particleBlock
+      integer :: particleProc, arrayIndex
+      !type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (mpas_particle_type), pointer :: particle
+
+      err = 0
+
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'make_proc_to_proc_particlelists'
+#endif
+
+      block => domain % blocklist
+      do while(associated(block))
+        ! for each particle on each block
+        particlelist => block % particlelist
+        do while(associated(particlelist))
+#ifdef MPAS_DEBUG
+          !write(stderrunit,*) 'link on particlelist ', loc(particlelist)
+          if(.not.associated(particlelist % particle)) then
+            write(stderrunit,*) 'particle not associated!'
+          end if
+#endif
+          particle => particlelist % particle
+#ifdef MPAS_DEBUG
+          if(.not.associated(particle % haloDataPool)) then
+            write(stderrunit,*) 'particle haloDataPool not associated!'
+          end if
+#endif
+          call mpas_pool_get_array(particle % haloDataPool, blockSendToName, particleBlock)
+#ifdef MPAS_DEBUG
+          ! For example:
+          !call mpas_pool_get_array(particle % haloDataPool, 'currentBlock', particleBlock)
+
+          !write(stderrunit,*) 'particleBlock ', particleBlock, ' for ', trim(blockSendToName)
+          !write(stderrunit,*) 'before mpas call'
+#endif
+          call mpas_get_owning_proc(domain % dminfo, particleBlock, particleProc)
+#ifdef MPAS_DEBUG
+          if(particleBlock /= particleProc) write(stderrunit,*) 'Error if one block per proc: currentBlock = ', &
+            particleBlock, ' currentProc = ', particleProc
+          write(stderrunit,*) 'after mpas call'
+          ! determine whether it belongs on thisBlock
+          write(stderrUnit,*) 'myproc= ', domain % dminfo % my_proc_id, ' particleProc= ', particleProc
+#endif
+          ! eventual support for multiple blocks
+          !if(particleBlock /= block % blockID) then
+          if(particleProc /= domain % dminfo % my_proc_id) then
+            ! we need to move the particle to a list for export to particleProc
+            ! get index for array and place particle in list at that index location
+            !write(stderrUnit,*) 'get array index'
+            arrayIndex = find_index(procNeighs, particleProc)
+            if(arrayIndex == -1) write(stderrUnit,*) 'Found processor is not on list of "halo" processors!'
+#ifdef MPAS_DEBUG
+            write(stderrUnit,*) 'ammending particle to processor index  ', arrayIndex
+#endif
+            call append_particle_to_particlelist(particle, interProcPLArray(arrayIndex)%list)
+#ifdef MPAS_DEBUG
+            !write(stderrUnit,*) 'added particle ', loc(particle), ' on link ', loc(particlelist), ' to list'
+#endif
+            if (.not.copyOnly) then
+              ! REMOVE PARTICLE FROM EXISTING PARTICLELIST
+              ! remove particle reference from existing particle list to prevent bug / hitting null
+              ! particle if particle is deallocated when interProcPLArray particlelists are destroyed
+              ! next two lines mean (particlelist % prev) % next => particlelist % next, which
+              ! fortran doesn't allow even though syntactically this makes perfect sense.
+              ! 3 cases: head, middle, tail
+              if(associated(particlelist % prev)) then
+                !write(stderrUnit,*) 'have previous particlelist link'
+                particlelisttemp => particlelist % prev
+                if (associated(particlelist % next)) then
+#ifdef MPAS_DEBUG
+                  write(stderrUnit,*) 'in middle of list'
+#endif
+                  ! case of the middle
+                  particlelisttemp % next => particlelist % next
+                  particlelisttemp2 => particlelisttemp
+                  ! want to keep particle memory intact because their pointers were passed previously,
+                  ! so just empty the list, don't destroy it and its contents
+                  particlelisttemp => particlelist % next
+                  particlelisttemp % prev => particlelisttemp2
+
+                  particlelisttemp => particlelisttemp % prev
+                  ! just need to remove the single link, particle memory needs to stay intact
+                  !write(stderrunit,*) 'deallocating link ', loc(particlelist)
+                  ! deallocate link and get next link
+                  deallocate(particlelist)
+                  particlelist => particlelisttemp
+                else
+#ifdef MPAS_DEBUG
+                  write(stderrUnit,*) 'in tail of list'
+#endif
+                  ! case of tail
+                  nullify(particlelisttemp % next)
+                  !write(stderrunit,*) 'deallocating link ', loc(particlelist)
+                  ! deallocate link and get next link
+                  deallocate(particlelist)
+                  ! no other links to process
+                end if
+              else
+                if(associated(particlelist % next)) then
+#ifdef MPAS_DEBUG
+                  write(stderrUnit,*) 'in head of list'
+#endif
+                  ! case of head, set new head (assumes more than one particle)
+                  particlelisttemp => particlelist % next
+                  nullify(particlelisttemp % prev)
+                  deallocate(particlelist)
+                  block % particlelist => particlelisttemp
+                  !write(stderrunit,*) 'deallocating link ', loc(particlelist)
+                  ! deallocate link and get next link
+                  particlelist => particlelisttemp
+                else
+#ifdef MPAS_DEBUG
+                  !write(stderrUnit,*) 'single link ', loc(particlelist)
+                  !write(stderrUnit,*) 'block % particlelist', loc(block % particlelist)
+#endif
+                  ! case of single link / particle
+                  !write(stderrunit,*) 'deallocating link ', loc(particlelist)
+                  deallocate(particlelist)
+                  nullify(block % particlelist) !deallocate(block % particlelist)
+                  ! there is no other particle in the list (we now have 0!)
+                end if
+              end if
+            else
+              particlelist => particlelist % next
+            end if
+          else
+            !write(stderrUnit,*) 'just go to the next particle'
+            particlelist => particlelist % next
+          end if
+        end do
+
+        ! this is done for each block because we want processor - processor communication
+        block => block % next
+      end do
+
+   end subroutine make_proc_to_proc_particlelists!}}}
+
+   subroutine get_num_particlelists(particlelists, numLists, nPartList) !{{{
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_list_of_particle_list_type), dimension(:), &
+                            pointer, intent(in) :: particlelists
+      integer, intent(in) :: numLists
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+      integer, dimension(:), pointer, intent(inout) :: nPartList
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+      integer :: i, allerr=0
+
+      ! now get number of particles in each list
+      ! for each entry in list of particlelist
+      nPartList = -1
+      do i=1, numLists
+        nPartList(i) = count_particlelist(particlelists(i)%list)
+#ifdef MPAS_DEBUG
+      write(stderrunit,*) 'nPartList(i)=', nPartList(i)
+#endif
+      end do
+
+   end subroutine get_num_particlelists !}}}
+
+!***********************************************************************
+!
+!  routine communicate_num_particles_send_recv
+!
+!> \brief   Communicate the number of particles to be sent/recv'd
+!>          from adjacent processors
+!> \author  Phillip Wolfram
+!> \date    06/27/2014
+!> \details
+!>  This routine transmitts nPartSend to be stored in nPartRecv of
+!>  adjacent processors in procNeighs.  Not that matrix with
+!>  procNeighs in columns stored in rows for each processor
+!>  must be symmetric for this to work.
+!
+!-----------------------------------------------------------------------
+   subroutine communicate_num_particles_send_recv(domain, procNeighs, nPartSend, nPartRecv) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     integer, dimension(:), pointer, intent(in) :: procNeighs
+     integer, dimension(:), pointer, intent(in) :: nPartSend
+     integer, dimension(:), pointer, intent(out) :: nPartRecv
+
+     integer :: i, j, numProcs
+     integer, dimension(:), pointer :: requestID
+     integer :: mpi_ierr
+
+     numProcs = size(procNeighs)
+
+     ! set to be -1 for error catching
+     nPartRecv = -1
+
+     ! want to send individual values in nPartSend to each entry in procNeighs (paired data)
+     ! values obtained after communication are to be stored in nPartRecv
+
+     allocate(requestID(2*numProcs))
+#ifdef MPAS_DEBUG
+write(stderrUnit,*) 'before 1st barrier'
+#ifdef _MPI
+     call MPI_Barrier(domain % dminfo % comm, mpi_ierr)
+#endif
+write(stderrUnit,*) 'after 1st barrier'
+write(stderrUnit,*) 'receiving data'
+write(stderrUnit,*) 'numProcs =', numProcs
+#endif
+     do i=1,numProcs
+#ifdef MPAS_DEBUG
+       write(stderrUnit,*) 'procNeighs=', procNeighs
+       write(stderrUnit,*) 'sending data i=',i, ' procNeighs(i)=', procNeighs(i), ' nPartSend(i)=', nPartSend(i)
+#endif
+#ifdef _MPI
+         call MPI_ISend(nPartSend(i), 1, MPI_INTEGERKIND, procNeighs(i), domain % dminfo % my_proc_id, &
+           domain % dminfo % comm, requestID(numProcs + i), mpi_ierr)
+#endif
+#ifdef MPAS_DEBUG
+       write(stderrUnit,*) 'receiving data i=',i, ' procNeighs(i)=', procNeighs(i)
+#endif
+#ifdef _MPI
+         call MPI_IRecv(nPartRecv(i), 1, MPI_INTEGERKIND, procNeighs(i), procNeighs(i), &
+           domain % dminfo % comm, requestID(i), mpi_ierr)
+#endif
+     end do
+#ifdef MPAS_DEBUG
+  write(stderrUnit,*) 'done with send receive calls'
+#endif
+#ifdef _MPI
+     call MPI_WaitAll(2*numProcs, requestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+#ifdef MPAS_DEBUG
+write(stderrUnit,*) 'before 2nd barrier'
+#ifdef _MPI
+call MPI_Barrier(domain % dminfo % comm, mpi_ierr)
+#endif
+write(stderrUnit,*) 'after 2nd barrier'
+  write(stderrUnit,*) 'done with wait'
+#endif
+     deallocate(requestID)
+
+   end subroutine communicate_num_particles_send_recv !}}}
+
+!***********************************************************************
+!
+!  routine compute_particle_send_list
+!
+!> \brief   Update send list
+!> \author  Phillip Wolfram
+!> \date    06/24/2015
+!> \details
+!>  Compute send list for all particles residing on correct block 'currentBlock'
+!-----------------------------------------------------------------------
+   subroutine compute_particle_send_list(domain, ioProcSendList) !{{{
+     implicit none
+     type (domain_type), intent(in) :: domain
+     logical, dimension(:), pointer, intent(inout) :: ioProcSendList
+
+     ! local variables
+     type (block_type), pointer :: block
+     type (mpas_particle_list_type), pointer :: particlelist
+     type (mpas_particle_type), pointer :: particle
+     integer, pointer :: ioBlock
+     integer :: ioProc
+
+     block => domain % blocklist
+     do while (associated(block)) !{{{
+       particlelist => block % particlelist
+       do while(associated(particlelist)) !{{{
+         particle => particlelist % particle
+         call mpas_pool_get_array(particle % haloDataPool, 'ioBlock', ioBlock)
+         call mpas_get_owning_proc(domain % dminfo, ioBlock, ioProc)
+         ioProcSendList(ioProc+1) = .True.
+         ! get next particle to process on the list
+         particlelist => particlelist % next
+       end do !}}}
+       ! get next block
+       block => block % next
+     end do !}}}
+
+   end subroutine compute_particle_send_list !}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine allocate_list_particlelists
+!
+!> \brief MPAS allocate list of particlelists
+!> \author Phillip Wolfram
+!> \date   07/01/2014
+!> \details
+!>  This routine allocates a list of particlelists.  Useful in preparation
+!>  to receive data from MPI communication
+!
+!-----------------------------------------------------------------------
+subroutine allocate_list_particlelists(nPart, listPL) !{{{
+  implicit none
+
+  type (mpas_list_of_particle_list_type), dimension(:), intent(inout), pointer :: listPL
+  integer, dimension(:), pointer, intent(in) :: nPart
+
+  integer :: nProcs, i
+
+  nProcs = size(nPart)
+
+  ! allocate size of particeLists
+  do i=1,nProcs
+    call build_new_particlelist(nPart(i), listPL(i)%list)
+  end do
+
+end subroutine allocate_list_particlelists !}}}
+
+!***********************************************************************
+!
+!  routine distribute_particlelist_to_blocks
+!
+!> \brief   Take a list of particlelists and move them onto the appropriate
+!>          block on the processor
+!> \author  Phillip Wolfram
+!> \date    07/01/2014
+!> \details
+!>  This routine places particles in a list of particlelist on the appropriate
+!>  block (currentBlock) on the processor
+!
+!-----------------------------------------------------------------------
+   subroutine distribute_particlelist_to_blocks(domain, blockSendToName, listPL) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     type (mpas_list_of_particle_list_type), dimension(:), pointer, intent(in) :: listPL
+     character(len=*), intent(in) :: blockSendToName
+
+     integer :: i, numLists
+     type (block_type), pointer :: block
+     type (mpas_particle_list_type), pointer :: tempPL
+     type (mpas_particle_type), pointer :: particle
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     integer, pointer :: blockNum
+
+     ! need to copy pointers to particles from each entry of the listPL and move the
+     ! particle to the appropriate block
+
+     ! loop over each part of the particle list
+     numLists = size(listPL)
+     do i=1,numLists
+       ! get a single list of particles
+       tempPL => listPL(i) % list
+       ! iterate through the list and assign particles
+       do while(associated(tempPL))
+         ! get the particle blockNum
+         particle => tempPL % particle
+         call mpas_pool_get_array(particle % haloDataPool, blockSendToName, blockNum)
+
+         ! determine the block the particle should be moved to
+         block => domain % blocklist
+         !write(stderrunit,*) 'blockNum = ' , blockNum
+         blocksearch: do while(associated(block))
+           !write(stderrunit,*) 'blockID = ', block % blockID, 'blockNum = ', blockNum
+           if (block % blockID == blockNum) then
+             ! we have the correct block
+             exit blocksearch
+           end if
+           block => block % next
+         end do blocksearch
+
+         ! check to make sure block is correct
+         !write(stderrunit,*) 'blockNum = ', blockNum
+         if (blockNum /= block % blockID) then
+           write(stderrunit,*) 'block is not correct! for blockNum =', blockNum, ' and blockID = ', block % blockID
+         end if
+
+         ! move the particle to the block
+         call append_particle_to_particlelist(particle, block % particlelist)
+
+         ! get the next particle in the list
+         tempPL => tempPL % next
+       end do
+
+     end do
+
+   end subroutine distribute_particlelist_to_blocks !}}}
+
+!***********************************************************************
+!
+!  routine compute_ordering_vector
+!
+!> \brief   Compute the orderingVector for restructuring of mixed up particles
+!>          into original order
+!> \author  Phillip Wolfram
+!> \date    07/03/2014
+!> \details
+!>  This routine ensures that the particles are ordered consistently with
+!>  the ordering of the original data.
+!
+!-----------------------------------------------------------------------
+   subroutine compute_ordering_vector(arrayOrig, arrayNew, orderingVector) !{{{
+     implicit none
+
+     integer, dimension(:), pointer, intent(in) :: arrayOrig, arrayNew
+     integer, dimension(:), pointer, intent(out) :: orderingVector
+
+     integer :: i, idx
+
+     allocate(orderingVector(size(arrayOrig)))
+     ! allocate to -1 to that if a value isn't found it isn't random data, assuming arrays
+     ! are all indexed starting from 1
+     orderingVector = -1
+     ! loop over each element and figure out index
+     do i=1,size(arrayOrig)
+       !N.B. should in principle check to make sure index is found
+       idx = find_index(arrayNew, arrayOrig(i))
+#ifdef MPAS_DEBUG
+       if ( idx  > 0 ) then
+#endif
+         orderingVector(i) = idx
+#ifdef MPAS_DEBUG
+       else
+         write(stderrunit,*) "ERROR! Didn't find correct ordering index"
+       end if
+#endif
+     end do
+
+   end subroutine compute_ordering_vector !}}}
+
+!***********************************************************************
+!
+!  routine  find_index
+!
+!> \brief   find the index corresponding to num in array
+!> \author  Phillip Wolfram
+!> \date    07/03/2014
+!> \details
+!>  This routine returns the index such that array(find_index) = num.
+!>  If the index doesn't exist it returns -1.
+!
+!-----------------------------------------------------------------------
+   integer function find_index(array, num) !{{{
+     implicit none
+
+     integer, dimension(:), pointer, intent(in) :: array
+     integer, intent(in) :: num
+
+     integer :: i
+
+     ! allocate to negative number to make sure it breaks if
+     ! an index is not found
+
+     find_index = -1
+     ! an error here could be caused by running with different
+     ! processors (blocks) specified in the input file
+     ! than run with MPI
+     do i=1,size(array)
+       if(num == array(i)) then
+         find_index = i
+         return
+       end if
+     end do
+
+#ifdef MPAS_DEBUG
+     if(find_index == -1) write(stderrunit,*) 'Error: Index number ', num,' not found in array!'
+#endif
+
+   end function find_index !}}}
+
+!***********************************************************************
+!
+!  routine communicate_particle_nonhalo_data
+!
+!> \brief   Communicate particle nonhalo data to relevant processors
+!>          based on particlelists
+!> \author  Phillip Wolfram
+!> \date    07/07/2014
+!> \details
+!>  This routine transmitts nonHaloData from particlelists
+!
+!-----------------------------------------------------------------------
+   subroutine communicate_particle_nonhalo_data(domain, procNeighs, nPartSend, nPartRecv, listSend, listRecv) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     integer, dimension(:), pointer, intent(in) :: procNeighs
+     integer, dimension(:), pointer, intent(in) :: nPartSend
+     integer, dimension(:), pointer, intent(out) :: nPartRecv
+     type (mpas_list_of_particle_list_type), dimension(:), pointer :: listSend, listRecv
+
+     integer :: i, j, numProcs, numFields, numRecv, numSends
+     integer, dimension(:), pointer :: recvRequestID, sendRequestID
+     integer :: mpi_ierr
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     type (mpas_pool_iterator_type) :: dimItr
+     type array1DReal_list
+       real (kind=RKIND), dimension(:), pointer :: val
+     end type
+     type array1DInt_list
+       integer, dimension(:), pointer :: val
+     end type
+     type (array1DInt_list), dimension(:), pointer :: array1DIntSend, array1DIntRecv
+     type (array1DReal_list), dimension(:), pointer :: array1DRealSend, array1DRealRecv
+
+     ! for each entry in the halo pool, want to send and recv the data
+
+#ifdef _MPI
+     !call MPI_Barrier(domain % dminfo % comm)
+#endif
+
+     numProcs = size(procNeighs)
+     allocate(array1DRealSend(numProcs), array1DRealRecv(numProcs))
+     allocate(array1DIntSend(numProcs),  array1DIntRecv(numProcs))
+
+     numSends = 0
+     do i = 1, numProcs
+       if (nPartSend(i) > 0) numSends = numSends + 1
+     end do
+     allocate(sendRequestID(numSends))
+
+     numRecv = 0
+     do i = 1, numProcs
+       if (nPartRecv(i) > 0) numRecv = numRecv + 1
+     end do
+     allocate(recvRequestID(numRecv))
+
+     !Notes !{{{
+     !! get number of items that need transfered from halo pool, numFields which is a constant
+     !call mpas_pool_get_subpool(domain % blocklist % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+     !call mpas_pool_begin_iteration(lagrPartTrackPool)
+     !numFields = 0
+     !do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+     !  ! only need to transfer pool
+     !  if (dimItr % memberType == MPAS_POOL_FIELD) then
+     !    numFields = numFields + 1
+     !  end if
+     !end do
+     !! assume, for now, that this will be constant accross processors.  If not, it would need to be sent to other
+     !! processors too.  This also presumes that properties will be fixed accross the processesors.
+     !}}}
+
+     ! on each list, transmit relevant fields to associated processors (note using the var struct since it has the names
+     ! required and this information is on each processor, even if the pool's fields are empty their names and types
+     ! are there from the registry).
+     call mpas_pool_get_subpool(domain % blocklist % structs, 'lagrPartTrackNonHalo', lagrPartTrackPool)
+     call mpas_pool_begin_iteration(lagrPartTrackPool)
+     do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+       if (dimItr % memberType == MPAS_POOL_FIELD) then
+         !write(stderrUnit,*) 'transfering ', trim(dimItr % memberName)
+         if (dimItr % dataType == MPAS_POOL_REAL) then
+           ! recv
+           j = 1
+           do i=1,numProcs
+             if(nPartRecv(i) > 0) then
+               allocate(array1DRealRecv(i)%val(nPartRecv(i)))
+              !write(stderrUnit,*) 'receiving real ', trim(dimItr % memberName), ' from ', procNeighs(i)
+               ! receive communicated data
+#ifdef _MPI
+               call MPI_IRecv(array1DRealRecv(i)%val, nPartRecv(i), MPI_REALKIND, procNeighs(i), procNeighs(i), &
+                 domain % dminfo % comm, recvRequestID(j), mpi_ierr)
+#endif
+               j = j + 1
+             end if
+           end do
+           ! send
+           j = 1
+           do i=1,numProcs
+             if (nPartSend(i) > 0) then
+               allocate(array1DRealSend(i)%val(nPartSend(i)))
+               !write(stderrUnit,*) 'sending real ', trim(dimItr % memberName), ' to ', procNeighs(i)
+               call get_nonhalo_data_from_particle_list_array(listSend(i)%list, dimItr % memberName, &
+                 array1DRealSend(i)%val)
+#ifdef _MPI
+               call MPI_ISend(array1DRealSend(i)%val, nPartSend(i), MPI_REALKIND, procNeighs(i), &
+                 domain % dminfo % my_proc_id, domain % dminfo % comm, sendRequestID(j), mpi_ierr)
+#endif
+               j = j + 1
+             end if
+           end do
+
+#ifdef _MPI
+          call MPI_WaitAll(numRecv, recvRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'recv: mpi_ierr = ', mpi_ierr
+#ifdef _MPI
+          call MPI_WaitAll(numSends, sendRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'send: mpi_ierr = ', mpi_ierr
+
+          ! store values
+          j = 1
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              ! place it in particle list
+              call add_nonhalo_data_to_particle_list_array(listRecv(i)%list, dimItr % memberName, &
+                array1DRealRecv(i)%val)
+              j = j + 1
+            end if
+          end do
+
+           do i=1,numProcs
+             if(nPartSend(i) > 0) deallocate(array1DRealSend(i)%val)
+           end do
+           do i=1,numProcs
+             if(nPartRecv(i) > 0) deallocate(array1DRealRecv(i)%val)
+           end do
+          !write(stderrUnit,*) 'finished'
+
+        elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+          ! recv
+          j = 1
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              allocate(array1DIntRecv(i)%val(nPartRecv(i)))
+              ! receive communicated data
+              !write(stderrUnit,*) 'receiving int ', trim(dimItr % memberName), ' from ', procNeighs(i)
+#ifdef _MPI
+              call MPI_IRecv(array1DIntRecv(i)%val, nPartRecv(i), MPI_INTEGERKIND, procNeighs(i), procNeighs(i), &
+                domain % dminfo % comm, recvRequestID(j), mpi_ierr)
+#endif
+              !if( trim(dimItr % memberName) == 'currentBlock') write(stderrUnit,*) 'currentBlock received ',nPartRecv(i), ' from', procNeighs(i), ' = ', array1DIntRecv(i)%val
+              j = j + 1
+            end if
+          end do
+          ! send
+          j = 1
+          do i=1,numProcs
+            if(nPartSend(i) > 0) then
+              allocate(array1DIntSend(i)%val(nPartSend(i)))
+              !write(stderrUnit,*) 'sending int ', trim(dimItr % memberName), ' to ', procNeighs(i)
+              call get_nonhalo_data_from_particle_list_array(listSend(i)%list, dimItr % memberName, array1DIntSend(i)%val)
+              !if( trim(dimItr % memberName) == 'currentBlock') write(stderrUnit,*) 'currentBlock sent ',nPartSend(i), ' to ', procNeighs(i), ' = ', array1DIntSend(i)%val
+#ifdef _MPI
+              call MPI_ISend(array1DIntSend(i)%val, nPartSend(i), MPI_INTEGERKIND, procNeighs(i), &
+                domain % dminfo % my_proc_id, domain % dminfo % comm, sendRequestID(j), mpi_ierr)
+#endif
+              j = j + 1
+            end if
+          end do
+
+#ifdef _MPI
+          call MPI_WaitAll(numRecv, recvRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'mpi_ierr = ', mpi_ierr
+#ifdef _MPI
+          call MPI_WaitAll(numSends, sendRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'mpi_ierr = ', mpi_ierr
+
+          !do i=1,numProcs
+          !  if(nPartRecv(i) > 0) write(stderrUnit,*) 'Received ', trim(dimItr % memberName), ' = ', array1DIntRecv(i) % val
+          !end do
+
+          ! store values
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              ! place it in particle list
+              call add_nonhalo_data_to_particle_list_array(listRecv(i)%list, dimItr % memberName, array1DIntRecv(i)%val)
+              j = j + 1
+            end if
+          end do
+
+          do i=1,numProcs
+            if(nPartSend(i) > 0) deallocate(array1DIntSend(i)%val)
+          end do
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) deallocate(array1DIntRecv(i)%val)
+          end do
+          !write(stderrUnit,*) 'finished'
+        else
+           !write(stderrunit,*) "Different field type than implemented during nonHalo communication!"
+         end if
+       elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+         ! ignore dimensions for now and have this code so they aren't printed as an error message
+       else
+         !write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in nonHalo data for communication, don't know what to do!"
+       end if
+     end do
+
+     deallocate(array1DIntSend, array1DIntRecv, array1DRealSend, array1DRealRecv, recvRequestID, sendRequestID)
+     !write(stderrunit,*) 'Finished primary MPI communication for nonhalo'
+
+   end subroutine communicate_particle_nonhalo_data!}}}
+
+!***********************************************************************
+!
+!  routine communicate_particle_halo_data
+!
+!> \brief   Communicate particle halo data to relevant processors
+!>          based on particlelists
+!> \author  Phillip Wolfram
+!> \date    07/01/2014
+!> \details
+!>  This routine transmitts haloData from particlelists
+!
+!-----------------------------------------------------------------------
+   subroutine communicate_particle_halo_data(domain, procNeighs, nPartSend, nPartRecv, listSend, listRecv) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     integer, dimension(:), pointer, intent(in) :: procNeighs
+     integer, dimension(:), pointer, intent(in) :: nPartSend
+     integer, dimension(:), pointer, intent(out) :: nPartRecv
+     type (mpas_list_of_particle_list_type), dimension(:), pointer :: listSend, listRecv
+
+     integer :: i, j, numProcs, numFields, numRecv, numSends
+     integer, dimension(:), pointer :: recvRequestID, sendRequestID
+     integer :: mpi_ierr
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     type (mpas_pool_iterator_type) :: dimItr
+     type array1DReal_list
+       real (kind=RKIND), dimension(:), pointer :: val
+     end type
+     type array1DInt_list
+       integer, dimension(:), pointer :: val
+     end type
+     type (array1DInt_list), dimension(:), pointer :: array1DIntSend, array1DIntRecv
+     type (array1DReal_list), dimension(:), pointer :: array1DRealSend, array1DRealRecv
+
+     ! for each entry in the halo pool, want to send and recv the data
+
+#ifdef _MPI
+     !call MPI_Barrier(domain % dminfo % comm)
+#endif
+
+     numProcs = size(procNeighs)
+     allocate(array1DRealSend(numProcs), array1DRealRecv(numProcs))
+     allocate(array1DIntSend(numProcs),  array1DIntRecv(numProcs))
+
+     numSends = 0
+     do i = 1, numProcs
+       if (nPartSend(i) > 0) numSends = numSends + 1
+     end do
+     allocate(sendRequestID(numSends))
+
+     numRecv = 0
+     do i = 1, numProcs
+       if (nPartRecv(i) > 0) numRecv = numRecv + 1
+     end do
+     allocate(recvRequestID(numRecv))
+
+     !Notes !{{{
+     !! get number of items that need transfered from halo pool, numFields which is a constant
+     !call mpas_pool_get_subpool(domain % blocklist % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+     !call mpas_pool_begin_iteration(lagrPartTrackPool)
+     !numFields = 0
+     !do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+     !  ! only need to transfer pool
+     !  if (dimItr % memberType == MPAS_POOL_FIELD) then
+     !    numFields = numFields + 1
+     !  end if
+     !end do
+     !! assume, for now, that this will be constant accross processors.  If not, it would need to be sent to other
+     !! processors too.  This also presumes that properties will be fixed accross the processesors.
+     !}}}
+
+     ! on each list, transmit relevant fields to associated processors (note using the var struct since it has the names
+     ! required and this information is on each processor, even if the pool's fields are empty their names and types
+     ! are there from the registry).
+     call mpas_pool_get_subpool(domain % blocklist % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+     call mpas_pool_begin_iteration(lagrPartTrackPool)
+     do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+       if (dimItr % memberType == MPAS_POOL_FIELD) then
+         !write(stderrUnit,*) 'transfering ', trim(dimItr % memberName)
+         if (dimItr % dataType == MPAS_POOL_REAL) then
+           ! recv
+           j = 1
+           do i=1,numProcs
+             if(nPartRecv(i) > 0) then
+               allocate(array1DRealRecv(i)%val(nPartRecv(i)))
+              !write(stderrUnit,*) 'receiving real ', trim(dimItr % memberName), ' from ', procNeighs(i)
+               ! receive communicated data
+#ifdef _MPI
+               call MPI_IRecv(array1DRealRecv(i)%val, nPartRecv(i), MPI_REALKIND, procNeighs(i), procNeighs(i), &
+                 domain % dminfo % comm, recvRequestID(j), mpi_ierr)
+#endif
+               j = j + 1
+             end if
+           end do
+           ! send
+           j = 1
+           do i=1,numProcs
+             if (nPartSend(i) > 0) then
+               allocate(array1DRealSend(i)%val(nPartSend(i)))
+               !write(stderrUnit,*) 'sending real ', trim(dimItr % memberName), ' to ', procNeighs(i)
+               call get_halo_data_from_particle_list_array(listSend(i)%list, dimItr % memberName, &
+                 array1DRealSend(i)%val)
+#ifdef _MPI
+               call MPI_ISend(array1DRealSend(i)%val, nPartSend(i), MPI_REALKIND, procNeighs(i), &
+                 domain % dminfo % my_proc_id, domain % dminfo % comm, sendRequestID(j), mpi_ierr)
+#endif
+               j = j + 1
+             end if
+           end do
+
+#ifdef _MPI
+          call MPI_WaitAll(numRecv, recvRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'recv: mpi_ierr = ', mpi_ierr
+#ifdef _MPI
+          call MPI_WaitAll(numSends, sendRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'send: mpi_ierr = ', mpi_ierr
+
+          ! store values
+          j = 1
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              ! place it in particle list
+              call add_halo_data_to_particle_list_array(listRecv(i)%list, dimItr % memberName, &
+                array1DRealRecv(i)%val)
+              j = j + 1
+            end if
+          end do
+
+           do i=1,numProcs
+             if(nPartSend(i) > 0) deallocate(array1DRealSend(i)%val)
+           end do
+           do i=1,numProcs
+             if(nPartRecv(i) > 0) deallocate(array1DRealRecv(i)%val)
+           end do
+          !write(stderrUnit,*) 'finished'
+
+        elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+          ! recv
+          j = 1
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              allocate(array1DIntRecv(i)%val(nPartRecv(i)))
+              ! receive communicated data
+              !write(stderrUnit,*) 'receiving int ', trim(dimItr % memberName), ' from ', procNeighs(i)
+#ifdef _MPI
+              call MPI_IRecv(array1DIntRecv(i)%val, nPartRecv(i), MPI_INTEGERKIND, procNeighs(i), procNeighs(i), &
+                domain % dminfo % comm, recvRequestID(j), mpi_ierr)
+#endif
+              !if( trim(dimItr % memberName) == 'currentBlock') write(stderrUnit,*) 'currentBlock received ',nPartRecv(i), ' from', procNeighs(i), ' = ', array1DIntRecv(i)%val
+              j = j + 1
+            end if
+          end do
+          ! send
+          j = 1
+          do i=1,numProcs
+            if(nPartSend(i) > 0) then
+              allocate(array1DIntSend(i)%val(nPartSend(i)))
+              !write(stderrUnit,*) 'sending int ', trim(dimItr % memberName), ' to ', procNeighs(i)
+              call get_halo_data_from_particle_list_array(listSend(i)%list, dimItr % memberName, array1DIntSend(i)%val)
+              !if( trim(dimItr % memberName) == 'currentBlock') write(stderrUnit,*) 'currentBlock sent ',nPartSend(i), ' to ', procNeighs(i), ' = ', array1DIntSend(i)%val
+#ifdef _MPI
+              call MPI_ISend(array1DIntSend(i)%val, nPartSend(i), MPI_INTEGERKIND, procNeighs(i), &
+                domain % dminfo % my_proc_id, domain % dminfo % comm, sendRequestID(j), mpi_ierr)
+#endif
+              j = j + 1
+            end if
+          end do
+
+#ifdef _MPI
+          call MPI_WaitAll(numRecv, recvRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'mpi_ierr = ', mpi_ierr
+#ifdef _MPI
+          call MPI_WaitAll(numSends, sendRequestID, MPI_STATUSES_IGNORE, mpi_ierr)
+#endif
+          if (mpi_ierr /= 0) write(stderrUnit,*) 'mpi_ierr = ', mpi_ierr
+
+          !do i=1,numProcs
+          !  if(nPartRecv(i) > 0) write(stderrUnit,*) 'Received ', trim(dimItr % memberName), ' = ', array1DIntRecv(i) % val
+          !end do
+
+          ! store values
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) then
+              ! place it in particle list
+              call add_halo_data_to_particle_list_array(listRecv(i)%list, dimItr % memberName, array1DIntRecv(i)%val)
+              j = j + 1
+            end if
+          end do
+
+          do i=1,numProcs
+            if(nPartSend(i) > 0) deallocate(array1DIntSend(i)%val)
+          end do
+          do i=1,numProcs
+            if(nPartRecv(i) > 0) deallocate(array1DIntRecv(i)%val)
+          end do
+          !write(stderrUnit,*) 'finished'
+        else
+           !write(stderrunit,*) "Different field type than implemented during halo communication!"
+         end if
+       elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+         ! ignore dimensions for now and have this code so they aren't printed as an error message
+       else
+         !write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in halo data for communication, don't know what to do!"
+       end if
+     end do
+
+     deallocate(array1DIntSend, array1DIntRecv, array1DRealSend, array1DRealRecv, recvRequestID, sendRequestID)
+     !write(stderrunit,*) 'Finished primary MPI communication for halo'
+
+   end subroutine communicate_particle_halo_data!}}}
+
+!***********************************************************************
+!
+!  routine allocate_nonHalo_data
+!
+!> \brief   Allocate space for nonHalo data for diagnostic output
+!>          on particlelists
+!> \author  Phillip Wolfram
+!> \date    07/01/2014
+!> \details
+!>  This routine allocates space for nonHaloData on the particlelist
+!
+!-----------------------------------------------------------------------
+   subroutine allocate_nonHalo_data(domain, particlelist) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     type (mpas_particle_list_type), pointer, intent(in) :: particlelist
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     type (mpas_pool_iterator_type) :: dimItr
+
+     integer :: i, nPart
+     real (kind=RKIND), dimension(:), pointer :: array1DRealPointer
+     integer, dimension(:), pointer :: array1DIntPointer
+
+
+     ! get number of particle on list
+     nPart = count_particlelist(particlelist)
+
+     ! allocate zero arrays
+     allocate(array1DRealPointer(nPart))
+     allocate(array1DIntPointer(nPart))
+     array1DRealPointer = 0.0_RKIND
+     array1DIntPointer = 0
+
+     ! on each list, transmit relevant fields to associated processors
+     call mpas_pool_get_subpool(domain % blocklist % structs, 'lagrPartTrackNonHalo', lagrPartTrackPool)
+     call mpas_pool_begin_iteration(lagrPartTrackPool)
+     do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+       if (dimItr % memberType == MPAS_POOL_FIELD) then
+         if (dimItr % dataType == MPAS_POOL_REAL) then
+             call add_nonhalo_data_to_particle_list_array(particlelist, dimItr % memberName, array1DRealPointer)
+         elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+             call add_nonhalo_data_to_particle_list_array(particlelist, dimItr % memberName, array1DIntPointer)
+         else
+           !write(stderrunit,*) "Different field type than implemented during halo communication!"
+         end if
+       elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+         ! ignore dimensions for now and have this code so they aren't printed as an error message
+       else
+         !write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in halo data for communication, don't know what to do!"
+       end if
+     end do
+
+     ! deallocate arrays
+     deallocate(array1DRealPointer)
+     deallocate(array1DIntPointer)
+
+   end subroutine allocate_nonHalo_data !}}}
+
+   subroutine allocate_list_nonHalo_data(domain, listPL) !{{{
+     implicit none
+
+     type (domain_type), intent(in) :: domain
+     type (mpas_list_of_particle_list_type), dimension(:), pointer, intent(inout) :: listPL
+
+     integer :: i, numList
+
+     numList = size(listPL)
+     do i=1, numList
+       call allocate_nonHalo_data(domain, listPL(i)%list)
+     end do
+
+   end subroutine allocate_list_nonHalo_data !}}}
+
+!***********************************************************************
+!
+!  routine build_block_particlelists
+!
+!> \brief   Allocates empty particlelist
+!> \author  Phillip Wolfram
+!> \date    04/15/2014
+!> \details
+!>  This routine allocates empty particlelist data structures
+!
+!-----------------------------------------------------------------------
+   subroutine build_block_particlelists(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_particle_list_type), pointer :: particlelist
+      integer, pointer :: nParticles
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! allocate pointers
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_dimension(meshPool, 'nParticles', nParticles)
+
+        ! allocate the memory in its location for use
+#ifdef MPAS_DEBUG
+        write(stderrUnit,*) 'in build_block_particlelists: nParticles = ', nParticles
+
+#endif
+        if (nParticles > 0) then
+          allocate(block % particlelist)
+          particlelist => block % particlelist
+
+          !-----------------------------------------------------------------
+          ! populate list of particles from input data structures
+          !-----------------------------------------------------------------
+
+          ! initialize the particlelist for population
+          call build_new_particlelist(nParticles, particlelist, block % blockID)
+        end if
+
+        block => block % next
+      end do
+
+   end subroutine build_block_particlelists!}}}
+
+   subroutine clear_block_particlelists(domain, err) !{{{
+     implicit none
+
+     !-----------------------------------------------------------------
+     ! input/output variables
+     !-----------------------------------------------------------------
+     type (domain_type), intent(in) :: domain
+
+     !-----------------------------------------------------------------
+     ! output variables
+     !-----------------------------------------------------------------
+     integer, intent(out) :: err !< Output: error flag
+
+     !-----------------------------------------------------------------
+     ! local variables
+     !-----------------------------------------------------------------
+     type (block_type), pointer :: block
+
+     err = 0
+
+     block => domain % blocklist
+     do while (associated(block))
+
+       call mpas_particle_list_destroy_particle_list(block % particlelist)
+
+       block => block % next
+     end do
+
+   end subroutine clear_block_particlelists !}}}
+
+!***********************************************************************
+!
+!  routine read_haloData
+!
+!> \brief   Reads haloData from netCDF-injected struct arrays
+!> \author  Phillip Wolfram
+!> \date    04/15/2014
+!> \details
+!>  This routine reads haloData input for this MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine read_haloData(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (mpas_pool_iterator_type) :: dimItr
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (field1DReal), pointer :: field1DRealPointer
+      !type (field2DReal), pointer :: field2DRealPointer
+      type (field1DInteger), pointer :: field1DIntPointer
+      integer, dimension(:), pointer :: array1DInt
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! allocate pointers
+        particlelist => block % particlelist
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+
+        ! iterate over each member of the pool and make the relevant assignment
+        call mpas_pool_begin_iteration(lagrPartTrackPool)
+        do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+          ! determine the type of data
+          if (dimItr % memberType == MPAS_POOL_FIELD) then
+            if (dimItr % dataType == MPAS_POOL_REAL) then
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DRealPointer)
+#ifdef MPAS_DEBUG
+              write(stderrunit,*) dimItr % memberName, ' = '
+              write(stderrunit,*) field1DRealPointer % array
+#endif
+              call add_halo_data_to_particle_list(particlelist, dimItr % memberName, field1DRealPointer)
+            elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DIntPointer)
+              ! assign ioBlock explicitly during initial read
+              if (dimItr % memberName == 'ioBlock') then
+#ifdef MPAS_DEBUG
+                write(stderrunit,*) 'ioBlock = ', field1DIntPointer % array
+#endif
+                field1DIntPointer % array = domain % dminfo % my_proc_id
+              end if
+              call add_halo_data_to_particle_list(particlelist, dimItr % memberName, field1DIntPointer)
+            else
+#ifdef MPAS_DEBUG
+              write(stderrunit,*) "Different field type than implemented during halo read!"
+#endif
+            end if
+          elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+            ! ignore dimensions for now and have this code so they aren't printed as an error message
+          else
+#ifdef MPAS_DEBUG
+            write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in halo data for read, don't know what to do!"
+            ! false warning for 
+            !Different type expected in registry for key on_a_sphere in nonHalo data for read, don't know what to do!
+            !Different type expected in registry for key sphere_radius in nonHalo data for read, don't know what to do!
+            !Different type expected in registry for key is_periodic in nonHalo data for read, don't know what to do!
+            !Different type expected in registry for key x_period in nonHalo data for read, don't know what to do!
+            !Different type expected in registry for key y_period in nonHalo data for read, don't know what to do!
+#endif
+          end if
+        end do
+
+         block => block % next
+      end do
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'Finished reading halo data'
+#endif
+
+   end subroutine read_haloData!}}}
+
+!***********************************************************************
+!
+!  routine read_nonhaloData
+!
+!> \brief   Reads nonhaloData from netCDF-injected struct arrays
+!> \author  Phillip Wolfram
+!> \date    04/15/2014
+!> \details
+!>  This routine reads nonhaloData input for this MPAS-Ocean analysis member.
+!
+!-----------------------------------------------------------------------
+   subroutine read_nonhaloData(domain, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(in) :: domain
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: lagrPartTrackPool
+      type (mpas_pool_iterator_type) :: dimItr
+      type (mpas_particle_list_type), pointer :: particlelist
+      type (field1DReal), pointer :: field1DRealPointer
+      type (field1DInteger), pointer :: field1DIntPointer
+
+      err = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+        ! allocate pointers
+        particlelist => block % particlelist
+        call mpas_pool_get_subpool(block % structs, 'lagrPartTrackNonHalo', lagrPartTrackPool)
+
+        ! iterate over each member of the pool and make the relevant assignment
+        call mpas_pool_begin_iteration(lagrPartTrackPool)
+        do while(mpas_pool_get_next_member(lagrPartTrackPool, dimItr))
+          ! determine the type of data
+          if (dimItr % memberType == MPAS_POOL_FIELD) then
+            if (dimItr % dataType == MPAS_POOL_REAL) then
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DRealPointer)
+              call add_nonhalo_data_to_particle_list(particlelist, dimItr % memberName, field1DRealPointer)
+            elseif (dimItr % dataType == MPAS_POOL_INTEGER) then
+              call mpas_pool_get_field(lagrPartTrackPool, dimItr % memberName, field1DIntPointer)
+              call add_nonhalo_data_to_particle_list(particlelist, dimItr % memberName, field1DIntPointer)
+            else
+#ifdef MPAS_DEBUG
+              write(stderrunit,*) "Different field type than implemented in nonHalo read!"
+#endif
+            end if
+          elseif (dimItr % memberType == MPAS_POOL_DIMENSION) then
+            ! ignore dimensions for now and have this code so they aren't printed as an error message
+          else
+#ifdef MPAS_DEBUG
+            write(stderrunit,*) "Different type expected in registry for key ", trim(dimItr % memberName), " in nonHalo data for read, don't know what to do!"
+#endif
+          end if
+        end do
+
+        ! alternatively, could initialize these fields or just make sure that they exist!
+
+         block => block % next
+      end do
+#ifdef MPAS_DEBUG
+      write(stderrUnit,*) 'Finished reading non-halo data'
+#endif
+
+   end subroutine read_nonhaloData!}}}
+
+!***********************************************************************
+!
+!  routine mpas_particle_list_update_computational_halos
+!
+!> \brief   Update halo
+!> \author  Phillip Wolfram
+!> \date    06/24/2015
+!> \details
+!>  This routine updates the halos for particles within the particlelist loop.
+!>  This constitutes a computational transfer of a particle from one domain
+!>  to another.  Its main goals are to
+!>        1. determine if iCell is on halo (just set each particle's
+!>           currentBlock to the correct currentBlock
+!>        2. determine owning block in halo, update particle's currentBlock
+!>        3. determine currentBlock ownership of iCell and set cellOwnerBlock
+!>           to be current block
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_particle_list_update_computational_halos(domain, block, particle, poolname, iCell, &
+       arrayIndex, ioProcRecvList, gioProcNeighs ) !{{{
+     implicit none
+     type (domain_type), intent(inout) :: domain
+     type (block_type), intent(inout), pointer :: block
+     type (mpas_particle_type), intent(inout), pointer :: particle
+     character(len=*), intent(in) :: poolname
+     integer, intent(inout) :: iCell, arrayIndex
+     integer, dimension(:), pointer, intent(inout) :: gioProcNeighs
+     logical, dimension(:,:), pointer, intent(inout) :: ioProcRecvList
+
+     ! local variables
+     integer :: currentProc, ioProc
+     type (mpas_pool_type), pointer :: lagrPartTrackCellsPool
+     integer, pointer :: currentBlock, ioBlock, transfered
+     integer, dimension(:), pointer :: cellOwnerBlock
+
+     call mpas_pool_get_subpool(block % structs, trim(poolname), lagrPartTrackCellsPool)
+     call mpas_pool_get_array(lagrPartTrackCellsPool, 'cellOwnerBlock', cellOwnerBlock)
+     call mpas_pool_get_array(particle % haloDataPool, 'currentBlock', currentBlock)
+     call mpas_pool_get_array(particle % haloDataPool, 'ioBlock', ioBlock)
+     if(cellOwnerBlock(iCell) /= currentBlock) then
+       ! increment transfer counter
+       call mpas_pool_get_array(particle % haloDataPool, 'transfered', transfered)
+       transfered = transfered + 1
+       ! set new current block
+       currentBlock = cellOwnerBlock(iCell)
+       ! reset cell_id to be brute force computed on new block after trasnfer
+       iCell = -1
+     end if
+     call mpas_get_owning_proc(domain % dminfo, currentBlock, currentProc)
+     call mpas_get_owning_proc(domain % dminfo, ioBlock, ioProc)
+
+     ! increment data for receiving processors (sum should be total number of particles on processor)
+#ifdef MPAS_DEBUG
+     write(stderrUnit,*) 'g_ioProcNeighs=',gioProcNeighs
+     write(stderrUnit,*) 'ioProc=',ioProc
+#endif
+     arrayIndex = find_index(gioProcNeighs, ioProc)
+     ioProcRecvList(arrayIndex, currentProc+1) = .True.
+     ! must be computed after computational particles are transferred (this was a bug left-over from serial IO)
+   end subroutine mpas_particle_list_update_computational_halos !}}}
+
+!}}}
+
+!-----------------------------------------------------------------------
+!
+! TESTING SUBROUTINES
+!
+!-----------------------------------------------------------------------
+!{{{
+   subroutine mpas_particle_list_test_neighscalc(domain, err) !{{{
+      implicit none
+
+      type (domain_type), intent(in) :: domain
+      integer, intent(out) :: err !< Output: error flag
+      type (block_type), pointer :: block
+
+      err = 0
+      block => domain % blocklist
+      do while (associated(block))
+
+        ! write out all blockNeighs and procNeighs
+        write(stderrUnit,*) 'blockID = ', block % blockID
+        write(stderrUnit,*) 'blockNeighs = ', block % blockNeighs
+        write(stderrUnit,*) 'procNeighs = ', block % procNeighs
+
+        block => block % next
+      end do
+
+   end subroutine mpas_particle_list_test_neighscalc !}}}
+
+   subroutine mpas_particle_list_test_numparticles_to_neighprocs(myproc, procNeighs, ioProcNeighs) !{{{
+     implicit none
+     integer, intent(in) :: myproc
+     integer, dimension(:), pointer, intent(in) :: procNeighs, ioProcNeighs
+
+     integer :: i, numNeighs
+
+     numNeighs = size(procNeighs)
+
+     write(stderrUnit,*) 'myproc, procNeighs'
+     do i=1,numNeighs
+       write(stderrUnit,*) myproc, procNeighs(i)
+     end do
+     if(associated(ioProcNeighs)) then
+       write(stderrUnit,*) 'myproc, ioProcNeighs'
+       numNeighs = size(ioProcNeighs)
+       do i=1,numNeighs
+         write(stderrUnit,*) myproc, ioProcNeighs(i)
+       end do
+     end if
+
+   end subroutine mpas_particle_list_test_numparticles_to_neighprocs !}}}
+
+   subroutine mpas_particle_list_test_num_current_particlelist(domain) !{{{
+     implicit none
+     type (domain_type), intent(in) :: domain
+     type (block_type), pointer :: block
+     integer :: nPartList, nPartList_particles
+
+     block => domain % blocklist
+     do while(associated(block))
+       ! THIS LINE CAUSED A VERY, VERY, VERY NASTY BUG-- BE CAREFUL ABOUT GETTING THE LOCATION OF POTENTIALLY NULLS!
+       nPartList = count_particlelist(block % particlelist)
+       nPartList_particles = count_particlelist_particles(block % particlelist)
+       write(stderrUnit,*) 'block = ', block % blockID, ' nPartList= ',  nPartList, ' nparticles = ', nPartList_particles
+       if (nPartList > nPartList_particles) then
+         write(stderrUnit,*) 'Possible error! ', nPartList - nPartList_particles, ' particles on particle list is not allocated!'
+       end if
+
+       block => block % next
+     end do
+
+   end subroutine mpas_particle_list_test_num_current_particlelist!}}}
+
+   subroutine test_currentBlock(domain) !{{{
+     implicit none
+     type (domain_type), intent(in) :: domain
+     type (block_type), pointer :: block
+     type (mpas_pool_type), pointer :: lagrPartTrackPool
+     integer, dimension(:), pointer :: field1DInt
+     integer :: currentBlock, countOnProc, i
+     countOnProc = 0
+     block => domain % blocklist
+     do while(associated(block))
+       call mpas_pool_get_subpool(block % structs, 'lagrPartTrackHalo', lagrPartTrackPool)
+       call mpas_pool_get_array(lagrPartTrackPool, 'currentBlock', field1DInt)
+       do i=1,size(field1DInt(:))
+         if (field1DInt(i) == block % blockID) countOnProc = countOnProc + 1
+       end do
+
+       block => block % next
+     end do
+     write(stderrUnit,*) 'number of particles on processor = ', countOnProc
+
+   end subroutine test_currentBlock !}}}
+
+   subroutine test_num_particles_on_particlelist(listPL, nlist) !{{{
+     implicit none
+     integer, intent(in) :: nlist
+     type (mpas_list_of_particle_list_type), dimension(:), pointer, intent(in) :: listPL
+
+     integer :: i, sumtot, listparticles
+
+     sumtot = 0
+     do i = 1, nlist
+       listparticles = count_particlelist(listPL(i)%list)
+       write(stderrUnit,*) 'list i=',i,' nparticles=', listparticles
+       sumtot = sumtot + listparticles
+     end do
+     write(stderrunit,*) 'total_on_list=', sumtot
+   end subroutine test_num_particles_on_particlelist !}}}
+!}}}
+
+
+end module ocn_particle_list
+! vim: foldmethod=marker


### PR DESCRIPTION
PRIVATE

Preliminary commit of LIGHT to MPAS-O as an analysis member with the understanding that code refactoring is necessary prior to the commit to ocean/develop.  This pull request is only meant to be fulfilled on ocean/private for now.  The hope is that the commit below should be complete to review the pull request but I am obviously grateful for any/all feedback, especially as I begin to plan the refactoring process for the November pull request.  Log commit follows.

Development and application to the SOMA eddying double-gyre basin published in

  P.J. Wolfram, T.D. Ringler, M.E. Maltrud, D.W. Jacobsen, and M.R.
  Petersen. Diagnosing isopycnal diffusivity in an eddying, idealized
  mid-latitude ocean basin via Lagrangian In-situ, Global,
  High-performance particle Tracking (LIGHT), Journal of Physical
  Oceanography, accepted, 2015.

Preliminary design documents can be found at

  https://github.com/pwolfram/MPAS-Scratch/tree/oceanLPTs/oceanLPTs/documents/design

LIGHT is meant to be validated via testing with
1. tests/LIGHT_feature_test_radial solid-body rotation test case
2. tests/LIGHT_feature_test_restart bit-reproducible restart
   demonstration for particles that are transferred across
   multiple compute processors

Tests can be _temporarily_ found at

https://drive.google.com/folderview?id=0B4eu3cL_hvkFSDJUV0pGdUpqaDA&usp=sharing

This commit should be equivalent to a series of commits terminating in 99f6ce4
on branch https://github.com/pwolfram/MPAS/tree/LIGHT_feature_pull_request
