### PR TITLE
Fixing duplicate_field to check isActive

### DIFF
--- a/src/framework/duplicate_field_array.inc
+++ b/src/framework/duplicate_field_array.inc
@@ -50,7 +50,9 @@
             dst_cursor % copyList => src_cursor % copyList
             call mpas_allocate_mold(dst_cursor % array, src_cursor % array)   ! Until we get F2008 support for ALLOCATE(A,MOLD=B)
          end if
-         dst_cursor % array = src_cursor % array
+         if ( dst_cursor % isActive .and. src_cursor % isActive ) then
+            dst_cursor % array = src_cursor % array
+         end if
 
 !        src_cursor => src_cursor % next
 !        if (.not. local_copy_only) then

--- a/src/framework/duplicate_field_scalar.inc
+++ b/src/framework/duplicate_field_scalar.inc
@@ -42,7 +42,9 @@
             dst_cursor % recvList => src_cursor % recvList
             dst_cursor % copyList => src_cursor % copyList
          end if
-         dst_cursor % scalar = src_cursor % scalar
+         if ( dst_cursor % isActive .and. src_cursor % isActive ) then
+            dst_cursor % scalar = src_cursor % scalar
+         end if
 
 !        src_cursor => src_cursor % next
 !        if (.not. local_copy_only) then


### PR DESCRIPTION
Previously, the duplicate_field routines would always attempt to copy
the array / scalar part of a field from the source to the destination
field, even if one of the two fields was not active
(i.e. `field % isActive = .false.`)

This merge updates the duplicate_field routines to check the isActive
attribute before copying data.
