### PR TITLE
Changing the default pool error behavior back to warn

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -84,7 +84,6 @@ module mpas_framework
 
 #ifdef MPAS_DEBUG
       call mpas_pool_set_error_level(MPAS_POOL_WARN)
-      call mpas_pool_set_error_level(MPAS_POOL_FATAL)
 #endif
 
       call mpas_pool_get_config(domain % configs, 'config_calendar_type', config_calendar_type)


### PR DESCRIPTION
Previously the default for pool errors when in debug mode was to throw
warnings. This was accidently changed to throw fatal errors when
generalizing the MPAS framework.

This merge changes the default back to warnings.
