### PR TITLE
Remove write statements from analysis member

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -429,20 +429,17 @@ contains
       do iCell=1,nCellsSolve
         if(latCell(iCell).lt. 60.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Arctic ', sum(workMask)
    elseif (iRegion.eq.2) then
       ! Equatorial
       do iCell=1,nCellsSolve
         if(latCell(iCell).gt. 15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
         if(latCell(iCell).lt.-15.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Equatorial ', sum(workMask)
    elseif (iRegion.eq.3) then
       ! Southern Ocean
       do iCell=1,nCellsSolve
         if(latCell(iCell).gt.-50.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Southern Ocean ', sum(workMask)
    elseif (iRegion.eq.4) then
       ! Nino 3
       do iCell=1,nCellsSolve
@@ -451,7 +448,6 @@ contains
         if(lonCell(iCell).lt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
         if(lonCell(iCell).gt.270.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Nino 3 ', sum(workMask)
    elseif (iRegion.eq.5) then
       ! Nino 4
       do iCell=1,nCellsSolve
@@ -460,7 +456,6 @@ contains
         if(lonCell(iCell).lt.160.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
         if(lonCell(iCell).gt.210.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Nino 4 ', sum(workMask)
    elseif (iRegion.eq.6) then
       ! Nino 3.4
       do iCell=1,nCellsSolve
@@ -469,10 +464,8 @@ contains
         if(lonCell(iCell).lt.190.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
         if(lonCell(iCell).gt.240.0_RKIND*dtr) workMask(iCell) = 0.0_RKIND
       enddo
-      write(6,*) ' Nino 3.4 ', sum(workMask)
    else
       ! global (do nothing!)
-      write(6,*) ' Global ', sum(workMask)
    endif
 
    end subroutine compute_mask


### PR DESCRIPTION
Currently, the water mass census analysis member prints unneeded debug statements to the log*out files on every compute call.

This PR removes those print statements.
