### PR TITLE
Fixing analysis members in debug mode

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
@@ -18,21 +18,21 @@
 !>  1. Copy these to your new analysis member name:
 !>     cp mpas_ocn_TEMPLATE.F mpas_ocn_your_new_name.F
 !>     cp Registry_ocn_TEMPLATE.xml Registry_ocn_your_new_name.xml
-!>  
+!>
 !>  2. In those two new files, replace the following text:
 !>     TEMPLATE, FILL_IN_AUTHOR, FILL_IN_DATE
 !>     Typically TEMPLATE uses underscores, like your_new_name
-!>  
+!>
 !>  3. Add a #include line for your registry to
 !>     Registry_analysis_members.xml
-!>  
+!>
 !>  4. In mpas_ocn_analysis_driver.F, add calls for your analysis member
 !>     by copying lines with TEMPLATE.
-!>  
+!>
 !>  5. In src/core_ocean/analysis_members/Makefile, add your
 !>     new analysis member everywhere you see
 !>     mpas_ocn_global_stats.o
-!>  
+!>
 !
 !-----------------------------------------------------------------------
 
@@ -88,7 +88,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -144,8 +144,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  FILL_IN_AUTHOR
 !> \date    FILL_IN_DATE
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -193,7 +193,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  FILL_IN_AUTHOR
 !> \date    FILL_IN_DATE
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -276,7 +276,7 @@ contains
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
          call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
 
-         ! Computations which are functions of nCells, nEdges, or nVertices 
+         ! Computations which are functions of nCells, nEdges, or nVertices
          ! must be placed within this block loop
          ! Here are some example loops
          do iCell = 1,nCellsSolve
@@ -296,7 +296,7 @@ contains
 !      call mpas_dmpar_min_real_array(dminfo, nMins, mins(1:nMins), reductions(1:nMins))
 !      call mpas_dmpar_max_real_array(dminfo, nMaxes, maxes(1:nMaxes), reductions(1:nMaxes))
 
-      ! Even though some variables do not include an index that is decomposed amongst 
+      ! Even though some variables do not include an index that is decomposed amongst
       ! domain partitions, we assign them within a block loop so that all blocks have the
       ! correct values for writing output.
       block => domain % blocklist
@@ -319,7 +319,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  FILL_IN_AUTHOR
 !> \date    FILL_IN_DATE
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -366,7 +366,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  FILL_IN_AUTHOR
 !> \date    FILL_IN_DATE
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
@@ -76,7 +76,7 @@ contains
 !> \brief   Setup packages for MPAS-Ocean analysis driver
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for all
 !>   ocean analysis members.
 !
@@ -115,7 +115,7 @@ contains
 
       integer :: err_tmp
       logical, pointer :: config_use_global_stats
-      logical, pointer :: config_use_zonal_mean 
+      logical, pointer :: config_use_zonal_mean
       logical, pointer :: config_use_okubo_weiss
       logical, pointer :: config_use_AM_sfc_area_weighted_avg
       logical, pointer :: config_use_AM_water_mass_census
@@ -182,8 +182,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis driver
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all initializations required for the 
+!> \details
+!>  This routine calls all initializations required for the
 !>  MPAS-Ocean analysis driver.
 !
 !-----------------------------------------------------------------------
@@ -287,8 +287,8 @@ contains
 !> \brief   Driver for MPAS-Ocean analysis computations
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all computation subroutines required for the 
+!> \details
+!>  This routine calls all computation subroutines required for the
 !>  MPAS-Ocean analysis driver.
 !
 !-----------------------------------------------------------------------
@@ -346,7 +346,7 @@ contains
          call mpas_stream_mgr_write(stream_manager, streamID='globalStatsOutput', forceWriteNow=.true., ierr=err_tmp)
          call mpas_timer_stop('io_write')
          err = ior(err, err_tmp)
-      endif 
+      endif
 
       call mpas_pool_get_config(domain % configs, 'config_use_AM_sfc_area_weighted_avg', config_use_AM_sfc_area_weighted_avg)
       call mpas_pool_get_config(domain % configs, 'config_AM_sfc_area_weighted_avg_compute_startup', config_AM_sfc_area_weighted_avg_compute_startup)
@@ -424,8 +424,8 @@ contains
 !> \brief   Driver for MPAS-Ocean analysis computations
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all computation subroutines required for the 
+!> \details
+!>  This routine calls all computation subroutines required for the
 !>  MPAS-Ocean analysis driver.
 !
 !-----------------------------------------------------------------------
@@ -523,8 +523,8 @@ contains
 !> \brief   Driver for MPAS-Ocean analysis computations
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all computation subroutines required for the 
+!> \details
+!>  This routine calls all computation subroutines required for the
 !>  MPAS-Ocean analysis driver.
 !
 !-----------------------------------------------------------------------
@@ -577,7 +577,7 @@ contains
       if (config_use_global_stats) then
          if (mpas_stream_mgr_ringing_alarms(stream_manager, streamID='globalStatsOutput', direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)) then
             call ocn_compute_global_stats(domain, timeLevel, err_tmp)
-         endif 
+         endif
       endif
 
       call mpas_pool_get_config(domain % configs, 'config_use_AM_sfc_area_weighted_avg', config_use_AM_sfc_area_weighted_avg)
@@ -638,7 +638,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis driver
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine calls all subroutines required to prepare to save
 !>  the restart state for the MPAS-Ocean analysis driver.
 !
@@ -743,8 +743,8 @@ contains
 !> \brief   Driver for MPAS-Ocean analysis output
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all output writing subroutines required for the 
+!> \details
+!>  This routine calls all output writing subroutines required for the
 !>  MPAS-Ocean analysis driver.
 !>  At this time this is just a stub, and all analysis output is written
 !>  to the output file specified by config_output_name.
@@ -784,7 +784,7 @@ contains
       integer :: err_tmp
 
       logical, pointer :: config_use_global_stats
-      logical, pointer :: config_use_AM_sfc_area_weighted_avg 
+      logical, pointer :: config_use_AM_sfc_area_weighted_avg
       logical, pointer :: config_use_AM_layer_volume_weighted_avg
       logical, pointer :: config_use_zonal_mean
       logical, pointer :: config_use_okubo_weiss
@@ -891,8 +891,8 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis driver
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine calls all finalize routines required for the 
+!> \details
+!>  This routine calls all finalize routines required for the
 !>  MPAS-Ocean analysis driver.
 !
 !-----------------------------------------------------------------------

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -69,7 +69,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -125,8 +125,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -174,7 +174,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -238,7 +238,7 @@ contains
          normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, pressure, montgomeryPotential, vertAleTransportTop, vertVelocityTop, &
          lowFreqDivergence, highFreqThickness, density
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
-      
+
       real (kind=RKIND), dimension(:), pointer :: minGlobalStats,maxGlobalStats,sumGlobalStats, averages, rms, verticalSumMins, verticalSumMaxes
       real (kind=RKIND), dimension(kMaxVariables) :: sumSquares, reductions, sums, mins, maxes
       real (kind=RKIND), dimension(kMaxVariables) :: sums_tmp, sumSquares_tmp, mins_tmp, maxes_tmp, averages_tmp, verticalSumMins_tmp, verticalSumMaxes_tmp
@@ -290,23 +290,23 @@ contains
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'amGlobalStats', amGlobalStatsPool)
-         
+
          call mpas_pool_get_dimension(statePool, 'num_tracers', num_tracers)
 
-         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)        
-         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)          
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)          
-         call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)    
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)    
-         call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop) 
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+         call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
          call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
 
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness)  
-         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity)  
-         call mpas_pool_get_array(statePool, 'tracers', tracers)         
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
+         call mpas_pool_get_array(statePool, 'tracers', tracers, 1)
          if(thicknessFilterActive) then
-            call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergence)
-            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThickness)
+            call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergence, 1)
+            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThickness, 1)
          end if
 
          call mpas_pool_get_array(diagnosticsPool, 'density', density)
@@ -491,7 +491,7 @@ contains
             verticalSumMins(variableIndex) = min(verticalSumMins(variableIndex), verticalSumMins_tmp(variableIndex))
             verticalSumMaxes(variableIndex) = max(verticalSumMaxes(variableIndex), verticalSumMaxes_tmp(variableIndex))
          end if
-   
+
          ! highFreqThickness
          variableIndex = variableIndex + 1
          if (thicknessFilterActive) then
@@ -663,7 +663,7 @@ contains
          variableIndex = variableIndex + 1
          averages(variableIndex) = sums(variableIndex)/volumeCellGlobal
          rms(variableIndex) = sqrt(sumSquares(variableIndex)/volumeCellGlobal)
-   
+
          ! highFreqThickness
          variableIndex = variableIndex + 1
          averages(variableIndex) = sums(variableIndex)/volumeCellGlobal
@@ -673,7 +673,7 @@ contains
          variableIndex = variableIndex + 1
          averages(variableIndex) = 0.0_RKIND
          rms(variableIndex) = 0.0_RKIND
-   
+
          ! highFreqThickness
          variableIndex = variableIndex + 1
          averages(variableIndex) = 0.0_RKIND
@@ -702,7 +702,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -749,7 +749,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -69,7 +69,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -125,8 +125,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -174,7 +174,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -265,7 +265,7 @@ contains
       real (kind=RKIND), dimension(:), allocatable :: workBufferSum, workBufferSumReduced
       real (kind=RKIND), dimension(:), allocatable :: workBufferMin, workBufferMinReduced
       real (kind=RKIND), dimension(:), allocatable :: workBufferMax, workBufferMaxReduced
-     
+
       ! assume no error
       err = 0
 
@@ -361,14 +361,14 @@ contains
 
          ! get pointers to data that will be analyzed
          ! listed in the order in which the fields appear in {avg,min,max}ValueWithinOceanLayerRegion
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness)
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
          call mpas_pool_get_array(diagnosticsPool, 'density', density)
          call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
          call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
          call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
          call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-         call mpas_pool_get_array(statePool, 'tracers', tracers)
+         call mpas_pool_get_array(statePool, 'tracers', tracers, 1)
          call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
          call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
          call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
@@ -457,7 +457,7 @@ contains
           do iLevel=1,nVertLevels
              avgValueWithinOceanVolumeRegion(iDataField, iRegion) = avgValueWithinOceanVolumeRegion(iDataField, iRegion) + avgValueWithinOceanLayerRegion(iDataField,iLevel,iRegion)
           enddo
-        enddo 
+        enddo
         do iDataField=4,nDefinedDataFields
           avgValueWithinOceanVolumeRegion(iDataField, iRegion) = avgValueWithinOceanVolumeRegion(iDataField, iRegion) / max(avgValueWithinOceanVolumeRegion(3,iRegion),1.0e-8_RKIND)
         enddo
@@ -500,9 +500,9 @@ contains
    contains
 
    subroutine compute_mask(iLevel, maxLevelCell, nCells, nCellsSolve, iRegion, lonCell, latCell, workMask)
-   ! this subroutines produces a 0/1 mask that is multiplied with workArray to 
+   ! this subroutines produces a 0/1 mask that is multiplied with workArray to
    ! allow for min/max/avg to represent specific regions of the ocean domain
-   ! 
+   !
    ! NOTE: computes_mask is temporary. workMask should be intent(in) to this entire module !
    !
    integer, intent(in) :: iLevel, nCells, nCellsSolve, iRegion
@@ -512,7 +512,7 @@ contains
    integer :: iCell
    real(kind=RKIND) :: dtr
 
-   dtr = 4.0*atan(1.0) / 180.0_RKIND 
+   dtr = 4.0*atan(1.0) / 180.0_RKIND
    workMask(:) = 0.0_RKIND
    do iCell=1,nCellsSolve
       if(iLevel.le.maxLevelCell(iCell)) workMask(iCell) = 1.0_RKIND
@@ -605,7 +605,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -652,7 +652,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -71,7 +71,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -126,8 +126,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -211,7 +211,7 @@ contains
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
          else
             call mpas_pool_get_array(meshPool, 'yCell', binVariable)
-         end if 
+         end if
 
          minBin = min(minBin, minval(binVariable) )
          maxBin = max(maxBin, maxval(binVariable) )
@@ -222,7 +222,7 @@ contains
       call mpas_dmpar_min_real_array(dminfo, 1, minBin, minBinDomain)
       call mpas_dmpar_max_real_array(dminfo, 1, maxBin, maxBinDomain)
 
-      ! Set up bins. 
+      ! Set up bins.
       binBoundaryMerHeatTrans = -1.0e34
 
       ! Change min and max bin bounds to configuration settings, if applicable.
@@ -257,7 +257,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -352,16 +352,16 @@ contains
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_dimension(statePool, 'index_temperature', indexTemperature)
 
-         call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)        
+         call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
 
-         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)        
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)    
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(statePool, 'tracers', tracers,timeLevel)         
+         call mpas_pool_get_array(statePool, 'tracers', tracers, timeLevel)
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
          call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
@@ -370,7 +370,7 @@ contains
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
          else
             call mpas_pool_get_array(meshPool, 'yCell', binVariable)
-         end if 
+         end if
 
          do iCell = 1, nCellsSolve
             kMax = maxLevelCell(iCell)
@@ -384,7 +384,7 @@ contains
 
                      ! Compute divergence of huT, i.e. layerThicknessEdge * normalVelocity * temperature, at an edge
                      ! for meridional heat transport.  Here we use a centered difference to compute the temperature at
-                     ! the edge, which is an approximation to the actual edge temperature used in the horizontal 
+                     ! the edge, which is an approximation to the actual edge temperature used in the horizontal
                      ! advection scheme (for example, FCT).  We expect that the error in this approximation is small.
                      ! Here we do not divide by the area, as one normally does in a divergence calculation, so that
                      ! div_huT is weighted by area here.
@@ -394,7 +394,7 @@ contains
                         iEdge = edgesOnCell(i, iCell)
                         div_huT = div_huT - layerThicknessEdge(k, iEdge) * normalTransportVelocity(k, iEdge) &
                              * 0.5_RKIND * (tracers(indexTemperature,k,cellsOnEdge(1,iEdge)) + tracers(indexTemperature,k,cellsOnEdge(2,iEdge))) &
-                             * edgeSignOnCell(i, iCell) * dvEdge(iEdge) 
+                             * edgeSignOnCell(i, iCell) * dvEdge(iEdge)
                      end do
                      sumMerHeatTrans(iField,k,iBin) = sumMerHeatTrans(iField,k,iBin) + div_huT
 
@@ -410,11 +410,11 @@ contains
       end do
 
       ! mpi summation over all processors
-      ! Note the input and output arrays are of the same dimension, so summation is 
+      ! Note the input and output arrays are of the same dimension, so summation is
       ! over the domain decompositon (by processor), not over an array index.
       call mpas_dmpar_sum_real_array(dminfo, nVertLevels*nMerHeatTransBinsUsed*nMerHeatTransVariables, sumMerHeatTrans, totalSumMerHeatTrans)
 
-      ! Even though these variables do not include an index that is decomposed amongst 
+      ! Even though these variables do not include an index that is decomposed amongst
       ! domain partitions, we assign them within a block loop so that all blocks have the
       ! correct values for writing output.
       block => domain % blocklist
@@ -474,7 +474,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -521,7 +521,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -115,7 +115,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -171,8 +171,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -270,7 +270,7 @@ contains
 !> \brief   Compute values of Okubo-Weiss and Lamba_2 field
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !> Computes the values for Okubo-Weiss field OW, as well as the second
 !> eigenvalue of the strain rate tensor Lambda_2.
 !> The OW and Lam2 values use the x/y components of the velocity gradient
@@ -733,7 +733,7 @@ contains
 !> \brief   Count the number of local connected components
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !> Local connected components are defined by being mapped to the same ID.
 !> For each component, there is one entry in the Union-Find data structure
 !> that is representative of the union, by mapping to itself. Thus this
@@ -829,7 +829,7 @@ contains
 !> \brief   Aggregate statistics of partial eddies
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !> Each (partial) eddy has an ID used for sorting and several statistics
 !> associated with it. For this, statistics are stored in an "array of structs"
 !> fashion, where the first value represents the ID.
@@ -1051,7 +1051,7 @@ contains
 !> \brief   Aggregate statistics of partial eddies
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !> Send all partial eddy statistics to IO node and merge them into
 !> statistics of complete eddies.
 !
@@ -1099,7 +1099,7 @@ contains
 
       ! Multiplex all eddy statistics into one array so it can be send with
       ! one MPI communication call
-      ! TODO this could be possibly be made more memory and network 
+      ! TODO this could be possibly be made more memory and network
       !      efficient with lists, because a large array is allocated
       !      allocated and communicated across all processors to merge eddies
       call mpas_timer_start("all gather", .false., CCAggGatherT)
@@ -1211,7 +1211,7 @@ contains
 !> \brief   Sorts eddy statistics according to eddy ID.
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !> Each (partial) eddy has an ID used for sorting and several statistics
 !> associated with it. For this, statistics are stored in an "array of structs"
 !> fashion (blocks of size elemSize), where the first value represents the ID.
@@ -1299,11 +1299,11 @@ contains
 
       ! Create output file.
       open(fileID, file=trim(config_okubo_weiss_directory)//'/eddy_census_'//trim(xtime)//'.txt', STATUS='UNKNOWN', POSITION='rewind')
-      
+
       if (use_lat_lon_coords) then
-         write (fileID, '(10A)') '"eddy ID", "number of cells", "volume sum, m^3", "average longitude, degrees", "average latitude, degrees", "average depth, m", "average zonal velocity, m/s", "average meridional velocity, m/s", "average vertical velocity, m/s"'  
+         write (fileID, '(10A)') '"eddy ID", "number of cells", "volume sum, m^3", "average longitude, degrees", "average latitude, degrees", "average depth, m", "average zonal velocity, m/s", "average meridional velocity, m/s", "average vertical velocity, m/s"'
       else
-         write (fileID, '(10A)') '"eddy ID", "number of cells", "volume sum, m^3", "average x-position, m", "average y-position, m", "average depth, m", "average x-velocity, m/s", "average y-velocity, m/s", "average z-velocity, m/s"' 
+         write (fileID, '(10A)') '"eddy ID", "number of cells", "volume sum, m^3", "average x-position, m", "average y-position, m", "average depth, m", "average x-velocity, m/s", "average y-velocity, m/s", "average z-velocity, m/s"'
       end if
 
       ! Output number of eddies and statistics for each eddy
@@ -1351,8 +1351,8 @@ contains
 !> \brief   Computes the velocity gradient at cell centers, in R3
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
-!>  This routine computes the velocity gradient at cell centers using the weak 
+!> \details
+!>  This routine computes the velocity gradient at cell centers using the weak
 !>  derivative.  Output is an R3 velocity gradient tensor in 3x3 format.
 !
 !-----------------------------------------------------------------------
@@ -1382,7 +1382,7 @@ contains
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information
 
-      logical, intent(in) :: & 
+      logical, intent(in) :: &
          includeHalo !< Input: If true, halo cells and edges are included in computation
 
       !-----------------------------------------------------------------
@@ -1416,7 +1416,7 @@ contains
 
       if (includeHalo) then
          call mpas_pool_get_dimension(meshPool, 'nCells', nCellsCompute)
-      else 
+      else
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsCompute)
       end if
 
@@ -1434,7 +1434,7 @@ contains
            do i=1,3
              do j=1,3
                ! outer produce at each edge:
-               ! u_e n_e n_e* + v_e n_e \tilde{n}_e* 
+               ! u_e n_e n_e* + v_e n_e \tilde{n}_e*
                outerProductEdge3x3(i,j) = edgeNormalVectors(i,iEdge) &
                        *(  normalVelocity(k,iEdge)    *edgeNormalVectors(j,iEdge) &
                          + tangentialVelocity(k,iEdge)*edgeTangentVectors(j,iEdge) &
@@ -1454,7 +1454,7 @@ contains
                ! edgeSignOnCell is to get outward unit normal on edgeNormalVectors
                ! minus sign in front is to match form on divergence operator
                velocityGradient(:,:,k,iCell) = velocityGradient(:,:,k,iCell) &
-                 - edgeSignOnCell(i,iCell)*outerProductEdgeFull(:,:,k,iEdge)*invAreaCell*dvEdge(iEdge) 
+                 - edgeSignOnCell(i,iCell)*outerProductEdgeFull(:,:,k,iEdge)*invAreaCell*dvEdge(iEdge)
             end do
          end do
       end do
@@ -1469,7 +1469,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -1517,14 +1517,14 @@ contains
       type (mpas_pool_type), pointer :: amOkuboWeiss
 
       integer, pointer :: nVertLevels, nCells, nEdges
-      integer, dimension(:), pointer :: maxLevelCell    
+      integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
       real (kind=RKIND), dimension(:,:), pointer :: edgeTangentVectors
-      
-      real (kind=RKIND), dimension(:,:), pointer :: om, OW 
+
+      real (kind=RKIND), dimension(:,:), pointer :: om, OW
       integer, dimension(:,:), pointer :: OW_cc_id
 
       type(field2DReal), pointer :: SField, Lam1Field, Lam2Field, Lam2_R3Field
@@ -1562,7 +1562,7 @@ contains
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
          call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
-         
+
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
          call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
 
@@ -1570,7 +1570,7 @@ contains
          call mpas_pool_get_array(amOkuboWeissPool, 'eddyID', OW_cc_id)
          call mpas_pool_get_array(amOkuboWeissPool, 'vorticity', om)
 
-         call mpas_pool_get_field(scratchPool, 'velocityGradient', velocityGradientField)         
+         call mpas_pool_get_field(scratchPool, 'velocityGradient', velocityGradientField)
          call mpas_pool_get_field(scratchPool, 'thresholdedOkuboWeiss', OW_threshField)
          call mpas_pool_get_field(scratchPool, 'shearAndStrain', SField)
          call mpas_pool_get_field(scratchPool, 'lambda1', Lam1Field)
@@ -1591,7 +1591,7 @@ contains
          Lam2 => Lam2Field % array
          Lam2_R3 => Lam2_R3Field % array
 
-         ! Compute velocity gradient         
+         ! Compute velocity gradient
          call mpas_velocity_gradient_R3Cell(normalVelocity, tangentialVelocity, &
                meshPool, edgeSignOnCell, edgeTangentVectors, .true., &
                nVertLevels, nEdges, velocityGradient)
@@ -1632,7 +1632,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -1679,7 +1679,7 @@ contains
 !> \brief   MPAS-Ocean analysis output
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !>  This routine writes all output for this MPAS-Ocean analysis member.
 !>  At this time this is just a stub, and all analysis output is written
 !>  to the output file specified by config_output_name.
@@ -1727,7 +1727,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Andre Schmeisser
 !> \date    August 2014
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -69,7 +69,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -125,8 +125,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -174,7 +174,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -239,12 +239,12 @@ contains
       real (kind=RKIND), dimension(:), pointer :: iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: rainFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux
-   
+
       ! frazilIce Pkg
       real (kind=RKIND), dimension(:), pointer :: seaIceEnergy
 
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux
-      real (kind=RKIND), dimension(:,:), pointer :: surfaceTracerFlux 
+      real (kind=RKIND), dimension(:,:), pointer :: surfaceTracerFlux
       real (kind=RKIND), dimension(:), pointer ::  penetrativeTemperatureFlux
 
       real (kind=RKIND), dimension(:), pointer :: seaIceSalinityFlux
@@ -281,7 +281,7 @@ contains
       real (kind=RKIND), dimension(:), allocatable :: workBufferSum, workBufferSumReduced
       real (kind=RKIND), dimension(:), allocatable :: workBufferMin, workBufferMinReduced
       real (kind=RKIND), dimension(:), allocatable :: workBufferMax, workBufferMaxReduced
-     
+
       ! assume no error
       err = 0
 
@@ -399,8 +399,8 @@ contains
          if (bulkForcingPkgActive) call mpas_pool_get_array(forcingPool, 'windStressZonal', windStressZonal)
          if (bulkForcingPkgActive) call mpas_pool_get_array(forcingPool, 'windStressMeridional', windStressMeridional)
          call mpas_pool_get_array(forcingPool, 'seaSurfacePressure', seaSurfacePressure)
-         call mpas_pool_get_array(statePool, 'ssh', ssh)  
-         call mpas_pool_get_array(statePool, 'tracers', tracers)
+         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+         call mpas_pool_get_array(statePool, 'tracers', tracers, 1)
          call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth',boundaryLayerDepth)
 
          ! compute mask
@@ -446,7 +446,7 @@ contains
                               + longWaveHeatFluxUp(:) &
                               + longWaveHeatFluxDown(:) &
                               + shortWaveHeatFlux(:)  &
-                              + seaIceHeatFlux(:) 
+                              + seaIceHeatFlux(:)
                      !        + seaIceEnergy
             workArray(29,:) =   seaIceSalinityFlux(:)
             workArray(30,:) =   evaporationFlux(:) &
@@ -454,7 +454,7 @@ contains
                               + riverRunoffFlux(:) &
                               + iceRunoffFlux(:) &
                               + rainFlux(:) &
-                              + snowFlux(:) 
+                              + snowFlux(:)
                      !        + seaIceEnergy(:)
          end if
 
@@ -517,9 +517,9 @@ contains
    contains
 
    subroutine compute_mask(nCells, nCellsSolve, iRegion, lonCell, latCell, workMask)!{{{
-   ! this subroutines produces a 0/1 mask that is multiplied with workArray to 
+   ! this subroutines produces a 0/1 mask that is multiplied with workArray to
    ! allow for min/max/avg to represent specific regions of the ocean domain
-   ! 
+   !
    ! NOTE: computes_mask is temporary. workMask should be intent(in) to this entire module !
    !
    integer, intent(in) :: nCells, nCellsSolve, iRegion
@@ -528,7 +528,7 @@ contains
    integer :: iCell
    real(kind=RKIND) :: dtr
 
-   dtr = 4.0*atan(1.0) / 180.0_RKIND 
+   dtr = 4.0*atan(1.0) / 180.0_RKIND
    workMask(:) = 0.0_RKIND
    do iCell=1,nCellsSolve
       workMask(iCell) = 1.0_RKIND
@@ -616,7 +616,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -663,7 +663,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    April 24, 2015
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -71,7 +71,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    May 10, 2015
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -127,8 +127,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    May 10, 2015
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -176,7 +176,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    May 10, 2015
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -321,7 +321,7 @@ contains
       call mpas_pool_get_config(domain % configs, 'config_AM_water_mass_census_maxTemperature', maxTemperature)
       call mpas_pool_get_config(domain % configs, 'config_AM_water_mass_census_minSalinity', minSalinity)
       call mpas_pool_get_config(domain % configs, 'config_AM_water_mass_census_maxSalinity', maxSalinity)
- 
+
       do iRegion=1,nOceanRegionsTmpCensus
         ! compute temperature and salinity domains
         ! (note: the ability to have different t/s domains for different regions is not yet built out)
@@ -334,7 +334,7 @@ contains
           waterMassCensusSalinityValues(iSalinityBin,iRegion) = minSalinity + deltaSalinity*(iSalinityBin-1)
         enddo
       enddo ! iRegion
-       
+
       ! initialize intent(out) of this analysis member
       waterMassFractionalDistribution(:,:,:)=0.0
       potentialDensityOfTSDiagram(:,:,:)=0.0
@@ -363,7 +363,7 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(statePool, 'tracers', tracers, timeLevel)
 
-         ! loop over and bin all data 
+         ! loop over and bin all data
          do iCell=1,nCellsSolve
          do iLevel=1,maxLevelCell(iCell)
 
@@ -477,9 +477,9 @@ contains
    contains
 
    subroutine compute_mask(maxLevelCell, nCells, nCellsSolve, iRegion, lonCell, latCell, workMask)
-   ! this subroutines produces a 0/1 mask that is multiplied with workArray to 
+   ! this subroutines produces a 0/1 mask that is multiplied with workArray to
    ! allow for min/max/avg to represent specific regions of the ocean domain
-   ! 
+   !
    ! NOTE: computes_mask is temporary. workMask should be intent(in) to this entire module !
    !
    integer, intent(in) :: nCells, nCellsSolve, iRegion
@@ -489,7 +489,7 @@ contains
    integer :: iCell
    real(kind=RKIND) :: dtr
 
-   dtr = 4.0*atan(1.0) / 180.0_RKIND 
+   dtr = 4.0*atan(1.0) / 180.0_RKIND
    workMask(:) = 0.0_RKIND
    do iCell=1,nCellsSolve
       workMask(iCell) = 1.0_RKIND
@@ -557,7 +557,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    May 10, 2015
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -604,7 +604,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Todd Ringler
 !> \date    May 10, 2015
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -71,7 +71,7 @@ contains
 !> \brief   Set up packages for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    November 2013
-!> \details 
+!> \details
 !>  This routine is intended to configure the packages for this MPAS
 !>   ocean analysis member
 !
@@ -126,8 +126,8 @@ contains
 !> \brief   Initialize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
-!>  This routine conducts all initializations required for the 
+!> \details
+!>  This routine conducts all initializations required for the
 !>  MPAS-Ocean analysis member.
 !
 !-----------------------------------------------------------------------
@@ -212,7 +212,7 @@ contains
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
          else
             call mpas_pool_get_array(meshPool, 'yCell', binVariable)
-         end if 
+         end if
 
          minBin = min(minBin, minval(binVariable) )
          maxBin = max(maxBin, maxval(binVariable) )
@@ -223,7 +223,7 @@ contains
       call mpas_dmpar_min_real_array(dminfo, 1, minBin, minBinDomain)
       call mpas_dmpar_max_real_array(dminfo, 1, maxBin, maxBinDomain)
 
-      ! Set up bins. 
+      ! Set up bins.
       binBoundaryZonalMean = -1.0e34
       binCenterZonalMean = -1.0e34
 
@@ -261,7 +261,7 @@ contains
 !> \brief   Compute MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !
@@ -361,11 +361,11 @@ contains
 
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
 
-         call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)        
+         call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
 
-         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)        
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)    
-         call mpas_pool_get_array(statePool, 'tracers', tracers,timeLevel)         
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+         call mpas_pool_get_array(statePool, 'tracers', tracers, timeLevel)
          call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
 
@@ -374,7 +374,7 @@ contains
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
          else
             call mpas_pool_get_array(meshPool, 'yCell', binVariable)
-         end if 
+         end if
 
          ! note that sum is for each vertical index, which is a little wrong for z-star and very wrong for PBCs.
          do iCell = 1, nCellsSolve
@@ -428,7 +428,7 @@ contains
          normZonalMean(:,:,iBin) = -1.0e34
       end do
 
-      ! Even though these variables do not include an index that is decomposed amongst 
+      ! Even though these variables do not include an index that is decomposed amongst
       ! domain partitions, we assign them within a block loop so that all blocks have the
       ! correct values for writing output.
       block => domain % blocklist
@@ -476,7 +476,7 @@ contains
 !> \brief   Save restart for MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts computation required to save a restart state
 !>  for the MPAS-Ocean analysis member.
 !
@@ -523,7 +523,7 @@ contains
 !> \brief   Finalize MPAS-Ocean analysis member
 !> \author  Mark Petersen
 !> \date    March 2014
-!> \details 
+!> \details
 !>  This routine conducts all finalizations required for this
 !>  MPAS-Ocean analysis member.
 !


### PR DESCRIPTION
This merge adds time levels to fields from the statePool. When building
in debug mode, a lack of these time levels causes the model to fail.
