### PR TITLE
Ensure garbage elements are giving a global index of 0

### DIFF
--- a/src/framework/mpas_block_creator.F
+++ b/src/framework/mpas_block_creator.F
@@ -1074,6 +1074,7 @@ module mpas_block_creator
        nullify(indexToCellIDPoolField % recvList)
        nullify(indexToCellIDPoolField % copyList)
        allocate(indexToCellIDPoolField % array(nCells+1))
+       indexToCellIDPoolField % array(nCells+1) = 0
 
        call mpas_pool_add_field(block_ptr % allFields, 'indexToCellID_blk', indexToCellIDPoolField)
 
@@ -1093,6 +1094,7 @@ module mpas_block_creator
        nullify(indexToEdgeIDPoolField % recvList)
        nullify(indexToEdgeIDPoolField % copyList)
        allocate(indexToEdgeIDPoolField % array(nEdges+1))
+       indexToEdgeIDPoolField % array(nEdges+1) = 0
 
        call mpas_pool_add_field(block_ptr % allFields, 'indexToEdgeID_blk', indexToEdgeIDPoolField)
 
@@ -1113,6 +1115,7 @@ module mpas_block_creator
        nullify(indexToVertexIDPoolField % recvList)
        nullify(indexToVertexIDPoolField % copyList)
        allocate(indexToVertexIDPoolField % array(nVertices+1))
+       indexToVertexIDPoolField % array(nVertices+1) = 0
 
        call mpas_pool_add_field(block_ptr % allFields, 'indexToVertexID_blk', indexToVertexIDPoolField)
 


### PR DESCRIPTION
Previously the garbage elements (cells, edges, and vertices) were not
initialized to zero. This caused some runs to have the garbage elements
be filled with large integer values, and visualization tools would be
unable to read the connectivity information.

When remapping the connectivity fields (prior to writing out mesh
information) the garbage elements (i.e. anything that had a missing
element) could be filled with a large value breaking the output mesh.
