### PR TITLE
Fix JM EOS to use zMid; fix potentialDensity to be referenced to z=0

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -501,8 +501,8 @@ contains
 
       end do
 
-      ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, 1, 'absolute', potentialDensity, err, timeLevelIn=timeLevel)
+      ! compute potentialDensity, the density displaced adiabatically to sea level.
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, 0, 'absolute', potentialDensity, err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.  
       ! That is, layer k has been displaced to the depth of layer k+1.

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -81,7 +81,10 @@ contains
    !        s - state: tracers
    !        k_displaced 
    !
-   !  If k_displaced==0, density is returned with no displacement 
+   !  If k_displaced==0 and displacement_type=='relative', density is returned with no displacement 
+   !
+   !  If k_displaced==0 and displacement_type=='absolute', density is returned and is for
+   !  a parcel adiabatically displaced from its original level to sea level (z=0)
    !
    !  If k_displaced~=0, density is returned, and is for
    !  a parcel adiabatically displaced from its original level to level 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -133,8 +133,6 @@ contains
          DRHODS,            &! derivative of density with respect to salinity
          tmin, tmax,        &! valid temperature range for level k
          smin, smax          ! valid salinity    range for level k
-      real (kind=RKIND), dimension(:), allocatable :: &
-         pRefEOS ! temporary pressure scalar
       real (kind=RKIND), dimension(:,:), allocatable :: &
          p, p2,    &! temporary pressure scalars
          TQ,SQ,             &! adjusted T,S
@@ -214,7 +212,7 @@ contains
          bup2s1t1 =  6.128773e-8,       &
          bup2s1t2 =  6.207323e-10
    
-      integer :: k_test, k_ref
+      integer :: k_ref
    
       err = 0
    
@@ -257,28 +255,22 @@ contains
 !  average temperatures and salinities from Levitus 1994, and 
 !  integrating using hydrostatic balance.
 
-      allocate(pRefEOS(nVertLevels),p(nVertLevels,nCells),p2(nVertLevels,nCells))
+      allocate(p(nVertLevels,nCells),p2(nVertLevels,nCells))
 
       allocate(TQ(nVertLevels,nCells),SQ(nVertLevels,nCells),BULK_MOD(nVertLevels,nCells),SQR(nVertLevels,nCells),DENOMK(nVertLevels,nCells), RHO_S(nVertLevels,nCells), &
          WORK1(nVertLevels,nCells), WORK2(nVertLevels,nCells), WORK3(nVertLevels,nCells), WORK4(nVertLevels,nCells), T2(nVertLevels,nCells))
 
 
       if (displacement_type_local == 'absolute' .and.   &
-         (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+         (k_displaced_local < 0 .or. k_displaced_local > nVertLevels) ) then
 
          write (stderrUnit,*) 'Abort: In equation_of_state_jm', &
-             ' k_displaced must be between 1 and nVertLevels for ', &
+             ' k_displaced must be between 0 and nVertLevels for ', &
              'displacement_type = absolute'
          call mpas_dmpar_abort(dminfo)
       endif
 
       do iCell=1,nCells
-        do k = 1,nVertLevels
-           depth = abs(zMid(k,iCell))
-           pRefEOS(k) = 0.059808*(exp(-0.025*depth) - 1.0) &
-               + 0.100766*depth + 2.28405e-7*depth**2
-        enddo
-
         !  If k_displaced=0, in-situ density is returned (no displacement)
         !  If k_displaced/=0, potential density is returned
   
@@ -288,24 +280,25 @@ contains
         !     referenced to level k_displaced for all k
         !  NOTE: k_displaced = 0 or > nVertLevels is incompatible with 'absolute'
         !     so abort if necessary
-        if (k_displaced_local == 0) then
-           do k=1,nVertLevels
-              p(k,iCell)   = pRefEOS(k)
-              p2(k,iCell)  = p(k,iCell)*p(k,iCell)
-           enddo
-        else ! k_displaced_local /= 0
-           do k=1,nVertLevels
-              if (displacement_type_local == 'relative') then
-                 k_test = min(k + k_displaced_local, nVertLevels)
-                 k_ref  = max(k_test, 1)
-              else
-                 k_test = min(k_displaced_local, nVertLevels)
-                 k_ref  = max(k_test, 1)
-              endif
-              p(k,iCell)   = pRefEOS(k_ref)
-              p2(k,iCell)  = p(k,iCell)*p(k,iCell)
-           enddo
-        endif
+        do k=1,nVertLevels
+          if (k_displaced_local == 0) then
+            if (displacement_type_local == 'relative') then
+              depth = abs(zMid(k,iCell))
+            else
+              depth = 0.0
+            endif
+          else ! k_displaced_local /= 0
+            if (displacement_type_local == 'relative') then
+              k_ref = max(min(k + k_displaced_local, nVertLevels),1)
+            else
+              k_ref = max(min(k_displaced_local, nVertLevels),1)
+            endif
+            depth = abs(zMid(k_ref,iCell))
+          endif
+          p(k,iCell) = 0.059808*(exp(-0.025*depth) - 1.0) &
+             + 0.100766*depth + 2.28405e-7*depth**2
+          p2(k,iCell)  = p(k,iCell)*p(k,iCell)
+        enddo
       enddo
   
       do iCell=1,nCells
@@ -396,7 +389,7 @@ contains
          end do
       endif
 
-      deallocate(pRefEOS,p,p2)
+      deallocate(p,p2)
       deallocate(tracerTS)
       deallocate(TQ,SQ,T2,BULK_MOD,SQR,DENOMK,RHO_S, WORK1, WORK2, WORK3, WORK4)
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -132,9 +132,9 @@ contains
 
       ! test of request to address out of bounds
       if (displacement_type_local == 'absolute' .and.   &
-         (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+         (k_displaced_local < 0 .or. k_displaced_local > nVertLevels) ) then
          write (stderrUnit,*) 'Abort: In equation_of_state_jm', &
-             ' k_displaced must be between 1 and nVertLevels for ', &
+             ' k_displaced must be between 0 and nVertLevels for ', &
              'displacement_type = absolute'
          call mpas_dmpar_abort(dminfo)
       endif


### PR DESCRIPTION
This pull request fixes two problems with the equation of state.

**1. Use zMid to compute pressure in JM EOS instead of refBottomDepth.**
Details: The Jackett and McDougall (JM) equaiton of state (EOS) uses refBottomDepth to compute pressure as a function of depth.  This is appropriate only for a z-level vertical coordinate, and only if layer thicknesses do not deviate significantly from their reference values.  Use of zMid instead of refBottomDepth will make the JM EOS more accurate for other vertical coordinates.

**2. Compute potential density referenced to z=0 instead of zMid(iCell,1).**
Details:  Potential density should be referenced to z=0, regardless of the vertical coordinate.  In case where the sea-surface height (SSH) is significantly different from zero, as in when it is depressed by an ice shelf, very large errors in potential density result from the large distance between the center of the top cell (where potential density is currently referenced to) and the surface.

**This is a non-bit-for-bit change.**  Configurations that use either the JM EOS will be affected.  It appears that the only other configurations that will be affected are those using config_pressure_gradient_type = 'MontgomeryPotential_and_density' (which makes use of potential density).  Potential density seems to serve purely as a diagnostic in all other parts of the code.
