### PR TITLE
Remove instances of uninitialized pointers

### DIFF
--- a/src/framework/mpas_decomp.F
+++ b/src/framework/mpas_decomp.F
@@ -46,7 +46,6 @@ module mpas_decomp
 !-----------------------------------------------------------------------
    subroutine mpas_decomp_create_decomp_list(decompList)!{{{
       type (mpas_decomp_list), pointer :: decompList
-      procedure (mpas_decomp_function), pointer :: decompFunc
 
       integer :: errLocal
 

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -5,7 +5,7 @@
 
       type (MPAS_Clock_type), pointer :: clock
       type (MPAS_streamManager_type), pointer :: streamManager
-      type (mpas_decomp_list), pointer :: decompositions
+      type (mpas_decomp_list), pointer :: decompositions => null()
 
       ! Also store parallelization info here
       type (dm_info), pointer :: dminfo

--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -32,9 +32,10 @@
         include 'f90papi.h'
 #endif
 
-        type (timer_node), pointer :: all_timers
+        type (timer_node), pointer :: all_timers => null()
         integer :: levels, synced
 
+        ! DWJ 06/12/2015 -- Needs to be removed for multiple domains
         type (dm_info), pointer :: domain_info
 
         public :: mpas_timer_start, &


### PR DESCRIPTION
This merge fixes some uninitialized pointers within the MPAS framework. Previously, they were not initialized when they were defined, and an `if associated` test was used. However, `if associated` only works if a pointer is initialized (since pointers default to undefined).
