### PR TITLE
Removing a redundant include from mpas_dmpar

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -5936,11 +5936,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
 !-----------------------------------------------------------------------
    subroutine mpas_dmpar_global_abort(mesg)!{{{
 
-      use mpas_io_units
-
       implicit none
-
-      include 'mpif.h'
 
       character (len=*), intent(in) :: mesg !< Input: Abort message
 


### PR DESCRIPTION
Previously, mpas_dmpar had a redundant include of mpif.h. This was left
over when mpas_dmpar_global_abort was moved from an external subroutine
to inside mpas_dmpar.

This merge removes the redundant lines, which cause build errors on
some compilers.
