### PR TITLE
Remove in_defaults from registry entries

### DIFF
--- a/src/core_ocean/mode_init/Registry_soma.xml
+++ b/src/core_ocean/mode_init/Registry_soma.xml
@@ -1,4 +1,4 @@
-        <nml_record name="soma" in_defaults="true" mode="init" configuration="soma">
+        <nml_record name="soma" mode="init" configuration="soma">
                 <nml_option name="config_soma_vert_levels" type="integer" default_value="100" units="unitless"
                                         description="Number of vertical levels in SOMA."
                                         possible_values="Any positive integer. Typically 40 or larger."

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -1,4 +1,4 @@
-	<nml_record name="tracer_forcing_activeTracers" in_defaults="true" mode="forward;analysis">
+	<nml_record name="tracer_forcing_activeTracers" mode="forward;analysis">
 		<nml_option name="config_use_activeTracers" type="logical" default_value=".true." units="unitless"
 					description="if true, the 'activeTracers' category is enabled for the run"
 					possible_values=".true. or .false."


### PR DESCRIPTION
in_defaults is no longer used (we use mode="..." in the ocean instead),
and so this merge removes the in_defaults attribute from all namelist
records / options.
