### PR TITLE
Update mpas_dmpar to be private by default

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -12,6 +12,7 @@ module init_atm_cases
    use mpas_pool_routines
    use mpas_constants
    use mpas_dmpar
+   use mpas_sort
    use atm_advection
    use mpas_atmphys_initialize_real
    use mpas_RBF_interpolation

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -22,6 +22,8 @@ module mpas_dmpar
    use mpas_hash
    use mpas_io_units
 
+   private
+
 #ifdef _MPI
 include 'mpif.h'
    integer, parameter :: MPI_INTEGERKIND = MPI_INTEGER
@@ -36,8 +38,47 @@ include 'mpif.h'
 #endif
 #endif
 
-   integer, parameter :: IO_NODE = 0
-   integer, parameter :: BUFSIZE = 6000
+   integer, parameter, public :: IO_NODE = 0
+   integer, parameter, public :: BUFSIZE = 6000
+
+   public :: mpas_dmpar_init
+   public :: mpas_dmpar_finalize
+   public :: mpas_dmpar_abort
+   public :: mpas_dmpar_bcast_int
+   public :: mpas_dmpar_bcast_ints
+   public :: mpas_dmpar_bcast_real
+   public :: mpas_dmpar_bcast_reals
+   public :: mpas_dmpar_bcast_double
+   public :: mpas_dmpar_bcast_doubles
+   public :: mpas_dmpar_bcast_logical
+   public :: mpas_dmpar_bcast_char
+   public :: mpas_dmpar_sum_int
+   public :: mpas_dmpar_sum_real
+   public :: mpas_dmpar_min_int
+   public :: mpas_dmpar_min_real
+   public :: mpas_dmpar_max_int
+   public :: mpas_dmpar_max_real
+   public :: mpas_dmpar_minloc_int
+   public :: mpas_dmpar_minloc_real
+   public :: mpas_dmpar_maxloc_int
+   public :: mpas_dmpar_maxloc_real
+   public :: mpas_dmpar_sum_int_array
+   public :: mpas_dmpar_min_int_array
+   public :: mpas_dmpar_max_int_array
+   public :: mpas_dmpar_sum_real_array
+   public :: mpas_dmpar_min_real_array
+   public :: mpas_dmpar_max_real_array
+   public :: mpas_dmpar_scatter_ints
+   public :: mpas_dmpar_get_index_range
+   public :: mpas_dmpar_compute_index_range
+   public :: mpas_dmpar_get_exch_list
+   public :: mpas_dmpar_build_comm_lists
+   public :: mpas_dmpar_init_multihalo_exchange_list
+   public :: mpas_dmpar_destroy_mulithalo_exchange_list
+   public :: mpas_dmpar_destroy_communication_list
+   public :: mpas_dmpar_destroy_exchange_list
+   public :: mpas_dmpar_global_abort
+   public :: mpas_dmpar_get_time
 
    interface mpas_dmpar_alltoall_field
       module procedure mpas_dmpar_alltoall_field1d_integer
@@ -48,6 +89,8 @@ include 'mpif.h'
       module procedure mpas_dmpar_alltoall_field4d_real
       module procedure mpas_dmpar_alltoall_field5d_real
    end interface
+
+   public :: mpas_dmpar_alltoall_field
 
    private :: mpas_dmpar_alltoall_field1d_integer
    private :: mpas_dmpar_alltoall_field2d_integer
@@ -69,6 +112,8 @@ include 'mpif.h'
       module procedure mpas_dmpar_exch_halo_field5d_real
    end interface
 
+   public :: mpas_dmpar_exch_halo_field
+
    private :: mpas_dmpar_exch_halo_field1d_integer
    private :: mpas_dmpar_exch_halo_field2d_integer
    private :: mpas_dmpar_exch_halo_field3d_integer
@@ -88,6 +133,8 @@ include 'mpif.h'
       module procedure mpas_dmpar_copy_field4d_real
       module procedure mpas_dmpar_copy_field5d_real
    end interface
+
+   public :: mpas_dmpar_copy_field
 
    private :: mpas_dmpar_copy_field1d_integer
    private :: mpas_dmpar_copy_field2d_integer

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -13,6 +13,7 @@ module mpas_stream_manager
     use mpas_io_units
     use mpas_io_streams
     use mpas_stream_list
+    use mpas_sort
 
 
     public :: MPAS_stream_mgr_init, &


### PR DESCRIPTION
This merge migrates the mpas_dmpar module to be private by default
instead of public. In addition it defines the public interface for the
mpas_dmpar module.

Two places made use of the mpas_sort module's subroutines which are no
longer publicly available through mpas_dmpar after this change. Fixes to
those are included as well.
