### PR TITLE
Add CXX vars to ESM Makefiles

### DIFF
--- a/src/Makefile.in.ACME
+++ b/src/Makefile.in.ACME
@@ -26,6 +26,7 @@ RM = rm -f
 CPP = cpp -P -traditional
 FC=$(MPIFC)
 CC=$(MPICC)
+CXX=$(MPICXX)
 NETCDF=$(NETCDF_PATH)
 PNETCDF=$(PNETCDF_PATH)
 PIO=$(EXEROOT)/pio
@@ -51,7 +52,7 @@ all:
 	@echo $(CPPINCLUDES)
 	@echo $(FCINCLUDES)
 	( $(MAKE) mpas RM="$(RM)" CPP="$(CPP)" NETCDF="$(NETCDF)" PNETCDF="$(PNETCDF)" \
-	  PIO="$(PIO)" FC="$(FC)" CC="$(CC)" SFC="$(SFC)" SCC="$(SCC)" \
+	  PIO="$(PIO)" FC="$(FC)" CC="$(CC)" CXX="$(CXX)" SFC="$(SFC)" SCC="$(SCC)" \
 	  CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" FCINCLUDES="$(FCINCLUDES)" \
 	  FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" )
 
@@ -63,7 +64,7 @@ mpas: externals frame ops dycore drver
 	ar ru lib$(COMPONENT).a $(DRIVER)/*.o
 
 externals:
-	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" ezxml-lib )
+	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" CXX="$(CXX)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" ezxml-lib )
 
 drver: externals frame ops dycore
 	( cd $(DRIVER); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" FREEFLAGS="$(FREEFLAGS)" all ) 

--- a/src/Makefile.in.CESM
+++ b/src/Makefile.in.CESM
@@ -26,6 +26,7 @@ RM = rm -f
 CPP = cpp -P -traditional
 FC=$(MPIFC)
 CC=$(MPICC)
+CXX=$(MPICXX)
 NETCDF=$(NETCDF_PATH)
 PNETCDF=$(PNETCDF_PATH)
 PIO=$(EXEROOT)/pio
@@ -51,7 +52,7 @@ all:
 	@echo $(CPPINCLUDES)
 	@echo $(FCINCLUDES)
 	( $(MAKE) mpas RM="$(RM)" CPP="$(CPP)" NETCDF="$(NETCDF)" PNETCDF="$(PNETCDF)" \
-	  PIO="$(PIO)" FC="$(FC)" CC="$(CC)" SFC="$(SFC)" SCC="$(SCC)" \
+	  PIO="$(PIO)" FC="$(FC)" CC="$(CC)" CXX="$(CXX)" SFC="$(SFC)" SCC="$(SCC)" \
 	  CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" FCINCLUDES="$(FCINCLUDES)" \
 	  FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" )
 
@@ -63,7 +64,7 @@ mpas: externals frame ops dycore drver
 	ar ru lib$(COMPONENT).a $(DRIVER)/*.o
 
 externals:
-	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" ezxml-lib )
+	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" CXX="$(CXX)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" ezxml-lib )
 
 drver: externals frame ops dycore
 	( cd $(DRIVER); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" FREEFLAGS="$(FREEFLAGS)" all ) 


### PR DESCRIPTION
Makefile.in.ACME and Makefile.in.CESM were missing CXX variables were
the C++ compiler was set to the MPI C++ compiler.  This caused builds
using C++ code in MPAS within ACME to fail on machines where the MPI and
serial compilers differ (e.g. Edison).  This fixes that issue.
