### PR TITLE
Addition of data structures for a particle list type

### DIFF
--- a/src/framework/mpas_block_types.inc
+++ b/src/framework/mpas_block_types.inc
@@ -21,13 +21,32 @@
       integer :: blockID   ! Unique global ID number for this block
       integer :: localBlockID  ! Unique local ID number for this block
 
+      ! Pointer to domain that owns the block
       type (domain_type), pointer :: domain
 
+      ! Data structures for exchange lists for a block (exchanging standard fields)
       type (parallel_info), pointer :: parinfo
 
+      ! Linked list pointers
       type (block_type), pointer :: prev => null()
       type (block_type), pointer :: next => null()
 
+      ! Data structures for core specific data
       type (mpas_pool_type), pointer :: structs, dimensions, configs, packages
+
+      ! Data structures for IO infrastructure
       type (mpas_pool_type), pointer :: allFields, allStructs
+
+      ! Data types for particle lists {{{
+
+      ! Define the particle list on a block
+      type (mpas_particle_list_type), pointer :: particlelist => null()
+
+      ! Define the list of neighboring blocks on a block, for exchanging particles
+      integer, dimension(:), pointer :: blockNeighs => null()
+      ! Define the list of neighboring processors on a block, for exchanging particles
+      integer, dimension(:), pointer :: procNeighs => null()
+
+      !}}}
+
    end type block_type

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -42,6 +42,8 @@ module mpas_derived_types
 
 #include "mpas_pool_types.inc"
 
+#include "mpas_particle_list_types.inc"
+
 #include "mpas_io_types.inc"
 
 #include "mpas_io_streams_types.inc"

--- a/src/framework/mpas_particle_list_types.inc
+++ b/src/framework/mpas_particle_list_types.inc
@@ -1,0 +1,24 @@
+    ! main particle type (used by particle_framework)
+    type mpas_particle_type
+       ! IO block number
+       !integer :: ioBlock = 0
+       ! pool containing particle data needed for communication
+       ! between computational cells
+       type (mpas_pool_type), pointer :: haloDataPool => NULL()
+       ! pool containing particle data not needing to be passed
+       ! between processors
+       type (mpas_pool_type), pointer :: nonhaloDataPool => NULL()
+    end type mpas_particle_type
+
+    ! just a list of particles (main unit that code operates on)
+    type mpas_particle_list_type
+       type (mpas_particle_type), pointer :: particle => NULL()
+       ! next item in the list
+       type (mpas_particle_list_type), pointer :: next => NULL()
+       ! previous item in the list
+       type (mpas_particle_list_type), pointer :: prev => NULL()
+    end type mpas_particle_list_type
+
+    type mpas_list_of_particle_list_type
+       type (mpas_particle_list_type), pointer :: list => NULL()
+    end type mpas_list_of_particle_list_type


### PR DESCRIPTION
This pull request adds the data structures that define a particle list. The infrastructure for manipulating a particle list is omitted from the pull request, as it lives within a core for now.
