### PR TITLE
Fixing a bug related to 1D arrays of dimensions

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -4790,7 +4790,7 @@ module mpas_pool_routines
 
       allocate(newmem % data)
       newmem % data % contentsType = MPAS_POOL_INTEGER
-      newmem % data % contentsDims = size(dims)
+      newmem % data % contentsDims = 1
       newmem % data % contentsTimeLevs = 0
       allocate(newmem % data % simple_int_arr(newmem % data % contentsDims))
       newmem % data % simple_int_arr(:) = dims(:)


### PR DESCRIPTION
This merge fixes a bug that prevented getting a 1D array of dimensions
out of a pool. Previously, the contentsDim attribute of the dimension
member within the pool was given a value equal to the size of the array
passed in. When getting an array of dimensions out of a pool, an error
was thrown if the contentsDim attribute did not have a value of 1. This
prevented the array from ever being returned.

This merge sets contentsDim to 1 for all 1D arrays of dimensions that
are added to pools.
