### PR TITLE
Add flag to read from nearest restart record.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -857,6 +857,10 @@
 					description="Disables tendencies on the tracer fields from CVMix/KPP nonlocal fluxes."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_read_nearest_restart" type="logical" default_value=".false." units="unitless"  mode="forward"
+					description="This flag is intended for the expert user.  If false, forward model will error out if time given by config_start_time (or Restart_timestamp file if config_start_time='file') does not match any xtime strings in the restart file.  If true, forward model will read in record with xtime nearest to config_start_time.  Note that the restart file name is still given by config_start_time (or Restart_timestamp file), regardless of the state of this flag."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<packages>
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -113,7 +113,7 @@ module ocn_forward_mode
       type (MPAS_Time_Type) :: startTime
       type (MPAS_TimeInterval_type) :: timeStep
 
-      logical, pointer :: config_do_restart, config_filter_btr_mode, config_conduct_tests
+      logical, pointer :: config_do_restart, config_read_nearest_restart, config_filter_btr_mode, config_conduct_tests
       character (len=StrKIND), pointer :: config_vert_coord_movement, config_pressure_gradient_type
       real (kind=RKIND), pointer :: config_maxMeshDensity
 
@@ -130,6 +130,7 @@ module ocn_forward_mode
       call ocn_constants_init(domain % configs, domain % packages)
 
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
+      call mpas_pool_get_config(domain % configs, 'config_read_nearest_restart', config_read_nearest_restart)
       call mpas_pool_get_config(domain % configs, 'config_vert_coord_movement', config_vert_coord_movement)
       call mpas_pool_get_config(domain % configs, 'config_pressure_gradient_type', config_pressure_gradient_type)
       call mpas_pool_get_config(domain % configs, 'config_filter_btr_mode', config_filter_btr_mode)
@@ -142,7 +143,11 @@ module ocn_forward_mode
       call mpas_timer_start('io_read', .false.)
       call MPAS_stream_mgr_read(domain % streamManager, streamID='mesh', whence=MPAS_STREAM_NEAREST, ierr=err_tmp)
       if ( config_do_restart ) then
-         call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=err_tmp)
+         if ( config_read_nearest_restart ) then
+            call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', whence=MPAS_STREAM_NEAREST, ierr=err_tmp)
+         else
+            call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=err_tmp)
+         end if
       else
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
       end if


### PR DESCRIPTION
In some situations, the user may want to use a restart record where the xtime entry does not match the file name.  This occurred on mustang and wolf, where xtime is often written incorrectly to restart files.

This PR adds a debug flag that allows the restart stream to read the restart record with the time nearest to the requested time.
