### PR TITLE
Changing the default git method to ssh for cvmix

### DIFF
--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -41,16 +41,16 @@ if [ ! -d cvmix ]; then
 
 	if [ "${GIT}" != "" ]; then 
 		echo " ** Using git to acquire cvmix source. ** "
-		PROTOCOL="git https"
-		git clone ${CVMIX_GIT_HTTP_ADDRESS} .cvmix_all &> /dev/null
+		PROTOCOL="git ssh"
+		git clone ${CVMIX_GIT_SSH_ADDRESS} .cvmix_all &> /dev/null
 		if [ -d .cvmix_all ]; then 
 			cd .cvmix_all 
 			git checkout ${CVMIX_TAG} &> /dev/null
 			cd ../ 
 			ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix 
 		else 
-			git clone ${CVMIX_GIT_SSH_ADDRESS} .cvmix_all &> /dev/null
-			PROTOCOL="git ssh"
+			git clone ${CVMIX_GIT_HTTP_ADDRESS} .cvmix_all &> /dev/null
+			PROTOCOL="git http"
 			if [ -d .cvmix_all ]; then 
 				cd .cvmix_all 
 				git checkout ${CVMIX_TAG} &> /dev/null


### PR DESCRIPTION
This merge changes the default method of acquiring cvmix via git to be
ssh instead of http. Some clusters have issues with http access to
github due to firewall issues, and using ssh is slightly more reliable
in these cases.
