### PR TITLE
Update framework build dependencies

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -1,6 +1,7 @@
 .SUFFIXES: .F .c .o
 
 DEPS := $(shell find ../core_$(CORE)/ -type f -name "*.xml" ! -name "*processed.xml")
+TYPE_DEPS := $(shell find . -type f -name "*_types.inc")
 
 OBJS = mpas_kind_types.o \
        mpas_framework.o \
@@ -52,11 +53,11 @@ mpas_constants.o: mpas_kind_types.o
 
 mpas_attlist.o: mpas_kind_types.o mpas_io_units.o mpas_derived_types.o
 
-mpas_derived_types.o: mpas_kind_types.o mpas_constants.o
+mpas_derived_types.o: mpas_kind_types.o mpas_constants.o $(TYPE_DEPS)
 
 mpas_domain_routines.o: mpas_derived_types.o mpas_pool_routines.o
 
-mpas_field_routines.o: mpas_derived_types.o
+mpas_field_routines.o: mpas_derived_types.o duplicate_field_array.inc duplicate_field_scalar.inc
 
 mpas_pool_routines.o: mpas_derived_types.o mpas_field_routines.o mpas_dmpar.o
 
@@ -78,7 +79,7 @@ mpas_block_creator.o: mpas_dmpar.o mpas_hash.o mpas_sort.o mpas_io_units.o mpas_
 
 mpas_io.o: mpas_dmpar.o mpas_io_units.o mpas_attlist.o
 
-mpas_io_streams.o: mpas_attlist.o mpas_derived_types.o mpas_timekeeping.o mpas_io.o mpas_io_units.o mpas_pool_routines.o $(DEPS)
+mpas_io_streams.o: mpas_attlist.o mpas_derived_types.o mpas_timekeeping.o mpas_io.o mpas_io_units.o mpas_pool_routines.o add_field_indices.inc $(DEPS)
 
 mpas_bootstrapping.o: mpas_derived_types.o mpas_dmpar.o mpas_block_decomp.o mpas_block_creator.o mpas_sort.o mpas_timekeeping.o mpas_io_streams.o mpas_io_units.o mpas_stream_manager.o random_id.o $(DEPS)
 


### PR DESCRIPTION
This merge updates the build dependencies for framework to include
dependencies related to derived types, and included files.

Previously, the derived type dependencies would not force a rebuild
when any of the *_type.inc files were modified.
