### PR TITLE
Remove defunct analysis member variables and calls

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -247,15 +247,11 @@ contains
 
       real (kind=RKIND), dimension(:,:), allocatable :: enstrophy, normalizedAbsoluteVorticity, workArray
 
-      logical, pointer :: thicknessFilterActive, globalStatsAMPKGActive
+      logical, pointer :: thicknessFilterActive
       logical, pointer :: config_AM_globalStats_text_file
       character (len=StrKIND), pointer :: config_AM_globalStats_directory
 
       err = 0
-
-      call mpas_pool_get_package(ocnPackages, 'globalStatsAMPKGActive', globalStatsAMPKGActive)
-
-      if ( .not. globalStatsAMPKGActive ) return
 
       dminfo = domain % dminfo
 

--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -196,9 +196,6 @@ contains
       integer :: iDataField, nDefinedDataFields
       integer :: iCell, iLevel, iRegion, iTracer, err_tmp
 
-      ! package flag
-      logical, pointer :: layerVolumeWeightedAverageAMPKGActive
-
       ! buffers data for message passaging
       integer :: kBuffer, kBufferLength
       real (kind=RKIND), dimension(:), allocatable :: workBufferSum, workBufferSumReduced

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -212,7 +212,6 @@ contains
       integer :: iCell, iRegion, iTracer, err_tmp
 
       ! package flag
-      logical, pointer :: surfaceAreaWeightedAveragesAMPKGActive
       logical, pointer :: bulkForcingPkgActive
       logical, pointer :: frazilIcePkgActive
 

--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -187,9 +187,6 @@ contains
       real (kind=RKIND), pointer :: minSalinity, maxSalinity
       real (kind=RKIND) :: deltaTemperature, deltaSalinity, temperature, salinity, density, zPosition, volume
 
-      ! package flag
-      logical, pointer :: waterMassCensusAMPKGActive
-
       ! buffers data for message passaging
       integer :: kBuffer, kBufferLength
       real (kind=RKIND), dimension(:), allocatable :: workBufferSum, workBufferSumReduced

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -62,59 +62,6 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_setup_packages_zonal_mean
-!
-!> \brief   Set up packages for MPAS-Ocean analysis member
-!> \author  Mark Petersen
-!> \date    November 2013
-!> \details
-!>  This routine is intended to configure the packages for this MPAS
-!>   ocean analysis member
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_setup_packages_zonal_mean(configPool, packagePool, err)!{{{
-
-      !-----------------------------------------------------------------
-      !
-      ! input variables
-      !
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: configPool
-      type (mpas_pool_type), intent(in) :: packagePool
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-      !
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-      logical, pointer :: zonalMeanAMActive
-
-      err = 0
-
-      call mpas_pool_get_package(packagePool, 'zonalMeanAMActive', zonalMeanAMActive)
-
-      ! turn on package for this analysis member
-      zonalMeanAMActive = .true.
-
-   end subroutine ocn_setup_packages_zonal_mean!}}}
-
-!***********************************************************************
-!
 !  routine ocn_init_zonal_mean
 !
 !> \brief   Initialize MPAS-Ocean analysis member


### PR DESCRIPTION
These changes remove some variables and calls that became defunct with
commit bb3e26d (PR #466), mostly because package management was moved
from the analysis member modules to the driver.
