### PR TITLE
Use testing core with pre-existing unit tests 

### DIFF
--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -74,6 +74,7 @@ module test_core
       use mpas_derived_types
       use mpas_kind_types
       use mpas_timer
+      use mpas_geometry_utils
    
       implicit none
    
@@ -85,6 +86,11 @@ module test_core
 
 
       iErr = 0
+
+
+      call mpas_unit_test_in_triangle(iErr)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', pool)
+      call mpas_unit_test_bary_weights(pool, iErr)
 
    end function test_core_run!}}}
 

--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -838,17 +838,17 @@ module mpas_geometry_utils
       point2 = (/ -0.01, 0.5, 0.0 /)
 
       if (.not. mpas_point_in_polygon(point1, trianglePoints, .false.)) then
-         write(stderrUnit,*) 'Error in mpas_unit_test_in_triangle: point1 calculated to be outside of triangle.'
+         write(stderrUnit,*) 'Error in mpas_unit_test_in_triangle: point1 calculated to be outside of triangle -- FAILED.'
          ierr = 1
       else
-         write(stdoutUnit,*) 'mpas_unit_test_in_triangle: point1 test - SUCCESS'
+         write(stderrUnit,*) 'mpas_unit_test_in_triangle: point1 test - SUCCESS'
       endif
 
       if (mpas_point_in_polygon(point2, trianglePoints, .false.)) then
-         write(stderrUnit,*) 'Error in mpas_unit_test_in_triangle: point2 calculated to be inside of triangle.'
+         write(stderrUnit,*) 'Error in mpas_unit_test_in_triangle: point2 calculated to be inside of triangle -- FAILED.'
          ierr = 1
       else
-         write(stdoutUnit,*) 'mpas_unit_test_in_triangle: point2 test - SUCCESS'
+         write(stderrUnit,*) 'mpas_unit_test_in_triangle: point2 test - SUCCESS'
       endif
 
    end subroutine mpas_unit_test_in_triangle !}}}
@@ -899,19 +899,19 @@ module mpas_geometry_utils
       call mpas_calculate_barycentric_weights(point1, trianglePoints(1,:), trianglePoints(2,:), trianglePoints(3,:), meshPool,     &
              weights(1), weights(2), weights(3), ierr)
       if (maxval(abs(weights - (/ 0.33333333333333333, 0.33333333333333333, 0.33333333333333333 /) )) > eps) then
-         write(stderrUnit,*) 'Error in mpas_unit_test_bary_weights: point1 weights have error greater than tolerance.'
+         write(stderrUnit,*) 'Error in mpas_unit_test_bary_weights: point1 weights have error greater than tolerance -- FAILED.'
          ierr = 1
       else
-         write(stdoutUnit,*) 'mpas_unit_test_bary_weights: point1 test - SUCCESS'
+         write(stderrUnit,*) 'mpas_unit_test_bary_weights: point1 test - SUCCESS'
       endif
 
       call mpas_calculate_barycentric_weights(point2, trianglePoints(1,:), trianglePoints(2,:), trianglePoints(3,:), meshPool,     &
              weights(1), weights(2), weights(3), ierr)
       if (maxval(abs(weights - (/ 1.0, 0.0, 0.0 /) )) > eps) then
-         write(stderrUnit,*) 'Error in mpas_unit_test_bary_weights: point1 weights have error greater than tolerance.'
+         write(stderrUnit,*) 'Error in mpas_unit_test_bary_weights: point1 weights have error greater than tolerance -- FAILED.'
          ierr = 1
       else
-         write(stdoutUnit,*) 'mpas_unit_test_bary_weights: point2 test - SUCCESS'
+         write(stderrUnit,*) 'mpas_unit_test_bary_weights: point2 test - SUCCESS'
       endif
 
    end subroutine mpas_unit_test_bary_weights !}}}


### PR DESCRIPTION
Now testing for
    + mpas_unit_test_in_triangle
    + mpas_unit_test_bary_weights

Minor edits to test cases

```
+ Added FAILED flag to other unit tests to allow for easy greping for failed tests.
+ Added calls in testing core to existing unit tests.
```

See discussion from pull request #464 with @mgduda, @douglasjacobsen, and @matthewhoffman .
