### PR TITLE
Small corrections to init mode templates.

### DIFF
--- a/src/core_ocean/mode_init/Registry_TEMPLATE.xml
+++ b/src/core_ocean/mode_init/Registry_TEMPLATE.xml
@@ -1,4 +1,4 @@
-	<nml_record name="TEMPLATE" mode="init" test_case="TEMPLATE">
+	<nml_record name="TEMPLATE" mode="init" configuration=="TEMPLATE">
 		<nml_option name="config_TEMPLATE_vert_levels" type="integer" default_value="XXX" units="unitless"
 					description="Number of vertical levels in TEMPLATE. Typical value is XX."
 					possible_values="Any positive integer number greater than 0."

--- a/src/core_ocean/mode_init/mpas_ocn_init_TEMPLATE.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_TEMPLATE.F
@@ -33,7 +33,10 @@
 !>  5. Add these lines for default namelist parsing:
 !>     in src/core_ocean/Makefile:
 !>     (cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.TEMPLATE mode=init configuration=TEMPLATE)
-!>     in src/core_ocean/Registry.xml
+!>
+!>     in src/core_ocean/Registry.xml, add your case to
+!>     nml_option name="config_init_configuration"
+!>     as 
 !>     TEMPLATE_value="TEMPLATE"
 !
 !-----------------------------------------------------------------------


### PR DESCRIPTION
These corrections allow a user to follow the instructions at the top of 
src/core_ocean/mode_init/mpas_ocn_init_TEMPLATE.F
to create a new init case.
