### PR TITLE
Fix a missing deallocate in ocean init routines

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -501,7 +501,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
                enddo
 
-               deallocate(minBottomDepth,zMidZLevel)
+               deallocate(minBottomDepth,minBottomDepthMid,zMidZLevel)
 
             elseif (config_pbc_alteration_type .eq. 'full_cell') then
 


### PR DESCRIPTION
This merge adds a missing deallocate within the ocean init routines. It is
needed when running with multiple blocks, but in general prevents a small
memory leak.
