### PR TITLE
Fix error handling in barycentric weight calcs

### DIFF
--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -336,6 +336,7 @@ module mpas_geometry_utils
       if (vertexDegree /= 3) then
          write (stderrUnit,*) 'Error: Barycentric weights can only be calculated if vertexDegree is 3'
          ierr = 1
+         return
       endif
 
       triangleArea = mpas_triangle_signed_area(a, b, c, meshPool)
@@ -450,8 +451,10 @@ module mpas_geometry_utils
       logical :: in_a_triangle
       real(kind=RKIND) :: this_triangle_distance, nearest_triangle_distance
       integer :: nearest_triangle_index
+      integer :: err_tmp
 
       ierr = 0
+      err_tmp = 0
 
       nPoints = size(xPoint)
 
@@ -555,8 +558,8 @@ module mpas_geometry_utils
          triangle_c = (/ xCell(cell3), yCell(cell3), zCell(cell3) /)
 
          call mpas_calculate_barycentric_weights(point, triangle_a, triangle_b, triangle_c, meshPool,     &
-             baryWeightsOnPoints(1, iPoint), baryWeightsOnPoints(2, iPoint), baryWeightsOnPoints(3, iPoint), ierr)
-
+             baryWeightsOnPoints(1, iPoint), baryWeightsOnPoints(2, iPoint), baryWeightsOnPoints(3, iPoint), err_tmp)
+         ierr = ior(ierr, err_tmp)
       enddo
 
    end subroutine mpas_calculate_barycentric_weights_for_points !}}}


### PR DESCRIPTION
This fixes an issue with error handling in
mpas_calculate_barycentric_weights_for_points.
This routine calls baryWeightsOnPoints many times for a list of points,
but only the last value of the error code returned by baryWeightsOnPoints
is used by mpas_calculate_barycentric_weights_for_points.  This led to an
inconsistent error state being returned by
mpas_calculate_barycentric_weights_for_points.

This corrects that issue by adding an ior statement on a temporary
error variable.

This also adds a 'return' to a fatal error in
mpas_cells_to_points_using_baryweights;
there is no point actually calculating baryWeights if vertexDegree is
not 3.
