### PR TITLE
Allow vector reconstruciton to provide reproducibile results

### DIFF
--- a/src/operators/mpas_vector_reconstruction.F
+++ b/src/operators/mpas_vector_reconstruction.F
@@ -48,15 +48,17 @@ module mpas_vector_reconstruction
 !>  Output: grid % coeffs_reconstruct - coefficients used to reconstruct 
 !>                                      velocity vectors at cell centers 
 !-----------------------------------------------------------------------
-  subroutine mpas_init_reconstruct(meshPool)!{{{
+  subroutine mpas_init_reconstruct(meshPool, includeHalos)!{{{
 
     implicit none
 
     type (mpas_pool_type), intent(in) :: &
          meshPool         !< Input: Mesh information
 
+    logical, optional, intent(in) :: includeHalos
+
     ! temporary arrays needed in the (to be constructed) init procedure
-    integer, pointer :: nCellsSolve
+    integer, pointer :: nCells
     integer, dimension(:,:), pointer :: edgesOnCell
     integer, dimension(:), pointer :: nEdgesOnCell
     integer :: i, iCell, iEdge, pointCount, maxEdgeCount
@@ -68,6 +70,14 @@ module mpas_vector_reconstruction
     real(kind=RKIND), dimension(:,:,:), pointer :: cellTangentPlane
 
     real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct
+
+    logical :: includeHalosLocal
+
+    if ( present(includeHalos) ) then
+       includeHalosLocal = includeHalos
+    else
+       includeHalosLocal = .false.
+    end if
 
     !========================================================
     ! arrays filled and saved during init procedure
@@ -88,7 +98,11 @@ module mpas_vector_reconstruction
     call mpas_pool_get_array(meshPool, 'edgeNormalVectors', edgeNormalVectors)
     call mpas_pool_get_array(meshPool, 'cellTangentPlane', cellTangentPlane)
 
-    call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+    if ( includeHalosLocal ) then
+       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+    else
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCells)
+    end if
 
     ! init arrays
     coeffs_reconstruct = 0.0
@@ -100,7 +114,7 @@ module mpas_vector_reconstruction
     allocate(coeffs(maxEdgeCount,3))
 
     ! loop over all cells to be solved on this block
-    do iCell=1,nCellsSolve
+    do iCell=1,nCells
       pointCount = nEdgesOnCell(iCell)
       cellCenter(1) = xCell(iCell)
       cellCenter(2) = yCell(iCell)
@@ -166,7 +180,7 @@ module mpas_vector_reconstruction
 !>  Input: grid meta data and vector component data residing at cell edges
 !>  Output: reconstructed vector field (measured in X,Y,Z) located at cell centers
 !-----------------------------------------------------------------------
-  subroutine mpas_reconstruct_2d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional)!{{{
+  subroutine mpas_reconstruct_2d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
 
     implicit none
 
@@ -177,9 +191,11 @@ module mpas_vector_reconstruction
     real (kind=RKIND), dimension(:,:), intent(out) :: uReconstructZ !< Output: Z Component of velocity reconstructed to cell centers
     real (kind=RKIND), dimension(:,:), intent(out) :: uReconstructZonal !< Output: Zonal Component of velocity reconstructed to cell centers
     real (kind=RKIND), dimension(:,:), intent(out) :: uReconstructMeridional !< Output: Meridional Component of velocity reconstructed to cell centers
+    logical, optional, intent(in) :: includeHalos !< Input: Optional logical that allows reconstruction over halo regions
 
     !   temporary arrays needed in the compute procedure
-    integer, pointer :: nCellsSolve
+    logical :: includeHalosLocal
+    integer, pointer :: nCells
     integer, dimension(:,:), pointer :: edgesOnCell
     integer, dimension(:), pointer :: nEdgesOnCell
     integer :: iCell,iEdge, i
@@ -191,6 +207,11 @@ module mpas_vector_reconstruction
 
     real (kind=RKIND) :: clat, slat, clon, slon
 
+    if ( present(includeHalos) ) then
+       includeHalosLocal = includeHalos
+    else
+       includeHalosLocal = .false.
+    end if
 
     ! stored arrays used during compute procedure
     call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', coeffs_reconstruct)
@@ -198,7 +219,12 @@ module mpas_vector_reconstruction
     ! temporary variables
     call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
     call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-    call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+    if ( includeHalosLocal ) then
+       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+    else
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCells)
+    end if
 
     call mpas_pool_get_array(meshPool, 'latCell', latCell)
     call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
@@ -211,7 +237,7 @@ module mpas_vector_reconstruction
     uReconstructZ = 0.0
 
     ! loop over cell centers
-    do iCell = 1, nCellsSolve
+    do iCell = 1, nCells
       ! a more efficient reconstruction where rbf_values*matrix_reconstruct has been precomputed
       ! in coeffs_reconstruct
       do i=1,nEdgesOnCell(iCell)
@@ -227,7 +253,7 @@ module mpas_vector_reconstruction
     enddo   ! iCell
 
     if (on_a_sphere) then
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
         clat = cos(latCell(iCell))
         slat = sin(latCell(iCell))
         clon = cos(lonCell(iCell))
@@ -257,7 +283,7 @@ module mpas_vector_reconstruction
 !>  Input: grid meta data and vector component data residing at cell edges
 !>  Output: reconstructed vector field (measured in X,Y,Z) located at cell centers
 !-----------------------------------------------------------------------
-  subroutine mpas_reconstruct_1d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional)!{{{
+  subroutine mpas_reconstruct_1d(meshPool, u, uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
 
     implicit none
 
@@ -268,9 +294,10 @@ module mpas_vector_reconstruction
     real (kind=RKIND), dimension(:), intent(out) :: uReconstructZ !< Output: Z Component of velocity reconstructed to cell centers
     real (kind=RKIND), dimension(:), intent(out) :: uReconstructZonal !< Output: Zonal Component of velocity reconstructed to cell centers
     real (kind=RKIND), dimension(:), intent(out) :: uReconstructMeridional !< Output: Meridional Component of velocity reconstructed to cell centers
+    logical, optional, intent(in) :: includeHalos !< Input: Logical flag that allows reconstructing over halo regions
 
     !   temporary arrays needed in the compute procedure
-    integer, pointer :: nCellsSolve
+    integer, pointer :: nCells
     integer, dimension(:,:), pointer :: edgesOnCell
     integer, dimension(:), pointer :: nEdgesOnCell
     integer :: iCell,iEdge, i
@@ -279,9 +306,15 @@ module mpas_vector_reconstruction
     real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct
 
     logical, pointer :: on_a_sphere
+    logical :: includeHalosLocal
 
     real (kind=RKIND) :: clat, slat, clon, slon
 
+    if ( present(includeHalos) ) then
+       includeHalosLocal = includeHalos
+    else
+       includeHalosLocal = .false.
+    end if
 
     ! stored arrays used during compute procedure
     call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', coeffs_reconstruct)
@@ -289,7 +322,12 @@ module mpas_vector_reconstruction
     ! temporary variables
     call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
     call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-    call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+    if ( includeHalosLocal ) then
+       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+    else
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCells)
+    end if
 
     call mpas_pool_get_array(meshPool, 'latCell', latCell)
     call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
@@ -302,7 +340,7 @@ module mpas_vector_reconstruction
     uReconstructZ = 0.0
 
     ! loop over cell centers
-    do iCell = 1, nCellsSolve
+    do iCell = 1, nCells
       ! a more efficient reconstruction where rbf_values*matrix_reconstruct has been precomputed
       ! in coeffs_reconstruct
       do i=1,nEdgesOnCell(iCell)
@@ -318,7 +356,7 @@ module mpas_vector_reconstruction
     enddo   ! iCell
 
     if (on_a_sphere) then
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
         clat = cos(latCell(iCell))
         slat = sin(latCell(iCell))
         clon = cos(lonCell(iCell))


### PR DESCRIPTION
Previously, the vector reconstruction routines would only perform
reconstruction over owned cells within a block. This merge allows an
optional argument that can be used to reconstruct over all elements
within a block.

If the old version of vector reconstruction was used for anything where
the reconstructed fields were used, they needed a a halo exchange to be
correct over the full block. This merge also allows the removal of
these halo exchanges.
