### PR TITLE
Protect procsSharingVertex call to Albany with ifdef

### DIFF
--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -322,7 +322,9 @@ contains
 
       ! Set physical parameters needed on the other side
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
+#if defined(USE_EXTERNAL_L1L2) || defined(USE_EXTERNAL_FIRSTORDER) || defined(USE_EXTERNAL_STOKES)
       call velocity_solver_set_parameters(config_ice_density, li_mask_ValueDynamicIce, li_mask_ValueIce)
+#endif
 
       ! === error check
       if (err > 0) then


### PR DESCRIPTION
The recent commit 7d730126 adds support for a new function called
procsSharingVertex which is used by Albany.  However, the call to Albany
was not protected by an ifdef, which breaks the build for standalone MPAS.
This fixes that.
