### PR TITLE
Fix FO floating ice mask in cpp interface

### DIFF
--- a/src/core_landice/Interface_velocity_solver.cpp
+++ b/src/core_landice/Interface_velocity_solver.cpp
@@ -630,6 +630,7 @@ void velocity_solver_compute_2d_grid(int const* verticesMask_F, int const* _diri
 
   nEdges = edgeToFEdge.size();
   indexToEdgeID.resize(nEdges);
+  floatingEdgesIds.clear();
   floatingEdgesIds.reserve(nEdges);
   for (int index = 0; index < nEdges; index++) {
     int fEdge = edgeToFEdge[index];
@@ -697,6 +698,7 @@ void velocity_solver_compute_2d_grid(int const* verticesMask_F, int const* _diri
       << std::endl;
 
   indexToVertexID.resize(nVertices);
+  dirichletNodesIDs.clear();
   dirichletNodesIDs.reserve(nVertices); //need to improve storage efficiency
   for (int index = 0; index < nVertices; index++) {
     int fCell = vertexToFCell[index];


### PR DESCRIPTION
The floating edges were not being cleared before each solve, so on
subsequent time steps the list of floating edges was being appended to
the current list, causing an error.  This fixes that, as well as the
same issue for dirichlet nodes.
