### PR TITLE
Ensure gradSSH is computed over all owned edges

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -658,7 +658,7 @@ contains
         call computeKPPInputFields(statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, timeLevel)
       endif
 
-      do iEdge = 1, nEdgesSolve
+      do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
 


### PR DESCRIPTION
This merge ensures that gradSSH is computed over all owned edges. Later
we use the RBF routines to reconstruct cell centered SSH gradient
values. Owned cells that have non-owned edges will end up having the
wrong value without this change, resulting in incorrect fields from a
coupler that depend on grad SSH.
