### PR TITLE
Fix makefile dependencies for parallel build

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -74,7 +74,7 @@ mpas_timekeeping.o: mpas_kind_types.o mpas_io_units.o mpas_derived_types.o mpas_
 
 mpas_timer.o: mpas_kind_types.o mpas_io_units.o mpas_dmpar.o
 
-mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o
+mpas_block_decomp.o: mpas_derived_types.o mpas_hash.o mpas_io_units.o mpas_dmpar.o
 
 mpas_block_creator.o: mpas_dmpar.o mpas_hash.o mpas_sort.o mpas_io_units.o mpas_block_decomp.o mpas_stream_manager.o mpas_decomp.o $(DEPS)
 


### PR DESCRIPTION
This merge fixes a missing dependency within the framework Makefile
that prevented parallel builds from working.
