### PR TITLE
Ocean/develop fix default init namelists to include forcing name list records

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -588,7 +588,7 @@
 					possible_values="Any positive value"
 		/>
 	</nml_record>
-	<nml_record name="forcing" mode="forward">
+	<nml_record name="forcing" mode="init;forward">
 		<nml_option name="config_use_bulk_wind_stress" type="logical" default_value=".false." units="unitless"
 					description="Controls if zonal and meridional components of windstress are used to build surfaceWindStress."
 					possible_values=".true. or .false."

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -1,4 +1,4 @@
-	<nml_record name="tracer_forcing_activeTracers" in_defaults="true" mode="forward;analysis">
+	<nml_record name="tracer_forcing_activeTracers" in_defaults="true" mode="init;forward;analysis">
 		<nml_option name="config_use_activeTracers" type="logical" default_value=".true." units="unitless"
 					description="if true, the 'activeTracers' category is enabled for the run"
 					possible_values=".true. or .false."


### PR DESCRIPTION
Adds the following name list records to init default name lists:

&forcing
&tracer_forcing_activeTracers

as discussed in the MPAS-O meeting today.  This should ensure that 
minimal set of name list records is available in `namelist.ocean.init.*` files.
