### PR TITLE
Correct global init bug in refBottomDepth

### DIFF
--- a/src/core_ocean/mode_init/Registry_global_realistic.xml
+++ b/src/core_ocean/mode_init/Registry_global_realistic.xml
@@ -12,7 +12,7 @@
 					possible_values="Dim name from input files."
 		/>
 		<nml_option name="config_global_realistic_depth_varname" type="character" default_value="none" units="unitless"
-					description="Name of the variable containing depth levels in temperature and salinity initial condition files."
+					description="Name of the variable containing mid-depth of levels in temperature and salinity initial condition files."
 					possible_values="Variable name from input files."
 		/>
 		<nml_option name="config_global_realistic_depth_conversion_factor" type="real" default_value="1.0" units="variable"

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_realistic.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_realistic.F
@@ -714,7 +714,11 @@ contains
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
 
          call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-         refBottomDepth(:) = depthIC % array(:)
+         ! depthIC is the mid-depth of each layer.  Convert to bottom depth.
+         refBottomDepth(1) = 2.0 * depthIC % array(1)
+         do k=2,nDepth
+            refBottomDepth(k) = refBottomDepth(k-1) + 2*(depthIC % array(k) - refBottomDepth(k-1))
+         enddo
 
          block_ptr => block_ptr % next
        end do


### PR DESCRIPTION
Previously, refBottomDepth was initialized incorrectly, resulting in
incorrect layerThickness.  The input file variable
  config_global_realistic_depth_varname
is the mid-depth of the layers.  The init core had treated these
as the bottom-depth.

This revision fixes this problem, so that refBottomDepth is correct.
