### PR TITLE
Convert hard coded reals to use _RKIND

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -292,12 +292,12 @@ contains
       allocate(workBufferSumReduced(kBufferLength))
       allocate(workBufferMinReduced(kBufferLength))
       allocate(workBufferMaxReduced(kBufferLength))
-      workBufferSum=0.0
-      workBufferMin=0.0
-      workBufferMax=0.0
-      workBufferSumReduced=0.0
-      workBufferMinReduced=0.0
-      workBufferMaxReduced=0.0
+      workBufferSum=0.0_RKIND
+      workBufferMin=0.0_RKIND
+      workBufferMax=0.0_RKIND
+      workBufferSumReduced=0.0_RKIND
+      workBufferMinReduced=0.0_RKIND
+      workBufferMaxReduced=0.0_RKIND
 
       ! get pointers to analysis member arrays
       call mpas_pool_get_subpool(domain % blocklist % structs, 'amLayerVolWeightedAvg', amLayerVolWeightedAvgPool)
@@ -373,9 +373,9 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
 
          ! initialize buffers
-         workBufferSum(:) = 0.0
-         workBufferMin(:) = +1.0e20
-         workBufferMax(:) = -1.0e20
+         workBufferSum(:) = 0.0_RKIND
+         workBufferMin(:) = +1.0e20_RKIND
+         workBufferMax(:) = -1.0e20_RKIND
 
          ! loop over all ocean regions
          do iRegion=1,nOceanRegionsTmp
@@ -448,9 +448,9 @@ contains
       enddo
 
       ! compute vertical sum before layer-by-layer normalization
-      minValueWithinOceanVolumeRegion = 0.0
-      maxValueWithinOceanVolumeRegion = 0.0
-      avgValueWithinOceanVolumeRegion = 0.0
+      minValueWithinOceanVolumeRegion = 0.0_RKIND
+      maxValueWithinOceanVolumeRegion = 0.0_RKIND
+      avgValueWithinOceanVolumeRegion = 0.0_RKIND
       do iRegion=1,nOceanRegionsTmp
         do iDataField=1,nDefinedDataFields
           do iLevel=1,nVertLevels
@@ -461,9 +461,9 @@ contains
           avgValueWithinOceanVolumeRegion(iDataField, iRegion) = avgValueWithinOceanVolumeRegion(iDataField, iRegion) / max(avgValueWithinOceanVolumeRegion(3,iRegion),1.0e-8_RKIND)
         enddo
         ! normalize total region volume by total volume cell area
-        avgValueWithinOceanVolumeRegion(3,iRegion) = avgValueWithinOceanVolumeRegion(3,iRegion) / max(avgValueWithinOceanVolumeRegion(2,iRegion),1.0e-8)
+        avgValueWithinOceanVolumeRegion(3,iRegion) = avgValueWithinOceanVolumeRegion(3,iRegion) / max(avgValueWithinOceanVolumeRegion(2,iRegion),1.0e-8_RKIND)
         ! normalize total volume cell area by total number of cells
-        avgValueWithinOceanVolumeRegion(2,iRegion) = avgValueWithinOceanVolumeRegion(2,iRegion) / max(avgValueWithinOceanVolumeRegion(1,iRegion),1.0e-8)
+        avgValueWithinOceanVolumeRegion(2,iRegion) = avgValueWithinOceanVolumeRegion(2,iRegion) / max(avgValueWithinOceanVolumeRegion(1,iRegion),1.0e-8_RKIND)
       enddo
 
       ! find min/max with region volume
@@ -482,9 +482,9 @@ contains
             avgValueWithinOceanLayerRegion(iDataField,iLevel,iRegion) = avgValueWithinOceanLayerRegion(iDataField,iLevel,iRegion) / max(avgValueWithinOceanLayerRegion(3,iLevel,iRegion),1.0e-8_RKIND)
          enddo
          ! normalize total layer volume by layer area
-         avgValueWithinOceanLayerRegion(3,iLevel,iRegion) = avgValueWithinOceanLayerRegion(3,iLevel,iRegion) / max(avgValueWithinOceanLayerRegion(2,iLevel,iRegion),1.0e-8)
+         avgValueWithinOceanLayerRegion(3,iLevel,iRegion) = avgValueWithinOceanLayerRegion(3,iLevel,iRegion) / max(avgValueWithinOceanLayerRegion(2,iLevel,iRegion),1.0e-8_RKIND)
          ! normalize total layer area by number of cells in region
-         avgValueWithinOceanLayerRegion(2,iLevel,iRegion) = avgValueWithinOceanLayerRegion(2,iLevel,iRegion) / max(avgValueWithinOceanLayerRegion(1,iLevel,iRegion),1.0e-8)
+         avgValueWithinOceanLayerRegion(2,iLevel,iRegion) = avgValueWithinOceanLayerRegion(2,iLevel,iRegion) / max(avgValueWithinOceanLayerRegion(1,iLevel,iRegion),1.0e-8_RKIND)
       enddo
       enddo
 
@@ -511,7 +511,7 @@ contains
    integer :: iCell
    real(kind=RKIND) :: dtr
 
-   dtr = 4.0*atan(1.0) / 180.0_RKIND 
+   dtr = 4.0_RKIND*atan(1.0_RKIND) / 180.0_RKIND 
    workMask(:) = 0.0_RKIND
    do iCell=1,nCellsSolve
       if(iLevel.le.maxLevelCell(iCell)) workMask(iCell) = 1.0_RKIND
@@ -520,42 +520,42 @@ contains
    if (iRegion.eq.1) then
       ! Arctic
       do iCell=1,nCellsSolve
-        if(latCell(iCell).lt. 60.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. 60.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    elseif (iRegion.eq.2) then
       ! Equatorial
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt. 15.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt.-15.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt. 15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt.-15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    elseif (iRegion.eq.3) then
       ! Southern Ocean
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.-50.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.-50.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    elseif (iRegion.eq.4) then
       ! Nino 3
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.210.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.270.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.270.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    elseif (iRegion.eq.5) then
       ! Nino 4
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.160.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.210.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.160.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    elseif (iRegion.eq.6) then
       ! Nino 3.4
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.190.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.240.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.190.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.240.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
    else
       ! global (do nothing!)
@@ -589,8 +589,8 @@ contains
    enddo
 
    do iDataField=1,nDefinedDataFields
-      workMin(iDataField) = minval(workArray(iDataField,1:nCellsSolve),workMask(1:nCellsSolve)>0.5)
-      workMax(iDataField) = maxval(workArray(iDataField,1:nCellsSolve),workMask(1:nCellsSolve)>0.5)
+      workMin(iDataField) = minval(workArray(iDataField,1:nCellsSolve),workMask(1:nCellsSolve)>0.5_RKIND)
+      workMax(iDataField) = maxval(workArray(iDataField,1:nCellsSolve),workMask(1:nCellsSolve)>0.5_RKIND)
    enddo
 
    end subroutine compute_statistics

--- a/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -183,8 +183,8 @@ contains
 
       err = 0
 
-      minBin =  1.0e34
-      maxBin = -1.0e34
+      minBin =  1.0e34_RKIND
+      maxBin = -1.0e34_RKIND
 
       call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nMerHeatTransBins', nMerHeatTransBins)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'MerHeatTrans', MerHeatTransPool)
@@ -220,21 +220,21 @@ contains
       call mpas_dmpar_max_real_array(dminfo, 1, maxBin, maxBinDomain)
 
       ! Set up bins. 
-      binBoundaryMerHeatTrans = -1.0e34
+      binBoundaryMerHeatTrans = -1.0e34_RKIND
 
       ! Change min and max bin bounds to configuration settings, if applicable.
-      if (config_min_meridional_heat_transport_bin > -1.0e33) then
+      if (config_min_meridional_heat_transport_bin > -1.0e33_RKIND) then
          minBinDomain(1) = config_min_meridional_heat_transport_bin
       else
          ! use measured min value, but decrease slightly to include least value.
-         minBinDomain(1) = minBinDomain(1) - 1.0e-10 * abs(minBinDomain(1))
+         minBinDomain(1) = minBinDomain(1) - 1.0e-10_RKIND * abs(minBinDomain(1))
       end if
 
-      if (config_max_meridional_heat_transport_bin > -1.0e33) then
+      if (config_max_meridional_heat_transport_bin > -1.0e33_RKIND) then
          maxBinDomain(1) = config_max_meridional_heat_transport_bin
       else
          ! use measured max value, but increase slightly to include max value.
-         maxBinDomain(1) = maxBinDomain(1) + 1.0e-10 * abs(maxBinDomain(1))
+         maxBinDomain(1) = maxBinDomain(1) + 1.0e-10_RKIND * abs(maxBinDomain(1))
       end if
 
       binBoundaryMerHeatTrans(1) = minBinDomain(1)
@@ -337,7 +337,7 @@ contains
       allocate(totalSumMerHeatTrans(nMerHeatTransVariables,nVertLevels,nMerHeatTransBinsUsed))
       allocate(mht_meridional_integral(nVertLevels,nMerHeatTransBinsUsed))
 
-      sumMerHeatTrans = 0.0
+      sumMerHeatTrans = 0.0_RKIND
 
       block => domain % blocklist
       do while (associated(block))

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -495,7 +495,7 @@ contains
             avgValueWithinOceanRegion(iDataField,iRegion) = avgValueWithinOceanRegion(iDataField,iRegion) / max(avgValueWithinOceanRegion(2,iRegion),1.0e-8_RKIND)
          enddo
          ! normalize total area by number of cells in region
-         avgValueWithinOceanRegion(2,iRegion) = avgValueWithinOceanRegion(2,iRegion) / max(avgValueWithinOceanRegion(1,iRegion),1.0e-8)
+         avgValueWithinOceanRegion(2,iRegion) = avgValueWithinOceanRegion(2,iRegion) / max(avgValueWithinOceanRegion(1,iRegion),1.0e-8_RKIND)
       enddo
 
       ! deallocate scratch fields
@@ -600,8 +600,8 @@ contains
    enddo
 
    do iData=1,nDefinedDataFields
-      workMin(iData) = minval(workArray(iData,1:nCellsSolve),workMask(1:nCellsSolve)>0.5)
-      workMax(iData) = maxval(workArray(iData,1:nCellsSolve),workMask(1:nCellsSolve)>0.5)
+      workMin(iData) = minval(workArray(iData,1:nCellsSolve),workMask(1:nCellsSolve)>0.5_RKIND)
+      workMax(iData) = maxval(workArray(iData,1:nCellsSolve),workMask(1:nCellsSolve)>0.5_RKIND)
    enddo
 
    end subroutine compute_statistics!}}}

--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -282,8 +282,8 @@ contains
       kBufferLength=3*nOceanRegionsTmpCensus*nTemperatureBins*nSalinityBins
       allocate(workBufferSum(kBufferLength))
       allocate(workBufferSumReduced(kBufferLength))
-      workBufferSum=0.0
-      workBufferSumReduced=0.0
+      workBufferSum=0.0_RKIND
+      workBufferSumReduced=0.0_RKIND
 
       ! all code below will go away when regionMask is intent(in)
       ! allocate region mask and fill array
@@ -335,9 +335,9 @@ contains
       enddo ! iRegion
        
       ! initialize intent(out) of this analysis member
-      waterMassFractionalDistribution(:,:,:)=0.0
-      potentialDensityOfTSDiagram(:,:,:)=0.0
-      zPositionOfTSDiagram(:,:,:)=0.0
+      waterMassFractionalDistribution(:,:,:)=0.0_RKIND
+      potentialDensityOfTSDiagram(:,:,:)=0.0_RKIND
+      zPositionOfTSDiagram(:,:,:)=0.0_RKIND
 
       ! loop over blocks
       block => domain % blocklist
@@ -441,16 +441,16 @@ contains
       do iRegion=1,nOceanRegionsTmpCensus
         potentialDensityOfTSDiagram(iTemperatureBin,iSalinityBin,iRegion) = &
           potentialDensityOfTSDiagram(iTemperatureBin,iSalinityBin,iRegion) / &
-          max(waterMassFractionalDistribution(iTemperatureBin,iSalinityBin,iRegion), 1.0e-8)
+          max(waterMassFractionalDistribution(iTemperatureBin,iSalinityBin,iRegion), 1.0e-8_RKIND)
         zPositionOfTSDiagram(iTemperatureBin,iSalinityBin,iRegion) = &
           zPositionOfTSDiagram(iTemperatureBin,iSalinityBin,iRegion) / &
-          max(waterMassFractionalDistribution(iTemperatureBin,iSalinityBin,iRegion), 1.0e-8)
+          max(waterMassFractionalDistribution(iTemperatureBin,iSalinityBin,iRegion), 1.0e-8_RKIND)
       enddo
       enddo
       enddo
 
       ! use workBufferSum as workspace to find total volume for each region
-      workBufferSum = 0.0
+      workBufferSum = 0.0_RKIND
       do iTemperatureBin=1,nTemperatureBins
       do iSalinityBin=1,nSalinityBins
       do iRegion=1,nOceanRegionsTmpCensus
@@ -461,7 +461,7 @@ contains
 
       ! use this sum to convert waterMassFractionalDistribution from total volume to fractional volume
       do iRegion=1,nOceanRegionsTmpCensus
-        waterMassFractionalDistribution(:,:,iRegion) = waterMassFractionalDistribution(:,:,iRegion) / max(workBufferSum(iRegion),1.0e-8)
+        waterMassFractionalDistribution(:,:,iRegion) = waterMassFractionalDistribution(:,:,iRegion) / max(workBufferSum(iRegion),1.0e-8_RKIND)
       enddo
 
       ! deallocate buffers
@@ -497,47 +497,47 @@ contains
    if (iRegion.eq.1) then
       ! Arctic
       do iCell=1,nCellsSolve
-        if(latCell(iCell).lt. 60.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. 60.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Arctic ', sum(workMask)
    elseif (iRegion.eq.2) then
       ! Equatorial
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt. 15.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt.-15.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt. 15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt.-15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Equatorial ', sum(workMask)
    elseif (iRegion.eq.3) then
       ! Southern Ocean
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.-50.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.-50.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Southern Ocean ', sum(workMask)
    elseif (iRegion.eq.4) then
       ! Nino 3
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.210.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.270.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.270.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Nino 3 ', sum(workMask)
    elseif (iRegion.eq.5) then
       ! Nino 4
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.160.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.210.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.160.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Nino 4 ', sum(workMask)
    elseif (iRegion.eq.6) then
       ! Nino 3.4
       do iCell=1,nCellsSolve
-        if(latCell(iCell).gt.  5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(latCell(iCell).lt. -5.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).lt.190.0*dtr) workMask(iCell) = 0.0_RKIND
-        if(lonCell(iCell).gt.240.0*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).gt.  5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(latCell(iCell).lt. -5.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).lt.190.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
+        if(lonCell(iCell).gt.240.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
       write(6,*) ' Nino 3.4 ', sum(workMask)
    else

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -183,8 +183,8 @@ contains
 
       err = 0
 
-      minBin =  1.0e34
-      maxBin = -1.0e34
+      minBin =  1.0e34_RKIND
+      maxBin = -1.0e34_RKIND
 
       call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nZonalMeanBins', nZonalMeanBins)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'amZonalMean', amZonalMeanPool)
@@ -221,28 +221,28 @@ contains
       call mpas_dmpar_max_real_array(dminfo, 1, maxBin, maxBinDomain)
 
       ! Set up bins. 
-      binBoundaryZonalMean = -1.0e34
-      binCenterZonalMean = -1.0e34
+      binBoundaryZonalMean = -1.0e34_RKIND
+      binCenterZonalMean = -1.0e34_RKIND
 
       ! Change min and max bin bounds to configuration settings, if applicable.
-      if (config_min_zonal_mean_bin > -1.0e33) then
+      if (config_min_zonal_mean_bin > -1.0e33_RKIND) then
          minBinDomain(1) = config_min_zonal_mean_bin
       else
          ! use measured min value, but decrease slightly to include least value.
-         minBinDomain(1) = minBinDomain(1) - 1.0e-10 * abs(minBinDomain(1))
+         minBinDomain(1) = minBinDomain(1) - 1.0e-10_RKIND * abs(minBinDomain(1))
       end if
 
-      if (config_max_zonal_mean_bin > -1.0e33) then
+      if (config_max_zonal_mean_bin > -1.0e33_RKIND) then
          maxBinDomain(1) = config_max_zonal_mean_bin
       else
          ! use measured max value, but increase slightly to include max value.
-         maxBinDomain(1) = maxBinDomain(1) + 1.0e-10 * abs(maxBinDomain(1))
+         maxBinDomain(1) = maxBinDomain(1) + 1.0e-10_RKIND * abs(maxBinDomain(1))
       end if
 
       binBoundaryZonalMean(1) = minBinDomain(1)
       binWidth = (maxBinDomain(1) - minBinDomain(1)) / nZonalMeanBinsUsed
 
-      binCenterZonalMean(1) = minBinDomain(1) + binWidth/2.0
+      binCenterZonalMean(1) = minBinDomain(1) + binWidth/2.0_RKIND
       do iBin = 2, nZonalMeanBinsUsed
          binBoundaryZonalMean(iBin) = binBoundaryZonalMean(iBin-1) + binWidth
          binCenterZonalMean(iBin) = binCenterZonalMean(iBin-1) + binWidth
@@ -339,7 +339,7 @@ contains
          totalSumZonalMean(nZonalMeanVariables,nVertLevels,nZonalMeanBinsUsed), &
          normZonalMean(nZonalMeanVariables,nVertLevels,nZonalMeanBins))
 
-      sumZonalMean = 0.0
+      sumZonalMean = 0.0_RKIND
 
       block => domain % blocklist
       do while (associated(block))
@@ -414,15 +414,15 @@ contains
       do iBin = 1, nZonalMeanBinsUsed
          do k = 1, nVertLevels
             ! Check if there is any area accumulated.  If so, normalize by the area.
-            if (totalSumZonalMean(1,k,iBin) > 1.0e-12) then
+            if (totalSumZonalMean(1,k,iBin) > 1.0e-12_RKIND) then
                normZonalMean(:,k,iBin) = totalSumZonalMean(:,k,iBin) / totalSumZonalMean(1,k,iBin)
             else
-               normZonalMean(:,k,iBin) = -1.0e34
+               normZonalMean(:,k,iBin) = -1.0e34_RKIND
             end if
          end do
       end do
       do iBin = nZonalMeanBinsUsed + 1, nZonalMeanBins
-         normZonalMean(:,:,iBin) = -1.0e34
+         normZonalMean(:,:,iBin) = -1.0e34_RKIND
       end do
 
       ! Even though these variables do not include an index that is decomposed amongst 


### PR DESCRIPTION
This merge adds the _RKIND specifier to hard coded real values in
analysis members. These definitions cause build errors on mira without
the _RKIND specification.
