### PR TITLE
Fixing timer names in timer_stop calls

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_TEMPLATE.F
@@ -248,7 +248,7 @@ contains
 
       dminfo = domain % dminfo
 
-      call mpas_timer_start("compute_TEMPLATE", .false., am_TEMPLATETimer)
+      call mpas_timer_start("AM_TEMPLATE", .false., am_TEMPLATETimer)
 
       block => domain % blocklist
       do while (associated(block))
@@ -305,7 +305,7 @@ contains
          block => block % next
       end do
 
-      call mpas_timer_stop("TEMPLATE", am_TEMPLATETimer)
+      call mpas_timer_stop("AM_TEMPLATE", am_TEMPLATETimer)
 
    end subroutine ocn_compute_TEMPLATE!}}}
 

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -254,7 +254,7 @@ contains
 
       dminfo = domain % dminfo
 
-      call mpas_timer_start("compute_global_stats", .false., amGlobalStatsTimer)
+      call mpas_timer_start("AM_global_stats", .false., amGlobalStatsTimer)
 
       call mpas_pool_get_package(ocnPackages, 'thicknessFilterActive', thicknessFilterActive)
 
@@ -690,7 +690,7 @@ contains
       maxGlobalStats(1:nVariables) =  maxes(1:nVariables)
       sumGlobalStats(1:nVariables) =  sums(1:nVariables)
 
-      call mpas_timer_stop("global_stats", amGlobalStatsTimer)
+      call mpas_timer_stop("AM_global_stats", amGlobalStatsTimer)
 
    end subroutine ocn_compute_global_stats!}}}
 

--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -273,7 +273,7 @@ contains
       if ( .not. amLayerVolWeightedAvgPkgActive ) return
 
       ! start timer
-      call mpas_timer_start("compute_layer_volume_weighted_averages", .false., amLayerVolWeightedAvgTimer)
+      call mpas_timer_start("AM_layer_volume_weighted_averages", .false., amLayerVolWeightedAvgTimer)
 
       ! set highest level pointer
       dminfo = domain % dminfo
@@ -494,7 +494,7 @@ contains
       deallocate(workBufferMaxReduced)
 
       ! stop timer
-      call mpas_timer_stop("layer_volume_weighted_averages", amLayerVolWeightedAvgTimer)
+      call mpas_timer_stop("AM_layer_volume_weighted_averages", amLayerVolWeightedAvgTimer)
 
    contains
 

--- a/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -320,7 +320,7 @@ contains
       err = 0
       dminfo = domain % dminfo
 
-      call mpas_timer_start("compute_meridional_heat_transport", .false., MerHeatTransTimer)
+      call mpas_timer_start("AM_meridional_heat_transport", .false., MerHeatTransTimer)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'MerHeatTrans', MerHeatTransPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
@@ -460,7 +460,7 @@ contains
       deallocate(totalSumMerHeatTrans)
       deallocate(mht_meridional_integral)
 
-      call mpas_timer_stop("meridional_heat_transport", MerHeatTransTimer)
+      call mpas_timer_stop("AM_meridional_heat_transport", MerHeatTransTimer)
 
    end subroutine ocn_compute_meridional_heat_transport!}}}
 

--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -1535,7 +1535,7 @@ contains
       logical, pointer :: config_compute_OW_eddy_census
       real (kind=RKIND), pointer :: OW_normalization, Lam2_normalization, threshold
 
-      call mpas_timer_start("compute_okubo_weiss", .false., amOkuboWeissTimer)
+      call mpas_timer_start("AM_okubo_weiss", .false., amOkuboWeissTimer)
       err = 0
       dminfo = domain % dminfo
 
@@ -1618,7 +1618,7 @@ contains
          block => block % next
       end do
 
-      call mpas_timer_stop("compute_okubo_weiss", amOkuboWeissTimer)
+      call mpas_timer_stop("AM_okubo_weiss", amOkuboWeissTimer)
 
    end subroutine ocn_compute_okubo_weiss!}}}
 

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -293,7 +293,7 @@ contains
       call mpas_pool_get_package(ocnPackages, 'frazilIceActive', frazilIcePkgActive)
 
       ! start timer
-      call mpas_timer_start("compute_surface_area_weighted_averages", .false., amSfcAreaWeighedAvgTimer)
+      call mpas_timer_start("AM_surface_area_weighted_averages", .false., amSfcAreaWeighedAvgTimer)
 
       ! set highest level pointer
       dminfo = domain % dminfo
@@ -511,7 +511,7 @@ contains
       deallocate(workBufferMaxReduced)
 
       ! stop timer
-      call mpas_timer_stop("surface_area_weighted_averages", amSfcAreaWeighedAvgTimer)
+      call mpas_timer_stop("AM_surface_area_weighted_averages", amSfcAreaWeighedAvgTimer)
 
    contains
 

--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -265,7 +265,7 @@ contains
       if ( .not. amWaterMassCensusPkgActive ) return
 
       ! start timer
-      call mpas_timer_start("compute_water_mass_census", .false., amWaterMassCensusTimer)
+      call mpas_timer_start("AM_water_mass_census", .false., amWaterMassCensusTimer)
 
       ! set highest level pointer
       dminfo = domain % dminfo
@@ -471,7 +471,7 @@ contains
       deallocate(workMask)
 
       ! stop timer
-      call mpas_timer_stop("water_mass_census", amWaterMassCensusTimer)
+      call mpas_timer_stop("AM_water_mass_census", amWaterMassCensusTimer)
 
    contains
 

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -321,7 +321,7 @@ contains
       err = 0
       dminfo = domain % dminfo
 
-      call mpas_timer_start("compute_zonal_mean", .false., amZonalMeanTimer)
+      call mpas_timer_start("AM_zonal_mean", .false., amZonalMeanTimer)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'amZonalMean', amZonalMeanPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
@@ -462,7 +462,7 @@ contains
 
       deallocate(sumZonalMean,totalSumZonalMean,normZonalMean)
 
-      call mpas_timer_stop("zonal_mean", amZonalMeanTimer)
+      call mpas_timer_stop("AM_zonal_mean", amZonalMeanTimer)
 
    end subroutine ocn_compute_zonal_mean!}}}
 


### PR DESCRIPTION
In the analysis members and the TEMPLATE, the timer names in the
timer_stop calls were different than the timer names in the timer_start
calls. This can cause issues when trying to profile the code, in
addition to providing incorrect timer information.

This merge fixes the analysis members so the names in both calls are
the same.
