### PR TITLE
Change references to config_density0 to rho_sw

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -646,14 +646,16 @@
 					possible_values="any positive real, typically 1.0e-3"
 		/>
 	</nml_record>
+	<nml_record name="ocean_constants">
+		<nml_option name="config_density0" type="real" default_value="1026.0" units="kg m^{-3}"
+					description="Density used as a coefficient of the pressure gradient terms, $\rho_0$. This is a constant due to the Boussinesq approximation."
+					possible_values="any positive real, but typically 1000-1035"
+		/>
+	</nml_record>
 	<nml_record name="pressure_gradient" mode="forward">
 		<nml_option name="config_pressure_gradient_type" type="character" default_value="pressure_and_zmid" units="unitless"
 					description="Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential."
 					possible_values="'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential'"
-		/>
-		<nml_option name="config_density0" type="real" default_value="1014.65" units="kg m^{-3}"
-					description="Density used as a coefficient of the pressure gradient terms, $\rho_0$. This is a constant due to the Boussinesq approximation."
-					possible_values="any positive real, but typically 1000-1035"
 		/>
 		<nml_option name="config_common_level_weight" type="real" default_value="0.5" units="unitless"
 					description="The weight between standard Jacobian and weighted Jacobian, $\gamma$."

--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -122,7 +122,6 @@ contains
       integer, pointer :: config_AM_eliassenPalm_nBuoyancyLayers
       real (kind=RKIND), pointer :: config_AM_eliassenPalm_rhomax_buoycoor
       real (kind=RKIND), pointer :: config_AM_eliassenPalm_rhomin_buoycoor
-      real (kind=RKIND), pointer :: config_density0
 
       integer, pointer :: nSamplesEA
 
@@ -157,8 +156,6 @@ contains
       call mpas_pool_get_config(domain % configs, 'config_AM_eliassenPalm_rhomin_buoycoor', &
         config_AM_eliassenPalm_rhomin_buoycoor)
       
-      call mpas_pool_get_config(domain % configs, 'config_density0', config_density0)
-      
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'eliassenPalmAM', amEPFTPool)
@@ -178,7 +175,7 @@ contains
          nBuoyancyLayers = config_AM_eliassenPalm_nBuoyancyLayers
          deltaDensity = (config_AM_eliassenPalm_rhomax_buoycoor &
             - config_AM_eliassenPalm_rhomin_buoycoor) / config_AM_eliassenPalm_nBuoyancyLayers
-         deltaBuoyancy = -gravity * deltaDensity / config_density0
+         deltaBuoyancy = -gravity * deltaDensity / rho_sw
 
          !-----------------------------------------------------------------
          ! compute density/bouyancy at top of each layer
@@ -186,7 +183,7 @@ contains
          do k = 1, nBuoyancyLayers
             potentialDensityTopRef(k) = config_AM_eliassenPalm_rhomin_buoycoor + deltaDensity * (k-1)
             buoyancyInterfaceRef(k) = -gravity &
-              * (config_AM_eliassenPalm_rhomin_buoycoor - config_density0) / config_density0 &
+              * (config_AM_eliassenPalm_rhomin_buoycoor - rho_sw) / rho_sw &
               + deltaBuoyancy * (k-1)
          end do
          k=nBuoyancyLayers
@@ -320,8 +317,6 @@ contains
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: diagnosticsPool 
 
-      real (kind=RKIND), pointer :: config_density0
-      
       !-----------------------------------------------------------------
       ! define pointers to namelist config variables local to the EPFT module
       !-----------------------------------------------------------------
@@ -527,8 +522,6 @@ contains
       ! define local work variables
       !-----------------------------------------------------------------
       integer :: nCellsGlobal, k, i
-      real(KIND=RKIND) :: rho0
-
       
       err = 0
 
@@ -553,9 +546,6 @@ contains
         config_AM_eliassenPalm_rhomin_buoycoor)
       call mpas_pool_get_config(domain % configs, 'config_AM_eliassenPalm_rhomax_buoycoor', &
         config_AM_eliassenPalm_rhomax_buoycoor)
-
-      call mpas_pool_get_config(domain % configs, 'config_density0', config_density0)
-      rho0 = config_density0
       
       if(config_AM_eliassenPalm_debug) then
          write(stderrUnit, *) ' '
@@ -1146,7 +1136,7 @@ contains
          ! compute the total force from the EPFT: div(EPFT)
          !-------------------------------------------------------------
          call calculateDivEPFT(config_AM_eliassenPalm_debug, &
-            domain % on_a_sphere, rho0, nBuoyancyLayers, nCells, nEdges, &
+            domain % on_a_sphere, rho_sw, nBuoyancyLayers, nCells, nEdges, &
             meshPool, buoyancyMidRef, sigmaEA, buoyancyMaskEA, EPFT, divEPFT)
          ! decompose the vector into its components for output
          divEPFT1 = divEPFT(1,:,:)
@@ -1158,7 +1148,7 @@ contains
          wrkTensor = 0.0
          wrkTensor(1:2,1:2,:,:) = EPFT(1:2,1:2,:,:)
          call calculateDivEPFT(config_AM_eliassenPalm_debug, &
-            domain % on_a_sphere, rho0, nBuoyancyLayers, nCells, nEdges, &
+            domain % on_a_sphere, rho_sw, nBuoyancyLayers, nCells, nEdges, &
             meshPool, buoyancyMidRef, sigmaEA, buoyancyMaskEA, wrkTensor, wrkVector)
          divEPFTshear1 = wrkVector(1,:,:)
          divEPFTshear2 = wrkVector(2,:,:)
@@ -1169,7 +1159,7 @@ contains
          wrkTensor = 0.0
          wrkTensor(3,1:2,:,:) = EPFT(3,1:2,:,:)
          call calculateDivEPFT(config_AM_eliassenPalm_debug, &
-            domain % on_a_sphere, rho0, nBuoyancyLayers, nCells, nEdges, &
+            domain % on_a_sphere, rho_sw, nBuoyancyLayers, nCells, nEdges, &
             meshPool, buoyancyMidRef, sigmaEA, buoyancyMaskEA, wrkTensor, wrkVector)
          divEPFTdrag1 = wrkVector(1,:,:)
          divEPFTdrag2 = wrkVector(2,:,:)

--- a/src/core_ocean/shared/mpas_ocn_constants.F
+++ b/src/core_ocean/shared/mpas_ocn_constants.F
@@ -96,8 +96,12 @@ contains
        type (mpas_pool_type), pointer :: packagePool
        integer :: n
 
+       real (kind=RKIND), pointer :: config_density0
+
        ocnConfigs => configPool
        ocnPackages => packagePool
+
+       call mpas_pool_get_config(configPool, 'config_density0', config_density0)
 
        !-----------------------------------------------------------------------
        !
@@ -109,7 +113,7 @@ contains
 
        T0_Kelvin = 273.16_RKIND               ! zero point for Celsius
        rho_air   = 1.2_RKIND                  ! ambient air density (kg/m^3)
-       rho_sw    = 1.026e3_RKIND              ! density of salt water (kg/m^3)
+       rho_sw    = config_density0            ! density of salt water (kg/m^3)
        rho_fw    = 1.0e3_RKIND                ! avg. water density (kg/m^3)
        rho_ice   = 0.917e3_RKIND              ! density of ice (kg/m^3)
        cp_sw     = 3.996e3_RKIND              ! specific heat salt water

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -140,7 +140,7 @@ contains
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
       logical, pointer :: config_use_cvmix_kpp
-      real (kind=RKIND), pointer :: config_density0, config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
+      real (kind=RKIND), pointer :: config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
       character (len=StrKIND), pointer :: config_pressure_gradient_type
 
       if (present(timeLevelIn)) then
@@ -149,7 +149,6 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_apvm_scale_factor', config_apvm_scale_factor)
       call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
       call mpas_pool_get_config(ocnConfigs, 'config_coef_3rd_order', config_coef_3rd_order)
@@ -561,7 +560,7 @@ contains
       !
       ! Brunt-Vaisala frequency (this has units of s^{-2})
       !
-      coef = -gravity / config_density0
+      coef = -gravity / rho_sw
       do iCell = 1, nCells
          BruntVaisalaFreqTop(1,iCell) = 0.0
          do k = 2, maxLevelCell(iCell)
@@ -1129,7 +1128,6 @@ contains
       real (kind=RKIND), dimension(:), allocatable :: buoySmoothed, shearSmoothed
 
       type (field2DReal), pointer :: densitySurfaceDisplacedField, thermalExpansionCoeffField, salineContractionCoeffField
-      real (kind=RKIND), pointer :: config_density0
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -1138,7 +1136,6 @@ contains
       end if
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
 
       ! set the parameter turbulentVelocitySquared
       turbulentVelocitySquared = 0.001_RKIND
@@ -1234,7 +1231,7 @@ contains
         surfacewindStressMagnitude(iCell) = sqrt(deltaVelocitySquared)
 
        ! compute surface friction velocity
-         surfaceFrictionVelocity(iCell) = sqrt(surfacewindStressMagnitude(iCell) / config_density0)
+         surfaceFrictionVelocity(iCell) = sqrt(surfacewindStressMagnitude(iCell) / rho_sw)
 
        ! zero the bulk Richardson number within the ocean surface layer
        ! this prevent CVMix/KPP from mis-diagnosing the OBL to be within the surface layer
@@ -1253,7 +1250,7 @@ contains
            deltaVelocitySquared = deltaVelocitySquared + factor * delU2
          enddo
 
-         buoyContribution = gravity * (density(k,iCell) - densitySurfaceDisplaced(k,iCell)) / config_density0
+         buoyContribution = gravity * (density(k,iCell) - densitySurfaceDisplaced(k,iCell)) / rho_sw
          shearContribution = max(deltaVelocitySquared,1.0e-15_RKIND)
 
          ! store the buoyancy and resolved shear contributions to bulk Richardson number

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -41,7 +41,7 @@ module ocn_gm
    private :: tridiagonal_solve
 
    ! Config options
-   real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc, config_standardGM_tracer_kappa, config_density0, &
+   real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc, config_standardGM_tracer_kappa, &
      config_max_relative_slope, config_Redi_kappa
    logical, pointer :: config_use_standardGM
    logical, pointer :: config_disable_redi_k33
@@ -385,7 +385,7 @@ contains
             BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
             tridiagB(k-1) = - 2.0_RKIND * config_gravWaveSpeed_trunc**2/(layerThicknessEdge(k-1,iEdge)*layerThicknessEdge(k,iEdge)) - BruntVaisalaFreqTopEdge
             tridiagC(k-1) = 2.0_RKIND * config_gravWaveSpeed_trunc**2/layerThicknessEdge(k,iEdge)/(layerThicknessEdge(k-1,iEdge)+layerThicknessEdge(k,iEdge))
-            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / config_density0 * gradDensityConstZTopOfEdge(k,iEdge)
+            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
 
             ! Second to next to the last rows
             do k = 3, maxLevelEdgeTop(iEdge)-1
@@ -394,7 +394,7 @@ contains
                tridiagA(k-2) = 2.0_RKIND * config_gravWaveSpeed_trunc**2/layerThicknessEdge(k-1,iEdge)/(layerThicknessEdge(k-1,iEdge)+layerThicknessEdge(k,iEdge))
                tridiagB(k-1) = - 2.0_RKIND * config_gravWaveSpeed_trunc**2/(layerThicknessEdge(k-1,iEdge)*layerThicknessEdge(k,iEdge)) - BruntVaisalaFreqTopEdge
                tridiagC(k-1) = 2.0_RKIND * config_gravWaveSpeed_trunc**2/layerThicknessEdge(k,iEdge)/(layerThicknessEdge(k-1,iEdge)+layerThicknessEdge(k,iEdge))
-               rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / config_density0 * gradDensityConstZTopOfEdge(k,iEdge)
+               rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
             end do
 
             ! Last row
@@ -403,7 +403,7 @@ contains
             BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
             tridiagA(k-2) = 2.0_RKIND * config_gravWaveSpeed_trunc**2/layerThicknessEdge(k-1,iEdge)/(layerThicknessEdge(k-1,iEdge)+layerThicknessEdge(k,iEdge))
             tridiagB(k-1) = - 2.0_RKIND * config_gravWaveSpeed_trunc**2/(layerThicknessEdge(k-1,iEdge)*layerThicknessEdge(k,iEdge)) - BruntVaisalaFreqTopEdge
-            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / config_density0 * gradDensityConstZTopOfEdge(k,iEdge)
+            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
 
             ! Total number of rows
             N = maxLevelEdgeTop(iEdge) - 1
@@ -546,7 +546,6 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
       call mpas_pool_get_config(ocnConfigs, 'config_max_relative_slope',config_max_relative_slope)
-      call mpas_pool_get_config(ocnConfigs, 'config_density0',config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_kappa', config_Redi_kappa)
       call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM',config_use_standardGM)
       call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_k33',config_disable_redi_k33)

--- a/src/core_ocean/shared/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_sea_ice.F
@@ -117,7 +117,6 @@ contains
       real (kind=RKIND) :: referenceSalinity, iceSalinity
       real (kind=RKIND) :: freezingTemp, density_ice
       real (kind=RKIND), dimension(:), allocatable :: iceTracer
-      real (kind=RKIND), pointer :: config_density0
 
       if(.not. frazilFormationOn) return
 
@@ -126,7 +125,6 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tracers, dim=1)
 
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
@@ -146,7 +144,7 @@ contains
             ! availableEnergyChange is:
             !     positive when frazil ice is formed
             !     negative when frazil ice can be melted
-            availableEnergyChange = config_density0 * cp_sw * layerThickness(k, iCell) &
+            availableEnergyChange = rho_sw * cp_sw * layerThickness(k, iCell) &
                                       * (freezingTemp - tracers(indexTemperature, k, iCell))
 
             ! energyChange is capped when negative.
@@ -155,9 +153,9 @@ contains
             energyChange = max(availableEnergyChange, -netEnergyChange)
 
             ! Compute temperature change in ocean cell due to energy change
-            temperatureChange = energyChange / ( config_density0 * cp_sw * layerThickness(k, iCell) )
+            temperatureChange = energyChange / ( rho_sw * cp_sw * layerThickness(k, iCell) )
             ! Compute thickness change in ocean cell due to energy change
-            thicknessChange = energyChange / ( config_density0 * latent_heat_fusion_mks )
+            thicknessChange = energyChange / ( rho_sw * latent_heat_fusion_mks )
             ! Compute thickness change in sea ice due to energy change
             iceThicknessChange = energyChange / ( density_ice * latent_heat_fusion_mks )
 
@@ -167,9 +165,9 @@ contains
                   ! computed as:
                   !    \rho_{ocn} h_{ocn}^{pre} \theta_{ocn}^{pre} = 
                   !               \rho_{ocn}^{new} h_{ocn}^{new} \theta_{ocn}^{new}  =  \rho_{si} h_{si} \theta_{si}
-                  tracers(iTracer, k, iCell) = ( config_density0 * layerThickness(k,iCell) * tracers(iTracer, k, iCell) &
+                  tracers(iTracer, k, iCell) = ( rho_sw * layerThickness(k,iCell) * tracers(iTracer, k, iCell) &
                                                - density_ice * iceThicknessChange * iceTracer(iTracer)) / &
-                                               (config_density0 * (layerThickness(k,iCell) + thicknessChange))
+                                               (rho_sw * (layerThickness(k,iCell) + thicknessChange))
                end if
             end do
 
@@ -197,7 +195,7 @@ contains
             ! availableEnergyChange is:
             !     positive when frazil ice is formed
             !     negative when frazil ice can be melted
-            availableEnergyChange = config_density0 * cp_sw * layerThickness(k, iCell) &
+            availableEnergyChange = rho_sw * cp_sw * layerThickness(k, iCell) &
                                       * (freezingTemp - tracers(indexTemperature, k, iCell))
 
             ! energyChange is capped when negative.
@@ -207,9 +205,9 @@ contains
             energyChange = max(availableEnergyChange, -seaIceEnergy(iCell))
 
             ! Compute temperature change in ocean cell due to energy change
-            temperatureChange = energyChange / ( config_density0 * cp_sw * layerThickness(k, iCell) )
+            temperatureChange = energyChange / ( rho_sw * cp_sw * layerThickness(k, iCell) )
             ! Compute thickness change in ocean cell due to energy change
-            thicknessChange = energyChange / ( config_density0 * latent_heat_fusion_mks )
+            thicknessChange = energyChange / ( rho_sw * latent_heat_fusion_mks )
             ! Compute thickness change in sea ice due to energy change
             iceThicknessChange = energyChange / ( density_ice * latent_heat_fusion_mks )
 
@@ -219,9 +217,9 @@ contains
                   ! computed as:
                   !    \rho_{ocn} h_{ocn}^{pre} \theta_{ocn}^{pre} = 
                   !               \rho_{ocn}^{new} h_{ocn}^{new} \theta_{ocn}^{new}  =  \rho_{si} h_{si} \theta_{si}
-                  tracers(iTracer, k, iCell) = ( config_density0 * layerThickness(k,iCell) * tracers(iTracer, k, iCell) &
+                  tracers(iTracer, k, iCell) = ( rho_sw * layerThickness(k,iCell) * tracers(iTracer, k, iCell) &
                                                - density_ice * iceThicknessChange * iceTracer(iTracer)) / &
-                                               (config_density0 * (layerThickness(k,iCell) + thicknessChange))
+                                               (rho_sw * (layerThickness(k,iCell) + thicknessChange))
                end if
             end do
 

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -53,7 +53,6 @@ module ocn_surface_bulk_forcing
    !
    !--------------------------------------------------------------------
 
-   real (kind=RKIND) :: refDensity
    logical :: bulkWindStressOn, bulkThicknessFluxOn
 
 !***********************************************************************
@@ -267,7 +266,9 @@ contains
 
       ! Build surface fluxes at cell centers
       do iCell = 1, nCells
-        surfaceThicknessFlux(iCell) = ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) + seaIceFreshWaterFlux(iCell) + iceRunoffFlux(iCell) + riverRunoffFlux(iCell) ) / refDensity
+        surfaceThicknessFlux(iCell) = ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) &
+                                    + seaIceFreshWaterFlux(iCell) + iceRunoffFlux(iCell) &
+                                    + riverRunoffFlux(iCell) ) / rho_sw
       end do
 
    end subroutine ocn_surface_bulk_forcing_thick!}}}
@@ -288,16 +289,13 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
-      real (kind=RKIND), pointer :: config_density0
       logical, pointer :: config_use_bulk_wind_stress, config_use_bulk_thickness_flux
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_use_bulk_wind_stress', config_use_bulk_wind_stress)
       call mpas_pool_get_config(ocnConfigs, 'config_use_bulk_thickness_flux', config_use_bulk_thickness_flux)
 
-      refDensity = config_density0
       bulkWindStressOn = config_use_bulk_wind_stress
       bulkThicknessFluxOn = config_use_bulk_thickness_flux
 

--- a/src/core_ocean/shared/mpas_ocn_test.F
+++ b/src/core_ocean/shared/mpas_ocn_test.F
@@ -283,14 +283,13 @@ contains
 
       real(kind=RKIND) :: zTop, config_gm_analytic_temperature2, config_gm_analytic_temperature3, config_gm_analytic_ymax, &
          config_gm_analytic_bottom_depth, L, R, c1, c2, zMax, zBot
-      real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc, config_density0, config_standardGM_tracer_kappa, config_eos_linear_alpha
+      real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc, config_standardGM_tracer_kappa, config_eos_linear_alpha
 
       real(kind=RKIND), dimension(:), pointer   :: bottomDepth, refBottomDepthTopOfCell, yCell, yEdge
       real(kind=RKIND), dimension(:,:), pointer :: yRelativeSlopeSolution, yGMStreamFuncSolution, yGMBolusVelocitySolution, zMid
 
       type (field2DReal), pointer :: yRelativeSlopeSolutionField, yGMStreamFuncSolutionField, yGMBolusVelocitySolutionField
 
-      call mpas_pool_get_config(ocnConfigs, 'config_density0',config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_alpha', config_eos_linear_alpha)
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
@@ -314,20 +313,20 @@ contains
       yGMBolusVelocitySolution => yGMBolusVelocitySolutionField % array 
 
       ! These are flags that must match your initial conditions settings.  See gm_analytic initial condition in mode_init.
-      config_gm_analytic_temperature2 = 10;
-      config_gm_analytic_temperature3 = -10;
-      config_gm_analytic_ymax = 500000;
-      config_gm_analytic_bottom_depth = 1000;
+      config_gm_analytic_temperature2 = 10
+      config_gm_analytic_temperature3 = -10
+      config_gm_analytic_ymax = 500000
+      config_gm_analytic_bottom_depth = 1000
 
       ! zMax is associated with linear temperature profile in z
-      zMax = -config_gm_analytic_bottom_depth;  
+      zMax = -config_gm_analytic_bottom_depth
       ! zBot is location we apply boundary conditions on the ODE for stream function.  
-      zBot = zMax;  
+      zBot = zMax
 
-      L = config_gravWaveSpeed_trunc * sqrt(config_density0*zMax/gravity/config_eos_linear_alpha/config_gm_analytic_temperature3);
-      R = - config_standardGM_tracer_kappa * config_gm_analytic_temperature2 * zMax / config_gm_analytic_temperature3 / config_gm_analytic_ymax;
-      c1 = R*(1-exp(-zBot/L))/(exp(zBot/L) - exp(-zBot/L));
-      c2 = R-c1;
+      L = config_gravWaveSpeed_trunc * sqrt(rho_sw * zMax / gravity / config_eos_linear_alpha / config_gm_analytic_temperature3)
+      R = - config_standardGM_tracer_kappa * config_gm_analytic_temperature2 * zMax / config_gm_analytic_temperature3 / config_gm_analytic_ymax
+      c1 = R*(1-exp(-zBot/L))/(exp(zBot/L) - exp(-zBot/L))
+      c2 = R-c1
 
       do iCell = 1, nCells
 

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_windstress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_windstress.F
@@ -117,8 +117,6 @@ contains
 
       real (kind=RKIND) :: transmissionCoeffTop, transmissionCoeffBot, zTop, zBot, remainingStress
 
-      real (kind=RKIND), pointer :: config_density0
-
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing tendencies
@@ -130,8 +128,6 @@ contains
       err = 0
 
       if ( .not. windStressOn ) return
-
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
 
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
 
@@ -150,7 +146,7 @@ contains
            remainingStress = remainingStress - (transmissionCoeffTop - transmissionCoeffBot)
 
            tend(k,iEdge) =  tend(k,iEdge) + edgeMask(k, iEdge) * surfaceWindStress(iEdge) &
-                         * (transmissionCoeffTop - transmissionCoeffBot) / config_density0 / layerThicknessEdge(k,iEdge)
+                         * (transmissionCoeffTop - transmissionCoeffBot) / rho_sw / layerThicknessEdge(k,iEdge)
 
            zTop = zBot
            transmissionCoeffTop = transmissionCoeffBot
@@ -159,7 +155,7 @@ contains
         if ( maxLevelEdgeTop(iEdge) > 0 .and. remainingStress > 0.0_RKIND) then
            tend(maxLevelEdgeTop(iEdge), iEdge) = tend(maxLevelEdgeTop(iEdge), iEdge) &
                          + edgeMask(maxLevelEdgeTop(iEdge), iEdge) * surfaceWindStress(iEdge) * remainingStress &
-                         / config_density0 / layerThicknessEdge(maxLevelEdgeTop(iEdge), iEdge)
+                         / rho_sw / layerThicknessEdge(maxLevelEdgeTop(iEdge), iEdge)
         end if
       enddo
 

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -618,21 +618,19 @@ contains
       ! call individual init routines for each parameterization
       !
       !-----------------------------------------------------------------
-      real (kind=RKIND), pointer :: config_density0
       logical, pointer :: config_disable_vel_pgrad
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
       call mpas_pool_get_config(ocnConfigs, 'config_common_level_weight', config_common_level_weight)
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_pgrad', config_disable_vel_pgrad)
 
       pgradOn = .true.
 
-      density0Inv = 1.0/config_density0
-      gdensity0Inv = gravity/config_density0
-      inv12 = 1.0/12.0
+      density0Inv = 1.0_RKIND / rho_sw
+      gdensity0Inv = gravity / rho_sw
+      inv12 = 1.0_RKIND / 12.0_RKIND
 
       if (config_disable_vel_pgrad) pgradOn = .false.
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_rich.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_rich.F
@@ -330,13 +330,12 @@ contains
       integer, dimension(:), pointer :: maxLevelCell
 
       real (kind=RKIND) :: coef
-      real (kind=RKIND), pointer :: config_density0, config_bkrd_vert_diff, config_bkrd_vert_visc, config_rich_mix, config_convective_diff
+      real (kind=RKIND), pointer :: config_bkrd_vert_diff, config_bkrd_vert_visc, config_rich_mix, config_convective_diff
 
       err = 0
 
       if(.not.richDiffOn) return
 
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
       call mpas_pool_get_config(ocnConfigs, 'config_bkrd_vert_diff', config_bkrd_vert_diff)
       call mpas_pool_get_config(ocnConfigs, 'config_bkrd_vert_visc', config_bkrd_vert_visc)
       call mpas_pool_get_config(ocnConfigs, 'config_rich_mix', config_rich_mix)
@@ -346,7 +345,7 @@ contains
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
-      coef = -gravity / config_density0 / 2.0
+      coef = -gravity / rho_sw / 2.0_RKIND
       do iCell = 1, nCells
          do k = 2, maxLevelCell(iCell)
             ! efficiency note: these if statements are inside iEdge and k loops.
@@ -441,14 +440,9 @@ contains
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
       real (kind=RKIND), dimension(:,:), allocatable :: ddensityTopOfCell, du2TopOfCell, &
                                                         ddensityTopOfEdge, du2TopOfEdge
-
-      real (kind=RKIND), pointer :: config_density0
-
       err = 0
 
       if ( ( .not. richViscOn ) .and. ( .not. richDiffOn ) ) return
-
-      call mpas_pool_get_config(ocnConfigs, 'config_density0', config_density0)
 
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -470,7 +464,7 @@ contains
          du2TopOfCell(nVertLevels+1,nCells+1), du2TopOfEdge(nVertLevels+1,nEdges))
 
       ! ddensityTopOfCell(k) = $\rho^*_{k-1}-\rho_k$, where $\rho^*$ has been adiabatically displaced to level k.
-      ddensityTopOfCell = 0.0
+      ddensityTopOfCell = 0.0_RKIND
       do iCell = 1, nCells
          do k = 2, maxLevelCell(iCell)
             ddensityTopOfCell(k,iCell) = displacedDensity(k-1,iCell) - density(k,iCell)
@@ -478,7 +472,7 @@ contains
       end do
 
       ! interpolate ddensityTopOfCell to ddensityTopOfEdge
-      ddensityTopOfEdge = 0.0
+      ddensityTopOfEdge = 0.0_RKIND
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -490,7 +484,7 @@ contains
        end do
 
       ! du2TopOfEdge(k) = $u_{k-1}-u_k$
-      du2TopOfEdge=0.0
+      du2TopOfEdge=0.0_RKIND
       do iEdge = 1, nEdges
          do k = 2, maxLevelEdgeTop(iEdge)
             du2TopOfEdge(k,iEdge) = (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2
@@ -498,38 +492,38 @@ contains
       end do
 
       ! interpolate du2TopOfEdge to du2TopOfCell
-      du2TopOfCell = 0.0
+      du2TopOfCell = 0.0_RKIND
       do iCell = 1, nCells
-        invAreaCell = 1.0 / areaCell(iCell)
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
 
           do k = 2, maxLevelEdgeBot(iEdge)
-            du2TopOfCell(k, iCell) = du2TopOfCell(k, iCell) + 0.5 * dcEdge(iEdge) * dvEdge(iEdge) * du2TopOfEdge(k, iEdge) * invAreaCell
+            du2TopOfCell(k, iCell) = du2TopOfCell(k, iCell) + 0.5_RKIND * dcEdge(iEdge) * dvEdge(iEdge) * du2TopOfEdge(k, iEdge) * invAreaCell
           end do
         end do
       end do
 
       ! compute RiTopOfEdge using ddensityTopOfEdge and du2TopOfEdge
       ! coef = -g/density_0/2
-      RiTopOfEdge = 0.0
-      coef = -gravity / config_density0 / 2.0
+      RiTopOfEdge = 0.0_RKIND
+      coef = -gravity / rho_sw / 2.0_RKIND
       do iEdge = 1, nEdges
          do k = 2, maxLevelEdgeTop(iEdge)
             RiTopOfEdge(k,iEdge) = coef * ddensityTopOfEdge(k,iEdge) &
                * ( layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge) ) &
-               / ( du2TopOfEdge(k,iEdge) + 1e-20 )
+               / ( du2TopOfEdge(k,iEdge) + 1e-20_RKIND )
          end do
       end do
 
       ! compute RiTopOfCell using ddensityTopOfCell and du2TopOfCell
       ! coef = -g/density_0/2
-      RiTopOfCell = 0.0
+      RiTopOfCell = 0.0_RKIND
       do iCell = 1,nCells
          do k = 2,maxLevelCell(iCell)
             RiTopOfCell(k,iCell) = coef * ddensityTopOfCell(k,iCell) &
                * (layerThickness(k-1,iCell) + layerThickness(k,iCell)) &
-               / (du2TopOfCell(k,iCell) + 1e-20)
+               / (du2TopOfCell(k,iCell) + 1e-20_RKIND)
          end do
       end do
 


### PR DESCRIPTION
This merge updates all references to config_density0 to use rho_sw
instead. rho_sw is a constant that the coupler defines when run in a
coupled model, and this allows all use of a reference density to use
consistent values of the reference density.

Additionally, this merge moves config_density0 from the
pressure_gradient namelist record to a new record named ocean_constants.

Finally, this merge performs some white space clean up and adds _RKIND
to some constants.
