### PR TITLE
Add iocontext as an argument to setup_packages

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -93,15 +93,16 @@ module atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function atm_setup_packages(configs, packages) result(ierr)
+   function atm_setup_packages(configs, packages, iocontext) result(ierr)
 
-      use mpas_derived_types, only : mpas_pool_type
+      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
       type (mpas_pool_type), intent(inout) :: packages
+      type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
 
       ierr = 0

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -93,9 +93,9 @@ module init_atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function init_atm_setup_packages(configs, packages) result(ierr)
+   function init_atm_setup_packages(configs, packages, iocontext) result(ierr)
 
-      use mpas_derived_types, only : mpas_pool_type
+      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
       use mpas_io_units, only : stderrUnit
 
@@ -103,6 +103,7 @@ module init_atm_core_interface
 
       type (mpas_pool_type), intent(inout) :: configs
       type (mpas_pool_type), intent(inout) :: packages
+      type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
 
       logical, pointer :: initial_conds, sfc_update, vertical_stage_in, vertical_stage_out, met_stage_in, met_stage_out

--- a/src/core_landice/mpas_li_core_interface.F
+++ b/src/core_landice/mpas_li_core_interface.F
@@ -86,11 +86,12 @@ module li_core_interface
 !>   *not* allocated until after this routine is called.
 !
 !-----------------------------------------------------------------------
-   function li_setup_packages(configPool, packagePool) result(ierr)
+   function li_setup_packages(configPool, packagePool, iocontext) result(ierr)
 
       implicit none
       type (mpas_pool_type), intent(inout) :: configPool
       type (mpas_pool_type), intent(inout) :: packagePool
+      type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
 
       ierr = 0

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -92,12 +92,13 @@ module ocn_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function ocn_setup_packages(configPool, packagePool) result(ierr)!{{{
+   function ocn_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
 
       use ocn_analysis_driver
 
       type (mpas_pool_type), intent(inout) :: configPool
       type (mpas_pool_type), intent(inout) :: packagePool
+      type (mpas_io_context_type), intent(inout) :: iocontext
 
       integer :: ierr
 

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -87,7 +87,7 @@ module sw_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function sw_setup_packages(configPool, packagePool) result(ierr)!{{{
+   function sw_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
 
       use mpas_derived_types
 
@@ -95,6 +95,7 @@ module sw_core_interface
 
       type (mpas_pool_type), intent(inout) :: configPool
       type (mpas_pool_type), intent(inout) :: packagePool
+      type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
 
       ierr = 0

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -87,7 +87,7 @@ module test_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function test_setup_packages(configPool, packagePool) result(ierr)!{{{
+   function test_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
 
       use mpas_derived_types
 
@@ -95,6 +95,7 @@ module test_core_interface
 
       type (mpas_pool_type), intent(inout) :: configPool
       type (mpas_pool_type), intent(inout) :: packagePool
+      type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
 
       ierr = 0

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -202,7 +202,7 @@ module mpas_subdriver
          call mpas_dmpar_global_abort('ERROR: Package definition failed for core ' // trim(domain_ptr % core % coreName))
       end if
 
-      ierr = domain_ptr % core % setup_packages(domain_ptr % configs, domain_ptr % packages)
+      ierr = domain_ptr % core % setup_packages(domain_ptr % configs, domain_ptr % packages, domain_ptr % iocontext)
       if ( ierr /= 0 ) then
          call mpas_dmpar_global_abort('ERROR: Package setup failed for core ' // trim(domain_ptr % core % coreName))
       end if

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -21,11 +21,13 @@
    end interface
 
    abstract interface
-      function mpas_setup_packages_function(configs, packages) result(iErr)
+      function mpas_setup_packages_function(configs, packages, iocontext) result(iErr)
          import mpas_pool_type
+		 import mpas_io_context_type
 
          type (mpas_pool_type), intent(inout) :: configs
          type (mpas_pool_type), intent(inout) :: packages
+         type (mpas_io_context_type), intent(inout) :: iocontext
          integer :: iErr
       end function mpas_setup_packages_function
    end interface


### PR DESCRIPTION
This merge adds iocontext as an inout argument to setup_packages so
cores that use setup_packages to do some pre-configuration of the model
can perform I/O if they need to.

An example would be needing to open a netcdf file to query dimensions
prior to allocating fields.
