### PR TITLE
Compute ranks of procs that share a vertex for external dycores

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -282,6 +282,7 @@ void computeMap();
 
 void setBdFacesOnPrism (const std::vector<std::vector<std::vector<int> > >& prismStruct, const std::vector<int>& prismFaceIds, std::vector<int>& tetraPos, std::vector<int>& facePos);
 void tetrasFromPrismStructured (int const* prismVertexMpasIds, int const* prismVertexGIds, int tetrasIdsOnPrism[][4]);
+void procsSharingVertex(const int vertex, std::vector<int>& procIds);
 
 bool belongToTria(double const* x, double const* t, double bcoords[3], double eps = 1e-3);
 


### PR DESCRIPTION
This introduces a function that computes the ranks of processes 
that share a vertex.
This is called by Albany-Felix starting with Albany hash:
39ed4d5f0c4fb790622cfeaa7943806afd0ef9e1 (Sept. 3, 2015)
to optimize the construction of the FE grid.

Albany builds newer than that commit will require this change to MPAS.

This should not change answers, but should increase performance of Albany 
by eliminating a number of MPI communications.
