### PR TITLE
Cleanup some timers in MPAS-O

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -663,7 +663,7 @@ contains
       call mpas_timer_start("CC eddy stats", .false., CCStatsTimer)
       call ocn_compute_eddy_stats(dminfo, block, nVertLevels, nCells, nCellsSolve, nLocalCCs, &
                                   nEdgesOnCell, cellsOnCell, OW_cc_id, OW_thresh)
-      call mpas_timer_stop("CC local", CCStatsTimer)
+      call mpas_timer_stop("CC eddy stats", CCStatsTimer)
 
    end subroutine ocn_compute_OW_component_IDs!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -499,8 +499,6 @@ contains
       real (KIND=RKIND) :: m
       integer i
 
-      call mpas_timer_start("tridiagonal_solve")
-      
       ! Use work variables for b and r
       bTemp(1) = b(1)
       rTemp(1) = r(1)
@@ -518,8 +516,6 @@ contains
          x(i) = (rTemp(i) - c(i)*x(i+1))/bTemp(i)
       end do
 
-      call mpas_timer_stop("tridiagonal_solve")
-      
    end subroutine tridiagonal_solve !}}}
 
 !***********************************************************************


### PR DESCRIPTION
Okubo weiss has timers with mismatched names, and GM has timers within a
tridiagonal solve. This merge fixes these issues.
