### PR TITLE
Add kind definition to some reals

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_global_realistic.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_realistic.F
@@ -470,7 +470,7 @@ contains
 
        type (field1DInteger), pointer :: cullStackField, touchedCellField, oceanCellField
 
-       real, dimension(:), pointer :: latCell, lonCell, bottomDepth
+       real (kind=RKIND), dimension(:), pointer :: latCell, lonCell, bottomDepth
        integer, dimension(:), pointer :: stack, oceanMask, touchMask
        integer, pointer :: stackSize
 


### PR DESCRIPTION
This merge adds a kind type definition to three real pointers in the
global_realistic configuration init module. Previously, they were
missing the kind type definition, would would cause some compilers to
fail to build as pool routines (such as get_array) were not built for
the same type.
