### PR TITLE
Fixing a bug related to adding 1D dimensions into a pool

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -4792,7 +4792,7 @@ module mpas_pool_routines
       newmem % data % contentsType = MPAS_POOL_INTEGER
       newmem % data % contentsDims = 1
       newmem % data % contentsTimeLevs = 0
-      allocate(newmem % data % simple_int_arr(newmem % data % contentsDims))
+      allocate(newmem % data % simple_int_arr(size(dims)))
       newmem % data % simple_int_arr(:) = dims(:)
    
       if (.not. pool_add_member(inPool, key, newmem)) then


### PR DESCRIPTION
This merge fixes a bug that prevents 1D dimensions from being added
into a pool.

Previously, contentsDim prevented a 1D dimension array from being
accessed inside of a pool, however the routine to add a 1D dimension
array into a pool only allocated an array as large as contentsDim. The
previous commit set this to 1, instead of `size(dims)`, which causes a
segfault in some situations when copying the values from dims into the
new array.
