### PR TITLE
Separating out the redi portion of hmix for gm

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -312,7 +312,7 @@
 	</nml_record>
 	<nml_record name="mesoscale_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_standardGM" type="logical" default_value=".false." units="NA"
-					description="If true, the standard GM for the tracer advection and mixing is turned on."
+					description="If true, the standard GM for the tracer advection and mixing is turned on. This includes the redi portion which is captured in hmix."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_standardGM_tracer_kappa" type="real" default_value="0.0" units="m^2 s^{-1}"

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -30,6 +30,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_tracer_hmix.o \
 	   mpas_ocn_tracer_hmix_del2.o \
 	   mpas_ocn_tracer_hmix_del4.o \
+	   mpas_ocn_tracer_hmix_redi.o \
 	   mpas_ocn_tracer_advection.o \
 	   mpas_ocn_tracer_nonlocalflux.o \
 	   mpas_ocn_tracer_short_wave_absorption.o \
@@ -89,11 +90,13 @@ mpas_ocn_vel_forcing_rayleigh.o: mpas_ocn_constants.o
 
 mpas_ocn_vel_coriolis.o: mpas_ocn_constants.o
 
-mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o
+mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 
 mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o
 
 mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o
+
+mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o
 
 mpas_ocn_tracer_advection.o: mpas_ocn_constants.o
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -407,7 +407,7 @@ contains
       ! tracer tendency: del2 horizontal tracer diffusion, div(h \kappa_2 \nabla \phi)
       !
       call mpas_timer_start("hmix", .false., tracerHmixTimer)
-      call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+      call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, zMid, tracers, &
                                 relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend_tr, err)
       call mpas_timer_stop("hmix", tracerHmixTimer)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -28,6 +28,7 @@ module ocn_tracer_hmix
    use ocn_constants
    use ocn_tracer_hmix_del2
    use ocn_tracer_hmix_del4
+   use ocn_tracer_hmix_redi
 
    implicit none
    private
@@ -55,7 +56,7 @@ module ocn_tracer_hmix
    !--------------------------------------------------------------------
 
    logical :: tracerHmixOn
-   type (timer_node), pointer :: del2Timer, del4Timer
+   type (timer_node), pointer :: del2Timer, del4Timer, rediTimer
 
 
 !***********************************************************************
@@ -79,7 +80,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+   subroutine ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, zMid, tracers, &
                                    relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend, err)!{{{
 
 
@@ -92,7 +93,6 @@ contains
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness,     &!< Input: thickness at cell centers
          layerThicknessEdge, &!< Input: thickness at edge
          zMid                 !< Input: Z coordinate at the center of a cell
 
@@ -140,12 +140,15 @@ contains
       if(.not.tracerHmixOn) return
 
       call mpas_timer_start("del2", .false., del2Timer)
-      call ocn_tracer_hmix_del2_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
-                                     relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend, err1)
+      call ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err1)
       call mpas_timer_stop("del2", del2Timer)
       call mpas_timer_start("del4", .false., del4Timer)
       call ocn_tracer_hmix_del4_tend(meshPool, layerThicknessEdge, tracers, tend, err2)
       call mpas_timer_stop("del4", del4Timer)
+      call mpas_timer_start("redi", .false., rediTimer)
+      call ocn_tracer_hmix_redi_tend(meshPool, scratchPool, layerThicknessEdge, zMid, tracers, &
+                                     relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend, err1)
+      call mpas_timer_stop("redi", rediTimer)
 
       err = ior(err1, err2)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -53,12 +53,7 @@ module ocn_tracer_hmix_del2
    !--------------------------------------------------------------------
 
    logical :: del2On
-   logical, pointer :: config_use_standardGM
-   logical, pointer :: config_disable_redi_horizontal_term1
-   logical, pointer :: config_disable_redi_horizontal_term2
-   logical, pointer :: config_disable_redi_horizontal_term3
    real (kind=RKIND) :: eddyDiff2
-   real (kind=RKIND), pointer :: config_Redi_kappa
 
 
 !***********************************************************************
@@ -78,10 +73,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_del2_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
-                                        relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend, err)!{{{
-
-
+   subroutine ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -89,15 +81,9 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness,     &!< Input: thickness at cell centers
-         layerThicknessEdge, &!< Input: thickness at edge
-         zMid,               &!< Input: Z coordinate at the center of a cell
-         relativeSlopeTopOfEdge,    &!< Input: slope of coordinate relative to neutral surface at edges
-         relativeSlopeTapering,     &!< Input: tapering of slope of coordinate relative to neutral surface at edges
-         relativeSlopeTaperingCell   !< Input: tapering of slope of coordinate relative to neutral surface at cells
+         layerThicknessEdge !< Input: thickness at edges
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         tracers !< Input: tracer quantities
@@ -127,36 +113,25 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2
       integer :: i, k, iTracer, num_tracers
-      integer, pointer :: nCells, nVertLevels, nEdges
+      integer, pointer :: nCells, nVertLevels
 
-      integer, dimension(:,:), allocatable :: boundaryMask
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell, maxLevelCell
+      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
 
-      real (kind=RKIND) :: invAreaCell1, invAreaCell2, invAreaCell, areaEdge
-      real (kind=RKIND) :: tracer_turb_flux, flux, s_tmp, r_tmp, h1, h2, s_tmpU, s_tmpD
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: tracer_turb_flux, flux, r_tmp
 
       real (kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
       real (kind=RKIND), dimension(:), pointer :: meshScalingDel2
-
-      real (kind=RKIND), dimension(:,:), pointer :: gradTracerEdge, gradTracerTopOfEdge, gradHTracerSlopedTopOfCell, &
-         dTracerdZTopOfCell, dTracerdZTopOfEdge, areaCellSum
-
-      type (field2DReal), pointer :: gradTracerEdgeField, gradTracerTopOfEdgeField, gradHTracerSlopedTopOfCellField, dTracerdZTopOfCellField, dTracerdZTopOfEdgeField, &
-         areaCellSumField
 
       err = 0
 
       if (.not.del2On) return
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       num_tracers = size(tracers, dim=1)
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -194,192 +169,6 @@ contains
         end do
       end do
 
-     !
-     ! COMPUTE the extra terms arising due to mismatch between the constant coordinate surfaces and the
-     ! isopycnal surfaces.
-     !
-     ! mrp note: Redi diffusion should be put in a separate subroutine
-      if (config_use_standardGM) then
-
-         call mpas_pool_get_field(scratchPool, 'gradTracerEdge', gradTracerEdgeField)
-         call mpas_pool_get_field(scratchPool, 'gradTracerTopOfEdge', gradTracerTopOfEdgeField)
-         call mpas_pool_get_field(scratchPool, 'gradHTracerSlopedTopOfCell', gradHTracerSlopedTopOfCellField)
-         call mpas_pool_get_field(scratchPool, 'dTracerdZTopOfCell', dTracerdZTopOfCellField)
-         call mpas_pool_get_field(scratchPool, 'dTracerdZTopOfEdge', dTracerdZTopOfEdgeField)
-         call mpas_pool_get_field(scratchPool, 'areaCellSum', areaCellSumField)
-
-         call mpas_allocate_scratch_field(gradTracerEdgeField, .true.)
-         call mpas_allocate_scratch_field(gradTracerTopOfEdgeField, .true.)
-         call mpas_allocate_scratch_field(gradHTracerSlopedTopOfCellField, .true.)
-         call mpas_allocate_scratch_field(dTracerdZTopOfCellField, .true.)
-         call mpas_allocate_scratch_field(dTracerdZTopOfEdgeField, .true.)
-         call mpas_allocate_scratch_field(areaCellSumField, .True.)
-
-         gradTracerEdge => gradTracerEdgeField % array
-         gradTracerTopOfEdge => gradTracerTopOfEdgeField % array
-         gradHTracerSlopedTopOfCell => gradHTracerSlopedTopOfCellField % array
-         dTracerdZTopOfCell => dTracerdZTopOfCellField % array
-         dTracerdZTopOfEdge => dTracerdZTopOfEdgeField % array
-         areaCellSum => areaCellSumField % array
-
-         gradTracerEdge = 0.0
-         gradTracerTopOfEdge = 0.0
-         gradHTracerSlopedTopOfCell = 0.0
-         dTracerdZTopOfCell = 0.0
-         dTracerdZTopOfEdge = 0.0
-
-         ! this is the "standard" del2 term, but forced to use config_redi_kappa
-         if(.not.config_disable_redi_horizontal_term1) then
-         do iCell = 1, nCells
-            invAreaCell = 1.0 / areaCell(iCell)
-            do i = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i, iCell)
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-
-               r_tmp = config_redi_kappa * dvEdge(iEdge) / dcEdge(iEdge)
-
-               do k = 1, maxLevelEdgeTop(iEdge)
-
-                  ! this is the tapering of config_redi_kappa where abs(slope) > config_max_relative_slope
-                  s_tmp = relativeSlopeTapering(k,iEdge)
-
-                  do iTracer = 1, num_tracers
-                     ! \kappa_2 \nabla \phi on edge
-                     tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)
-
-                     ! div(h \kappa_2 \nabla \phi) at cell center
-                     flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp * s_tmp
-
-                     tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
-                  end do
-               end do
-
-            end do
-         end do
-         endif
-
-         ! Compute vertical derivative of tracers at cell center and top of layer
-         do iTracer = 1, num_tracers
-
-            do iCell = 1, nCells
-               do k = 2, maxLevelCell(iCell)
-                  dTracerdZTopOfCell(k,iCell) = (tracers(iTracer,k-1,iCell) - tracers(iTracer,k,iCell)) / (zMid(k-1,iCell) - zMid(k,iCell))
-               end do
-
-               ! Approximation of dTracerdZTopOfCell on the top and bottom interfaces through the idea of having
-               ! ghost cells above the top and below the bottom layers of the same depths and tracer density.
-               ! Essentially, this enforces the boundary condition (d tracer)/dz = 0 at the top and bottom.
-               dTracerdZTopOfCell(1,iCell) = 0.0
-               dTracerdZTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0
-            end do
-
-            ! Compute tracer gradient (gradTracerEdge) along the constant coordinate surface.
-            ! The computed variables lives at edge and mid-layer depth
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-
-               do k=1,maxLevelEdgeTop(iEdge)
-                  gradTracerEdge(k,iEdge) = (tracers(iTracer,k,cell2) - tracers(iTracer,k,cell1)) / dcEdge(iEdge)
-               end do
-            end do
-
-            ! Interpolate dTracerdZTopOfCell to edge and top of layer
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               do k = 1, maxLevelEdgeTop(iEdge)
-                  dTracerdZTopOfEdge(k,iEdge) = 0.5 * (dTracerdZTopOfCell(k,cell1) + dTracerdZTopOfCell(k,cell2)) 
-               end do
-               dTracerdZTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = 0.0
-            end do
-
-            ! Interpolate gradTracerEdge to edge and top of layer
-            do iEdge = 1, nEdges
-               do k = 2, maxLevelEdgeTop(iEdge)
-                  h1 = layerThicknessEdge(k-1,iEdge)
-                  h2 = layerThicknessEdge(k,iEdge)
-
-                  ! Using second-order interpolation below
-                  gradTracerTopOfEdge(k,iEdge) = (h2 * gradTracerEdge(k-1,iEdge) + h1 * gradTracerEdge(k,iEdge)) / (h1 + h2)
-               end do
-
-               ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells above
-               ! the top and below the bottom layers of the same depths and tracer concentration.
-               gradTracerTopOfEdge(1,iEdge) = gradTracerEdge(1,iEdge)
-               gradTracerTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradTracerEdge(max(maxLevelEdgeTop(iEdge),1),iEdge)
-            end do
-
-            ! Compute \nabla\cdot(relativeSlope d\phi/dz)
-            if(.not.config_disable_redi_horizontal_term2) then
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               invAreaCell1 = 1./areaCell(cell1)
-               invAreaCell2 = 1./areaCell(cell2)
-
-               do k = 1, maxLevelEdgeTop(iEdge)
-                  s_tmpU = relativeSlopeTapering(k  , iEdge) * relativeSlopeTopOfEdge(k,iEdge)*dTracerdZTopOfEdge(k,iEdge)
-                  s_tmpD = relativeSlopeTapering(k+1, iEdge) * relativeSlopeTopOfEdge(k+1,iEdge)*dTracerdZTopOfEdge(k+1,iEdge)
-                  flux = 0.5*dvEdge(iEdge)*(s_tmpU + s_tmpD)
-                  flux = flux * layerThicknessEdge(k, iEdge)
-                  tend(iTracer,k,cell1) = tend(iTracer,k,cell1) + config_Redi_kappa * flux * invAreaCell1
-                  tend(iTracer,k,cell2) = tend(iTracer,k,cell2) - config_Redi_kappa * flux * invAreaCell2
-               end do
-
-            end do
-            endif
-
-            ! Compute dz * d(relativeSlope\cdot\nabla\phi)/dz  (so the dz cancel out)
-            gradHTracerSlopedTopOfCell = 0.0
-
-            ! Compute relativeSlope\cdot\nabla\phi (variable gradHTracerSlopedTopOfCell) at non-boundary edges
-            areaCellSum = 1.0e-34
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               ! contribution of cell area from this edge:
-               areaEdge = 0.25 * dcEdge(iEdge) * dvEdge(iEdge)
-
-               do k = 1, maxLevelEdgeTop(iEdge) 
-                  r_tmp = 2.0 * areaEdge * relativeSlopeTopOfEdge(k,iEdge) * gradTracerTopOfEdge(k,iEdge)
-                  gradHTracerSlopedTopOfCell(k,cell1) = gradHTracerSlopedTopOfCell(k,cell1) + r_tmp
-                  gradHTracerSlopedTopOfCell(k,cell2) = gradHTracerSlopedTopOfCell(k,cell2) + r_tmp
-
-                  areaCellSum(k,cell1) = areaCellSum(k,cell1) + areaEdge
-                  areaCellSum(k,cell2) = areaCellSum(k,cell2) + areaEdge
-
-               end do
-            end do
-            do iCell=1,nCells
-               do k = 1, maxLevelCell(iCell)
-                  gradHTracerSlopedTopOfCell(k,iCell) = gradHTracerSlopedTopOfCell(k,iCell)/areaCellSum(k,iCell)
-               end do
-            end do
-
-            if(.not.config_disable_redi_horizontal_term3) then
-            do iCell = 1, nCells
-               ! impose no-flux boundary conditions at top and bottom of column
-               gradHTracerSlopedTopOfCell(1,iCell) = 0.0
-               gradHTracerSlopedTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0
-               do k = 1, maxLevelCell(iCell)
-                  s_tmp = relativeSlopeTaperingCell(k,iCell)
-                  tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + s_tmp * config_Redi_kappa * (gradHTracerSlopedTopOfCell(k,iCell) - gradHTracerSlopedTopOfCell(k+1,iCell))
-               end do
-            end do
-            endif
-
-         end do  ! iTracer
-
-         call mpas_deallocate_scratch_field(gradTracerEdgeField, .true.)
-         call mpas_deallocate_scratch_field(gradTracerTopOfEdgeField, .true.)
-         call mpas_deallocate_scratch_field(gradHTracerSlopedTopOfCellField, .true.)
-         call mpas_deallocate_scratch_field(dTracerdZTopOfCellField, .true.)
-         call mpas_deallocate_scratch_field(dTracerdZTopOfEdgeField, .true.)
-
-      end if ! config_use_standardGM
-
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_hmix_del2_tend!}}}
@@ -416,27 +205,15 @@ contains
 
       call mpas_pool_get_config(ocnConfigs, 'config_use_tracer_del2', config_use_tracer_del2)
       call mpas_pool_get_config(ocnConfigs, 'config_tracer_del2', config_tracer_del2)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM',config_use_standardGM)
-      call mpas_pool_get_config(ocnConfigs, 'config_Redi_kappa',config_Redi_kappa)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term1',config_disable_redi_horizontal_term1)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term2',config_disable_redi_horizontal_term2)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term3',config_disable_redi_horizontal_term3)
 
       del2on = .false.
 
       if ( config_use_tracer_del2 ) then
-      if ( config_tracer_del2 > 0.0 ) then
-          del2On = .true.
-          eddyDiff2 = config_tracer_del2
+         if ( config_tracer_del2 > 0.0 ) then
+            del2On = .true.
+            eddyDiff2 = config_tracer_del2
+         endif
       endif
-      endif
-
-     if ( config_use_standardGM ) then
-     if ( config_Redi_kappa > 0.0 ) then
-          del2On = .true.
-     endif
-     endif
-
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -1,0 +1,401 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tracer_hmix_redi
+!
+!> \brief MPAS ocean horizontal tracer mixing driver
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This module contains the main driver routine for computing 
+!>  horizontal mixing tendencies.  
+!>
+!>  It provides an init and a tend function. Each are described below.
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_hmix_redi
+
+   use mpas_derived_types
+   use mpas_pool_routines
+
+   use ocn_constants
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_tracer_hmix_redi_tend, &
+             ocn_tracer_hmix_redi_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   logical :: rediOn
+   logical, pointer :: config_disable_redi_horizontal_term1
+   logical, pointer :: config_disable_redi_horizontal_term2
+   logical, pointer :: config_disable_redi_horizontal_term3
+   real (kind=RKIND), pointer :: config_Redi_kappa
+
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_tracer_hmix_redi_tend
+!
+!> \brief   Computes Laplacian tendency term for horizontal tracer mixing
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date    September 2011
+!> \details 
+!>  This routine computes the horizontal mixing tendency for tracers
+!>  based on current state using a Laplacian parameterization.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_hmix_redi_tend(meshPool, scratchPool, layerThicknessEdge, zMid, tracers, &
+                                        relativeSlopeTopOfEdge, relativeSlopeTapering, relativeSlopeTaperingCell, tend, err)!{{{
+
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+      type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge, &!< Input: thickness at edge
+         zMid,               &!< Input: Z coordinate at the center of a cell
+         relativeSlopeTopOfEdge,    &!< Input: slope of coordinate relative to neutral surface at edges
+         relativeSlopeTapering,     &!< Input: tapering of slope of coordinate relative to neutral surface at edges
+         relativeSlopeTaperingCell   !< Input: tapering of slope of coordinate relative to neutral surface at cells
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        tracers !< Input: tracer quantities
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: i, k, iTracer, num_tracers
+      integer, pointer :: nCells, nVertLevels, nEdges
+
+      integer, dimension(:,:), allocatable :: boundaryMask
+
+      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell, maxLevelCell
+      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
+
+      real (kind=RKIND) :: invAreaCell1, invAreaCell2, invAreaCell, areaEdge
+      real (kind=RKIND) :: tracer_turb_flux, flux, s_tmp, r_tmp, h1, h2, s_tmpU, s_tmpD
+
+      real (kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
+
+      real (kind=RKIND), dimension(:,:), pointer :: gradTracerEdge, gradTracerTopOfEdge, gradHTracerSlopedTopOfCell, &
+         dTracerdZTopOfCell, dTracerdZTopOfEdge, areaCellSum
+
+      type (field2DReal), pointer :: gradTracerEdgeField, gradTracerTopOfEdgeField, gradHTracerSlopedTopOfCellField, dTracerdZTopOfCellField, dTracerdZTopOfEdgeField, &
+         areaCellSumField
+
+      err = 0
+
+      if (.not.rediOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      num_tracers = size(tracers, dim=1)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+
+      call mpas_pool_get_config(ocnConfigs, 'config_Redi_kappa',config_Redi_kappa)
+      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term1',config_disable_redi_horizontal_term1)
+      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term2',config_disable_redi_horizontal_term2)
+      call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_horizontal_term3',config_disable_redi_horizontal_term3)
+
+      !
+      ! COMPUTE the extra terms arising due to mismatch between the constant coordinate surfaces and the
+      ! isopycnal surfaces.
+      !
+      ! mrp note: Redi diffusion should be put in a separate subroutine
+
+      call mpas_pool_get_field(scratchPool, 'gradTracerEdge', gradTracerEdgeField)
+      call mpas_pool_get_field(scratchPool, 'gradTracerTopOfEdge', gradTracerTopOfEdgeField)
+      call mpas_pool_get_field(scratchPool, 'gradHTracerSlopedTopOfCell', gradHTracerSlopedTopOfCellField)
+      call mpas_pool_get_field(scratchPool, 'dTracerdZTopOfCell', dTracerdZTopOfCellField)
+      call mpas_pool_get_field(scratchPool, 'dTracerdZTopOfEdge', dTracerdZTopOfEdgeField)
+      call mpas_pool_get_field(scratchPool, 'areaCellSum', areaCellSumField)
+
+      call mpas_allocate_scratch_field(gradTracerEdgeField, .true.)
+      call mpas_allocate_scratch_field(gradTracerTopOfEdgeField, .true.)
+      call mpas_allocate_scratch_field(gradHTracerSlopedTopOfCellField, .true.)
+      call mpas_allocate_scratch_field(dTracerdZTopOfCellField, .true.)
+      call mpas_allocate_scratch_field(dTracerdZTopOfEdgeField, .true.)
+      call mpas_allocate_scratch_field(areaCellSumField, .True.)
+
+      gradTracerEdge => gradTracerEdgeField % array
+      gradTracerTopOfEdge => gradTracerTopOfEdgeField % array
+      gradHTracerSlopedTopOfCell => gradHTracerSlopedTopOfCellField % array
+      dTracerdZTopOfCell => dTracerdZTopOfCellField % array
+      dTracerdZTopOfEdge => dTracerdZTopOfEdgeField % array
+      areaCellSum => areaCellSumField % array
+
+      gradTracerEdge = 0.0
+      gradTracerTopOfEdge = 0.0
+      gradHTracerSlopedTopOfCell = 0.0
+      dTracerdZTopOfCell = 0.0
+      dTracerdZTopOfEdge = 0.0
+
+      ! this is the "standard" del2 term, but forced to use config_redi_kappa
+      if(.not.config_disable_redi_horizontal_term1) then
+
+         do iCell = 1, nCells
+            invAreaCell = 1.0 / areaCell(iCell)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+
+               r_tmp = config_redi_kappa * dvEdge(iEdge) / dcEdge(iEdge)
+
+               do k = 1, maxLevelEdgeTop(iEdge)
+
+                  ! this is the tapering of config_redi_kappa where abs(slope) > config_max_relative_slope
+                  s_tmp = relativeSlopeTapering(k,iEdge)
+
+                  do iTracer = 1, num_tracers
+                     ! \kappa_2 \nabla \phi on edge
+                     tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)
+
+                     ! div(h \kappa_2 \nabla \phi) at cell center
+                     flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp * s_tmp
+
+                     tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+                  end do
+               end do
+
+            end do
+         end do
+
+      endif
+
+      ! Compute vertical derivative of tracers at cell center and top of layer
+      do iTracer = 1, num_tracers
+
+         do iCell = 1, nCells
+            do k = 2, maxLevelCell(iCell)
+               dTracerdZTopOfCell(k,iCell) = (tracers(iTracer,k-1,iCell) - tracers(iTracer,k,iCell)) / (zMid(k-1,iCell) - zMid(k,iCell))
+            end do
+
+            ! Approximation of dTracerdZTopOfCell on the top and bottom interfaces through the idea of having
+            ! ghost cells above the top and below the bottom layers of the same depths and tracer density.
+            ! Essentially, this enforces the boundary condition (d tracer)/dz = 0 at the top and bottom.
+            dTracerdZTopOfCell(1,iCell) = 0.0
+            dTracerdZTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0
+         end do
+
+         ! Compute tracer gradient (gradTracerEdge) along the constant coordinate surface.
+         ! The computed variables lives at edge and mid-layer depth
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+
+            do k=1,maxLevelEdgeTop(iEdge)
+               gradTracerEdge(k,iEdge) = (tracers(iTracer,k,cell2) - tracers(iTracer,k,cell1)) / dcEdge(iEdge)
+            end do
+         end do
+
+         ! Interpolate dTracerdZTopOfCell to edge and top of layer
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k = 1, maxLevelEdgeTop(iEdge)
+               dTracerdZTopOfEdge(k,iEdge) = 0.5 * (dTracerdZTopOfCell(k,cell1) + dTracerdZTopOfCell(k,cell2)) 
+            end do
+            dTracerdZTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = 0.0
+         end do
+
+         ! Interpolate gradTracerEdge to edge and top of layer
+         do iEdge = 1, nEdges
+            do k = 2, maxLevelEdgeTop(iEdge)
+               h1 = layerThicknessEdge(k-1,iEdge)
+               h2 = layerThicknessEdge(k,iEdge)
+
+               ! Using second-order interpolation below
+               gradTracerTopOfEdge(k,iEdge) = (h2 * gradTracerEdge(k-1,iEdge) + h1 * gradTracerEdge(k,iEdge)) / (h1 + h2)
+            end do
+
+            ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells above
+            ! the top and below the bottom layers of the same depths and tracer concentration.
+            gradTracerTopOfEdge(1,iEdge) = gradTracerEdge(1,iEdge)
+            gradTracerTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradTracerEdge(max(maxLevelEdgeTop(iEdge),1),iEdge)
+         end do
+
+         ! Compute \nabla\cdot(relativeSlope d\phi/dz)
+         if(.not.config_disable_redi_horizontal_term2) then
+            do iCell = 1, nCells
+               invAreaCell = 1.0_RKIND / areaCell(iCell)
+               do i = 1, nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(i, iCell)
+                  do k = 1, maxLevelEdgeTop(iEdge)
+                     s_tmpU = relativeSlopeTapering(k, iEdge) * relativeSlopeTopOfEdge(k, iEdge) * dTracerdZTopOfEdge(k, iEdge)
+                     s_tmpD = relativeSlopeTapering(k+1, iEdge) * relativeSlopeTopOfEdge(k+1, iEdge) * dTracerdZTopOfEdge(k+1, iEdge)
+
+                     flux = 0.5 * dvEdge(iEdge) * ( s_tmpU + s_tmpD )
+                     flux = flux * layerThicknessEdge(k, iEdge)
+                     tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + edgeSignOnCell(i, iCell) * config_Redi_kappa * flux * invAreaCell
+                  end do
+               end do
+            end do
+         endif
+
+         ! Compute dz * d(relativeSlope\cdot\nabla\phi)/dz  (so the dz cancel out)
+         gradHTracerSlopedTopOfCell = 0.0
+
+         ! Compute relativeSlope\cdot\nabla\phi (variable gradHTracerSlopedTopOfCell) at non-boundary edges
+         areaCellSum = 1.0e-34
+
+         do iCell = 1, nCells
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               areaEdge = 0.5 * dcEdge(iEdge) * dvEdge(iEdge)
+               do k = 1, maxLevelEdgeTop(iEdge)
+                  r_tmp = areaEdge * relativeSlopeTopOfEdge(k,iEdge) * gradTracerTopOfEdge(k,iEdge)
+                  gradHTracerSlopedTopOfCell(k, iCell) = gradHTracerSlopedTopOfCell(k, iCell) + r_tmp
+                  areaCellSum(k, iCell) = areaCellSum(k, iCell) + areaEdge
+               end do
+            end do
+         end do
+
+         do iCell=1,nCells
+            do k = 1, maxLevelCell(iCell)
+               gradHTracerSlopedTopOfCell(k,iCell) = gradHTracerSlopedTopOfCell(k,iCell)/areaCellSum(k,iCell)
+            end do
+         end do
+
+         if(.not.config_disable_redi_horizontal_term3) then
+            do iCell = 1, nCells
+               ! impose no-flux boundary conditions at top and bottom of column
+               gradHTracerSlopedTopOfCell(1,iCell) = 0.0
+               gradHTracerSlopedTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0
+               do k = 1, maxLevelCell(iCell)
+                  s_tmp = relativeSlopeTaperingCell(k,iCell)
+                  tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + s_tmp * config_Redi_kappa * &
+                      (gradHTracerSlopedTopOfCell(k,iCell) - gradHTracerSlopedTopOfCell(k+1,iCell))
+               end do
+            end do
+         endif
+      end do  ! iTracer
+
+      call mpas_deallocate_scratch_field(gradTracerEdgeField, .true.)
+      call mpas_deallocate_scratch_field(gradTracerTopOfEdgeField, .true.)
+      call mpas_deallocate_scratch_field(gradHTracerSlopedTopOfCellField, .true.)
+      call mpas_deallocate_scratch_field(dTracerdZTopOfCellField, .true.)
+      call mpas_deallocate_scratch_field(dTracerdZTopOfEdgeField, .true.)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_redi_tend!}}}
+
+!***********************************************************************
+!
+!  routine ocn_tracer_hmix_redi_init
+!
+!> \brief   Initializes ocean tracer horizontal mixing quantities
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date    September 2011
+!> \details 
+!>  This routine initializes a variety of quantities related to 
+!>  Laplacian horizontal velocity mixing in the ocean. 
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_hmix_redi_init(err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! call individual init routines for each parameterization
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      logical, pointer :: config_use_standardGM
+
+      err = 0
+
+      call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM', config_use_standardGM)
+
+      rediOn = .false.
+
+      if ( config_use_standardGM ) then
+          rediOn = .true.
+      endif
+
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_hmix_redi_init!}}}
+
+!***********************************************************************
+
+end module ocn_tracer_hmix_redi
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker


### PR DESCRIPTION
This merge separates out the redi portion of hmix that is used when GM
is turned on. Previously this was incorporated within the del2 module,
and the logic to control if redi was used or not was confusing.

In addition, this merge updates the redi hmix module to be bit
reproducible, which it was not previously.
