### PR TITLE
Add a call to ocn_analysis_restart in the forward mode

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -456,6 +456,7 @@ module ocn_forward_mode
          end do
 
          call ocn_analysis_compute(domain, err) 
+         call ocn_analysis_restart(domain, err) 
          call ocn_analysis_write(domain, err)
 
          call mpas_timer_start('io_write', .false.)


### PR DESCRIPTION
This merge adds a call to ocn_analysis_restart after
ocn_analysis_compute but before ocn_analysis_write. This allows an
analysis member to ensure that it's data is correct before writing it
out for a restart file.
