### PR TITLE
Sync analysis member restart streams with main restart stream

### DIFF
--- a/src/core_ocean/analysis_members/Registry_eliassen_palm.xml
+++ b/src/core_ocean/analysis_members/Registry_eliassen_palm.xml
@@ -651,7 +651,7 @@
 		  filename_template="restarts/eliassenPalm_restart.$Y-$M-$D.nc"
 		  filename_interval="01-00-00_00:00:00"
 		  input_interval="initial_only"
-		  output_interval="00-00-01_00:00:00"
+		  output_interval="stream:restart:output_interval"
 		  packages="eliassenPalmAMPKG"
 		  clobber_mode="truncate"
 		  runtime_format="single_file">

--- a/src/core_ocean/analysis_members/Registry_time_filters.xml
+++ b/src/core_ocean/analysis_members/Registry_time_filters.xml
@@ -66,7 +66,7 @@
       filename_template="restarts/timeFiltersRestart.$Y-$M-$D_$h.nc"
       filename_interval="01-00-00_00:00:00"
       input_interval="initial_only"
-      output_interval="00-00-01_00:00:00"
+      output_interval="stream:restart:output_interval"
       packages="timeFiltersAMPKG"
       clobber_mode="truncate"
       runtime_format="single_file">


### PR DESCRIPTION
This merge updates the output_interval of restart streams for analysis
members to ensure they are synchronized with the output_interval of the
restart stream, based on a new feature from the lastest MPAS framework.
