### PR TITLE
Update build_options.mk for use in standalone or ACME

### DIFF
--- a/src/core_landice/build_options.mk
+++ b/src/core_landice/build_options.mk
@@ -1,6 +1,9 @@
-PWD=$(shell pwd)
+ifeq "$(ROOT_DIR)" ""
+        ROOT_DIR=$(shell pwd)/src
+endif
 EXE_NAME=landice_model
 NAMELIST_SUFFIX=landice
+FCINCLUDES += -I$(ROOT_DIR)/core_landice
 override CPPFLAGS += -DCORE_LANDICE
 
 report_builds:


### PR DESCRIPTION
The root directory for the list of include paths needs to be generalized for MPAS-LI to build in either standalone mode or within ACME.  This change does that.
