### PR TITLE
Fixing an issue that prevented bit reproducibility

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_forcing_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing_restoring.F
@@ -115,19 +115,19 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k
-      integer, pointer :: nCellsSolve
+      integer, pointer :: nCells
 
       real (kind=RKIND) :: invTemp, invSalinity
 
       err = 0
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       invTemp = 1.0 / (temperatureTimeScale * 86400.0)
       invSalinity = 1.0 / (salinityTimeScale * 86400.0)
 
       k = 1  ! restoring only in top layer
-      do iCell=1,nCellsSolve
+      do iCell=1,nCells
         surfaceTracerFluxes(indexTFlux, iCell) = - temperatureLengthScale * (tracers(indexT, k, iCell) - temperatureRestoring(iCell)) * invTemp
         surfaceTracerFluxes(indexSFlux, iCell) = - salinityLengthScale * (tracers(indexS, k, iCell) - salinityRestoring(iCell)) * invSalinity
       enddo


### PR DESCRIPTION
Previously, surface tracer fluxes when performing a run with restoring
would only be computed over nCellsSolve. This meant cells outside of
nCellsSolve had a restoring flux of 0 instead of the correct flux for
their tracer values.

This merge changes restoring to compute fluxes over nCells to ensure
correct values are provided for all cells in a block.
