### PR TITLE
Correct a logic error when setting the edge normal vectors for periodic meshes

### DIFF
--- a/src/operators/mpas_vector_operations.F
+++ b/src/operators/mpas_vector_operations.F
@@ -723,15 +723,15 @@ contains
           edgeNormalVectors(3,iEdge) = zEdge(iEdge) - zCell(cell2)
         end if
 
-      elseif (cell2 == nCells+1) then ! this is a boundary edge
+      else if (cell2 == nCells+1) then ! this is a boundary edge
         ! the normal points from the cell location to the edge location
         if (is_periodic) then
-          edgeNormalVectors(1,iEdge) = xEdge(iEdge) - xCell(cell1)
-          edgeNormalVectors(2,iEdge) = yEdge(iEdge) - yCell(cell1)
-          edgeNormalVectors(3,iEdge) = zEdge(iEdge) - zCell(cell1)
-        else
           edgeNormalVectors(1,iEdge) = mpas_fix_periodicity(xEdge(iEdge), xCell(cell1), x_period) - xCell(cell1)
           edgeNormalVectors(2,iEdge) = mpas_fix_periodicity(yEdge(iEdge), yCell(cell1), y_period) - yCell(cell1)
+          edgeNormalVectors(3,iEdge) = zEdge(iEdge) - zCell(cell1)
+        else
+          edgeNormalVectors(1,iEdge) = xEdge(iEdge) - xCell(cell1)
+          edgeNormalVectors(2,iEdge) = yEdge(iEdge) - yCell(cell1)
           edgeNormalVectors(3,iEdge) = zEdge(iEdge) - zCell(cell1)
         end if
 
@@ -748,7 +748,7 @@ contains
           edgeNormalVectors(3,iEdge) = zCell(cell2) - zCell(cell1)
         end if
 
-      endif
+      end if
       call mpas_unit_vec_in_r3(edgeNormalVectors(:,iEdge))
     end do
 


### PR DESCRIPTION
The routine mpas_initialize_vectors() contained incorrect logic to fix the edge normal vector 
for boundary cells on non-periodic meshes, rather than periodic meshes, in one of the two cases
where this is done in the routine. This merge corrects the logic so that the edge normal vector 
is modified for periodic meshes as intended.
