### PR TITLE
Fixing a referenece to a var_array that is really a var_struct

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1250,10 +1250,10 @@
 				mode="forward">
 
 			<stream name="mesh"/>
+			<var_struct name="tracersSurfaceFlux"/>
 			<var_array name="tracersSurfaceValue"/>
 			<var_array name="surfaceVelocity"/>
 			<var_array name="SSHGradient"/>
-			<var_array name="tracersSurfaceFlux"/>
 			<var_array name="vertNonLocalFlux"/>
 			<var name="surfaceWindStressMagnitude"/>
 			<var name="surfaceWindStress"/>


### PR DESCRIPTION
This merge updates the default stream configurations to convert a
var_array to a var_struct, since tracersSurfaceFlux was changed to a
var_struct in the previous commit.
