### PR TITLE
Read in a separate mesh stream upon start-up.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -833,8 +833,9 @@
 
 	<streams>
 		<stream name="mesh" 
-				type="none"
-				filename_template="mesh_variables.nc"
+				type="input"
+				filename_template="mesh.nc"
+				input_interval="initial_only"
 				immutable="true"
 				mode="forward;analysis">
 
@@ -880,6 +881,10 @@
 			<var name="bottomDepth"/>
 			<var name="maxLevelCell"/>
 			<var name="refBottomDepth"/>
+			<var name="restingThickness"/>
+			<var name="temperatureRestore"/>
+			<var name="salinityRestore"/>
+			<var name="surfaceWindStress"/>
 		</stream>
 		<stream name="input" 
 				type="input"
@@ -894,10 +899,6 @@
 			<var name="layerThickness"/>
 			<var name="highFreqThickness"/>
 			<var name="lowFreqDivergence"/>
-			<var name="temperatureRestore"/>
-			<var name="salinityRestore"/>
-			<var name="restingThickness"/>
-			<var name="surfaceWindStress"/>
 			<var name="seaSurfacePressure"/>
 		</stream>
 		<stream name="restart"
@@ -919,11 +920,7 @@
 			<var name="lowFreqDivergence"/>
 			<var name="normalBarotropicVelocity"/>
 			<var name="vertCoordMovementWeights"/>
-			<var name="temperatureRestore"/>
-			<var name="salinityRestore"/>
-			<var name="restingThickness"/>
 			<var name="xtime"/>
-			<var name="surfaceWindStress"/>
 			<var name="seaSurfacePressure"/>
 			<var name="boundaryLayerDepth"/>
 			<var_array name="tracersSurfaceValue"/>
@@ -1057,6 +1054,7 @@
 			<var name="velocityX"/>
 			<var name="velocityY"/>
 		</stream>
+
 		<stream name="forcing"
 				type="none"
 				filename_template="output/forcing_variables.$Y-$M-$D_$h.$m.$s.nc"

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -285,15 +285,7 @@ module ocn_core_interface
       call mpas_pool_get_config(configs, 'config_ocean_run_mode', config_ocean_run_mode)
 
       if ( trim(config_ocean_run_mode) == 'forward' .or. trim(config_ocean_run_mode) == 'analysis' ) then
-         call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
-
-         if (.not. associated(config_do_restart)) then
-            ierr = 1
-         else if (config_do_restart) then
-            write(stream,'(a)') 'restart'
-         else
-            write(stream,'(a)') 'input'
-         end if
+         write(stream,'(a)') 'mesh'
       end if
 
    end function ocn_get_mesh_stream!}}}

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -92,6 +92,7 @@ module ocn_analysis_mode
       ! Read input data for model
       !
       call mpas_timer_start('io_read', .false.)
+      call MPAS_stream_mgr_read(domain % streamManager, streamID='mesh', whence=MPAS_STREAM_NEAREST, ierr=err_tmp)
       call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
       call mpas_timer_stop('io_read')
       call mpas_timer_start('io_reset_alarms', .false.)

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -139,15 +139,14 @@ module ocn_forward_mode
       !
       ! Read input data for model
       !
+      call mpas_timer_start('io_read', .false.)
+      call MPAS_stream_mgr_read(domain % streamManager, streamID='mesh', whence=MPAS_STREAM_NEAREST, ierr=err_tmp)
       if ( config_do_restart ) then
-         call mpas_timer_start('io_read', .false.)
          call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=err_tmp)
-         call mpas_timer_stop('io_read')
       else
-         call mpas_timer_start('io_read', .false.)
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
-         call mpas_timer_stop('io_read')
       end if
+      call mpas_timer_stop('io_read')
       call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='input', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)


### PR DESCRIPTION
Separates mesh variables from restart or init, so that we may write smaller restart files and avoid some i/o problems.  This requires that users either:
1. point filename_template="mesh.nc" to a valid init or restart file with mesh variables, or
2. add a soft link from a valid init or restart file to mesh.nc.

We expect this to be a b-f-b change.  I tested on 240km global, was b-f-b.  This PR is needed to use ocean/develop for RRS 15-5km spin-up.
