### PR TITLE
Adding attributes for periodic meshes

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -400,6 +400,9 @@ module mpas_subdriver
 
       call MPAS_stream_mgr_add_att(domain % streamManager, 'on_a_sphere', domain % on_a_sphere)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'sphere_radius', domain % sphere_radius)
+      call MPAS_stream_mgr_add_att(domain % streamManager, 'is_periodic', domain % is_periodic)
+      call MPAS_stream_mgr_add_att(domain % streamManager, 'x_period', domain % x_period)
+      call MPAS_stream_mgr_add_att(domain % streamManager, 'y_period', domain % y_period)
       ! DWJ 10/01/2014: Eventually add the real history attribute, for now (due to length restrictions)
       ! add a shortened version.
 !     call MPAS_stream_mgr_add_att(domain % streamManager, 'history', domain % history)

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -86,8 +86,8 @@ module mpas_bootstrapping
       integer :: ierr
       type (MPAS_IO_Handle_type) :: inputHandle
 
-      character (len=StrKIND) :: c_on_a_sphere
-      real (kind=RKIND) :: r_sphere_radius
+      character (len=StrKIND) :: c_on_a_sphere, c_is_periodic
+      real (kind=RKIND) :: r_sphere_radius, r_x_period, r_y_period
 
       type (field1dInteger), pointer :: indexToCellIDField
       type (field1dInteger), pointer :: indexToEdgeIDField
@@ -277,6 +277,45 @@ module mpas_bootstrapping
          domain % sphere_radius = 1.0
       else
          domain % sphere_radius = r_sphere_radius
+      end if
+
+      !
+      ! Get attributes based on planar mesh
+      !
+      if ( .not. domain % on_a_sphere ) then
+         call MPAS_io_get_att(inputHandle, 'is_periodic', c_is_periodic, ierr=ierr)
+         if ( ierr /= MPAS_IO_NOERR ) then
+            write(stderrUnit, *) 'Warning: is_periodic attribute not found in '//trim(mesh_filename)
+            write(stderrUnit, *) '   Setting is_periodic to .false.'
+            domain % is_periodic = .false.
+         else
+            if (index(c_is_periodic, 'YES') /= 0) then
+               domain % is_periodic = .true.
+            else
+               domain % is_periodic = .false.
+            end if
+         end if
+      else
+        domain % is_periodic = .false.
+      end if
+
+      if ( domain % is_periodic ) then
+         call MPAS_io_get_att(inputHandle, 'x_period', r_x_period, ierr=ierr)
+         if ( ierr /= MPAS_IO_NOERR ) then
+            call mpas_dmpar_global_abort('ERROR: Required attribute ''x_period'' missing from periodic input mesh. Exiting...')
+         else
+            domain % x_period = r_x_period
+         end if
+
+         call MPAS_io_get_att(inputHandle, 'y_period', r_y_period, ierr=ierr)
+         if ( ierr /= MPAS_IO_NOERR ) then
+            call mpas_dmpar_global_abort('ERROR: Required attribute ''y_period'' missing from periodic input mesh. Exiting...')
+         else
+            domain % y_period = r_y_period
+         end if
+      else
+         domain % x_period = 0
+         domain % y_period = 0
       end if
 
 

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -12,7 +12,10 @@
 
       ! Domain specific constants
       logical :: on_a_sphere
+      logical :: is_periodic
       real (kind=RKIND) :: sphere_radius
+      real (kind=RKIND) :: x_period
+      real (kind=RKIND) :: y_period
       character (len=StrKIND) :: namelist_filename !< Constant: Name of namelist file
       character (len=StrKIND) :: streams_filename !< Constant: Name of stream configuration file
       character (len=StrKIND) :: mesh_spec !< mesh_spec attribute, read in from input file.

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1596,6 +1596,9 @@ int parse_struct(FILE *fd, ezxml_t registry, ezxml_t superStruct, int subpool, c
 	fortprintf(fd, "      if (associated(newSubPool)) then\n");
 	fortprintf(fd, "         call mpas_pool_add_config(newSubPool, 'on_a_sphere', block %% domain %% on_a_sphere)\n");
 	fortprintf(fd, "         call mpas_pool_add_config(newSubPool, 'sphere_radius', block %% domain %% sphere_radius)\n");
+	fortprintf(fd, "         call mpas_pool_add_config(newSubPool, 'is_periodic', block %% domain %% is_periodic)\n");
+	fortprintf(fd, "         call mpas_pool_add_config(newSubPool, 'x_period', block %% domain %% x_period)\n");
+	fortprintf(fd, "         call mpas_pool_add_config(newSubPool, 'y_period', block %% domain %% y_period)\n");
 	fortprintf(fd, "      end if\n");
 	fortprintf(fd, "\n");
 


### PR DESCRIPTION
This merge adds reading of the following attributes which may be
required, if the input mesh is planar:
- is_periodic (Only read if on_a_sphere is .false.)
- x_period (Only read if is_periodic is .true.)
- y_period (Only read if is_periodic is .true.)
  
  These are defined in the mesh specification document to help deal with
  issues related to planar periodic meshes.
  
  NOTE: This merge will break support for older periodic meshes that do
  not contain these attributes. This only occurs in places where the
  attributes are used to fix periodic issues, which currently is no
  where, but when they are added they will not be able to work on older
  meshes.
