### PR TITLE
CVMIX update for the init core

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -135,7 +135,7 @@
 					baroclinic_channel_value="baroclinic_channel"
 					cvmix_convection_unit_test_value="cvmix_convection_unit_test"
 					cvmix_shear_unit_test_value="cvmix_shear_unit_test"
-					cvmx_WSwSBF_value="cvmx_WSwSBF"
+					cvmix_WSwSBF_value="cvmix_WSwSBF"
 					global_ocean_value="global_ocean"
 					internal_waves_value="internal_waves"
 					lock_exchange_value="lock_exchange"
@@ -588,7 +588,7 @@
 					possible_values="Any positive value"
 		/>
 	</nml_record>
-	<nml_record name="forcing" mode="init;forward">
+	<nml_record name="forcing" mode="forward">
 		<nml_option name="config_use_bulk_wind_stress" type="logical" default_value=".false." units="unitless"
 					description="Controls if zonal and meridional components of windstress are used to build surface wind stress."
 					possible_values=".true. or .false."
@@ -1044,7 +1044,18 @@
 			<var_struct name="tracersIdealAgeFields"/>
 			<var_struct name="tracersTTDFields"/>
                         <var name="landIceFraction"/>
-                        <var name="landIceSurfaceTemperature"/>
+			<var name="landIceSurfaceTemperature"/>
+                        <var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
+                        <var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
+                        <var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
+                        <var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
+                        <var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
+                        <var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
+                        <var name="latentHeatFlux"/>
+                        <var name="sensibleHeatFlux"/>
+                        <var name="shortWaveHeatFlux"/>
+                        <var name="evaporationFlux"/>
+                        <var name="rainFlux"/>
 		</stream>
 
 		<!-- Forward mode streams -->
@@ -1114,6 +1125,39 @@
 			<var name="highFreqThickness"/>
 			<var name="lowFreqDivergence"/>
 			<var name="seaSurfacePressure"/>
+		</stream>
+                <stream name="KPP_testing"
+                                type="output"
+                                filename_template="output/KPP_test.$Y-$M-$D_$h.$m.$s.nc"
+                                filename_interval="00-01-00_00:00:00"
+                                reference_time="0000-01-01_00:00:00"
+                                clobber_mode="truncate"
+                                output_interval="0000_01:00:00" 
+				runtime_format="single_file" >
+
+                        <stream name="mesh"/>
+			<var name="xtime"/>
+			<var_struct name="tracers"/>
+                        <var name="zMid"/>
+                        <var name="zTop"/>
+                        <var name="velocityZonal"/>
+                        <var name="velocityMeridional"/>
+                        <var name="bulkRichardsonNumber"/>
+                        <var name="bulkRichardsonNumberBuoy"/>
+                        <var name="unresolvedShear"/>
+                        <var name="boundaryLayerDepth"/>
+                        <var name="boundaryLayerDepthEdge"/>
+                        <var_array name="vertNonLocalFlux"/>
+                        <var name="surfaceFrictionVelocity"/>
+                        <var name="penetrativeTemperatureFluxOBL"/>
+                        <var name="surfaceBuoyancyForcing"/>
+                        <var name="windStressZonalDiag"/>
+                        <var name="windStressMeridionalDiag"/>
+                        <var name="transportVelocityZonal"/>
+                        <var name="transportVelocityMeridional"/>
+                        <var name="RiTopOfCell"/>
+			<var name="vertViscTopOfCell"/>
+			<var name="vertDiffTopOfCell"/>
 		</stream>
 
 		<stream name="restart"
@@ -1193,7 +1237,18 @@
 			<var_struct name="tracersIdealAgeFields"/>
 			<var_struct name="tracersTTDFields"/>
                         <var name="landIceFraction"/>
-                        <var name="landIceSurfaceTemperature"/>
+			<var name="landIceSurfaceTemperature"/>
+                        <var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
+                        <var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
+                        <var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
+                        <var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
+                        <var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
+                        <var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
+                        <var name="latentHeatFlux"/>
+                        <var name="sensibleHeatFlux"/>
+                        <var name="shortWaveHeatFlux"/>
+                        <var name="evaporationFlux"/>
+                        <var name="rainFlux"/>
 		</stream>
 
 		<!-- Diagnostics streams for forward mode -->

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -163,7 +163,7 @@ contains
       type (mpas_pool_type), pointer :: mixedLayerDepthsAM
 
       ! Here are some example variables which may be needed for your analysis member
-      integer, pointer :: nVertLevels, nCellsSolve, num_tracers
+      integer, pointer :: nVertLevels, nCellsSolve
       integer :: k, iCell, i, refIndex, refLevel(1)
       integer, pointer :: index_temperature
       integer, dimension(:), pointer :: maxLevelCell
@@ -194,8 +194,6 @@ contains
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mixedLayerDepthsAM', mixedLayerDepthsAMPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
-
-      call mpas_pool_get_dimension(statePool, 'num_tracers', num_tracers)
 
       call mpas_pool_get_config(domain % configs, 'config_AM_mixedLayerDepths_Tthreshold', tThresholdFlag)
       call mpas_pool_get_config(domain % configs, 'config_AM_mixedLayerDepths_Dthreshold', dThresholdFlag)

--- a/src/core_ocean/mode_init/Registry_cvmix_WSwSBF.xml
+++ b/src/core_ocean/mode_init/Registry_cvmix_WSwSBF.xml
@@ -62,7 +62,31 @@
                 <nml_option name="config_cvmix_WSwSBF_salinity_gradient" type="real" default_value="0.0" units="PSU m^{-1}"
                                         description="d/dz of salinity."
                                         possible_values="Any real number"
-                />
+		/>
+		<nml_option name="config_cvmix_WSwSBF_temperature_gradient_mixed_layer" type="real" default_value="0.0" units="deg C m^{-1}"
+			                description="d/dz of temperature in mixed temperature layer"
+					possible_values="Any real number"
+		/>
+	        <nml_option name="config_cvmix_WSwSBF_salinity_gradient_mixed_layer" type="real" default_value="0.0" units="PSU m^{-1}"
+			                description="d/dz of salinity in mixed salinity layer"
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_cvmix_WSwSBF_mixed_layer_depth_temperature" type="real" default_value="0.0" units="m"
+					description="depth mixed temperature layer"
+					possible_values="Any positive real number but must be less than bottom depth"
+		/>
+		<nml_option name="config_cvmix_WSwSBF_mixed_layer_depth_salinity" type="real" default_value="0.0" units="m"
+					description="depth mixed salinity layer"
+					possible_values="Any positive real number but less than bottom depth"
+		/>
+		<nml_option name="config_cvmix_WSwSBF_mixed_layer_temperature_change" type="real" default_value="0.0" units="deg C"
+					description="temperature jump when moving downward across the mixed layer interface"
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_cvmix_WSwSBF_mixed_layer_salinity_change" type="real" default_value="0.0" units="PSU"
+					description="salinity jump when moving downward across the mixed layer interface"
+					possible_values="Any real number"
+		/>
                 <nml_option name="config_cvmix_WSwSBF_vertical_grid" type="character" default_value="uniform" units="unitless"
                                         description="prescription of setting the vertical resolution of the test case"
                                         possible_values="'uniform' and 'stretched100'"

--- a/src/core_ocean/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
@@ -106,7 +106,9 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: interfaceLocations
 
-      integer :: iCell, iEdge, iVertex, k
+      integer :: iCell, iEdge, iVertex, k, kML
+
+      real (kind=RKIND) :: BLdepth
 
       character (len=StrKIND), pointer :: config_init_configuration, &
                                           config_cvmix_WSwSBF_vertical_grid
@@ -130,7 +132,13 @@ contains
                                           config_cvmix_WSwSBF_salinity_gradient, &
                                           config_cvmix_WSwSBF_bottom_depth, &
                                           config_cvmix_WSwSBF_max_windstress, &
-                                          config_cvmix_WSwSBF_coriolis_parameter
+                                          config_cvmix_WSwSBF_coriolis_parameter, &
+                                          config_cvmix_WSwSBF_temperature_gradient_mixed_layer, &
+                                          config_cvmix_WSwSBF_salinity_gradient_mixed_layer, &
+                                          config_cvmix_WSwSBF_mixed_layer_depth_temperature, &
+                                          config_cvmix_WSwSBF_mixed_layer_depth_salinity,    &
+                                          config_cvmix_WSwSBF_mixed_layer_temperature_change,       &
+                                          config_cvmix_WSwSBF_mixed_layer_salinity_change
       ! assume no error
       iErr = 0
 
@@ -164,6 +172,18 @@ contains
       call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_bottom_depth', config_cvmix_WSwSBF_bottom_depth)
       call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_max_windstress', config_cvmix_WSwSBF_max_windstress)
       call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_coriolis_parameter', config_cvmix_WSwSBF_coriolis_parameter)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_temperature_gradient_mixed_layer', &
+                config_cvmix_WSwSBF_temperature_gradient_mixed_layer)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_salinity_gradient_mixed_layer', &
+                config_cvmix_WSwSBF_salinity_gradient_mixed_layer)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_mixed_layer_depth_temperature', &
+                config_cvmix_WSwSBF_mixed_layer_depth_temperature)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_mixed_layer_depth_salinity', &
+                config_cvmix_WSwSBF_mixed_layer_depth_salinity)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_mixed_layer_temperature_change', &
+                config_cvmix_WSwSBF_mixed_layer_temperature_change)
+      call mpas_pool_get_config(domain % configs, 'config_cvmix_WSwSBF_mixed_layer_salinity_change', &
+                config_cvmix_WSwSBF_mixed_layer_salinity_change)
 
       ! load data that required to initialize the ocean simulation
       block_ptr => domain % blocklist
@@ -177,7 +197,7 @@ contains
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields', tracersSurfaceRestoringFieldsPool)
         call mpas_pool_get_subpool(forcingPool, 'tracersInteriorRestoringFields', tracersInteriorRestoringFieldsPool)
-
+        
         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
@@ -216,6 +236,7 @@ contains
         call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
         call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
 
+        
         ! Set refBottomDepth and refBottomDepthTopOfCell
         do k = 1, nVertLevels
            refBottomDepth(k) = config_cvmix_WSwSBF_bottom_depth * interfaceLocations(k+1)
@@ -224,106 +245,167 @@ contains
 
         ! Set vertCoordMovementWeights
         vertCoordMovementWeights(:) = 1.0_RKIND
-
+        
         do iCell = 1, nCellsSolve
-           ! Set temperature and salinity
-           do k = 1, nVertLevels
-              if ( associated(activeTracers) ) then
-                 temperature = config_cvmix_WSwSBF_surface_temperature + refZMid(k) * config_cvmix_WSwSBF_temperature_gradient
-                 activeTracers(index_temperature, k, iCell) = temperature
-                 salinity = config_cvmix_WSwSBF_surface_salinity + refZMid(k) * config_cvmix_WSwSBF_salinity_gradient
-                 activeTracers(index_salinity, k, iCell) = salinity
-              end if
-              
-              if ( associated(debugTracers) ) then
-                 debugTracers(index_tracer1, k, iCell) = 1.0_RKIND
-              end if
-           end do
+           if(associated(activeTracers) ) then
 
-           ! Set layerThickness
-           do k = 1, nVertLevels
-              layerThickness(k, iCell) = config_cvmix_WSwSBF_bottom_depth * (interfaceLocations(k+1) - interfaceLocations(k))
-              restingThickness(k, iCell) = layerThickness(k, iCell)
-           end do
+           ! Loop from surface through surface layer depth
+           k=1
+       			
+           do while (k .le. nVertLevels .and. refZMid(k) > - config_cvmix_WSwSBF_mixed_layer_depth_temperature)
+              temperature = config_cvmix_WSwSBF_surface_temperature + refZMid(k) *  &
+                            config_cvmix_WSwSBF_temperature_gradient_mixed_layer
+              activeTracers(index_temperature, k, iCell) = temperature
+              k = k + 1
+           enddo
+        		
+           ! the value of k is now the first layer below the surface layer
+           if ( k > 1 ) then
+              temperature = activeTracers(index_temperature, k-1, iCell) + config_cvmix_WSwSBF_mixed_layer_temperature_change
+              activeTracers(index_temperature, k, iCell) = temperature
+              BLdepth = refZMid(k)
+           else
+              activeTracers(index_temperature, k, iCell) = config_cvmix_WSwSBF_surface_temperature
+              BLdepth = 0.0
+           endif
+                 
+           ! find the first level below the mixed layer
+           kML = k + 1
 
-           ! Set surface temperature restoring value and rate
-           ! Value in units of C, piston velocity in units of m/s
-           if ( associated(activeTracersSurfaceRestoringValue) ) then
-              activeTracersSurfaceRestoringValue(index_temperature, iCell) = config_cvmix_WSwSBF_surface_restoring_temperature
-           end if
-           if ( associated(activeTracersPistonVelocity) ) then
-              activeTracersPistonVelocity(index_temperature, iCell) = config_cvmix_WSwSBF_temperature_piston_velocity
-           end if
-
-           ! Set surface salinity restoring value and rate
-           ! Value in units of PSU, piston velocity in units of m/s
-           if ( associated(activeTracersSurfaceRestoringValue) ) then
-              activeTracersSurfaceRestoringValue(index_salinity, iCell) = config_cvmix_WSwSBF_surface_restoring_salinity
-           end if
-           if ( associated(activeTracersPistonVelocity) ) then
-              activeTracersPistonVelocity(index_salinity, iCell) = config_cvmix_WSwSBF_salinity_piston_velocity
-           end if
-
-           ! Set sensible heat flux
-           sensibleHeatFlux(iCell) = config_cvmix_WSwSBF_sensible_heat_flux
-
-           ! Set latent heat flux
-           latentHeatFlux(iCell) = config_cvmix_WSwSBF_latent_heat_flux
-
-           ! Set shortwave heat flux
-           shortWaveHeatFlux(iCell) = config_cvmix_WSwSBF_shortwave_heat_flux
-
-           ! Set precipation and evaporation
-           rainFlux(iCell) = config_cvmix_WSwSBF_rain_flux
-           evaporationFlux(iCell) = config_cvmix_WSwSBF_evaporation_flux
-
-           ! Set interior temperature restoring value and rate
-           do k = 1, nVertLevels
-              if ( associated(activeTracersInteriorRestoringValue) ) then
-                 activeTracersInteriorRestoringValue(index_temperature, k, iCell) = activeTracers(index_temperature, k, iCell)
-              end if
-              if ( associated(activeTracersInteriorRestoringRate) ) then
-                 activeTracersInteriorRestoringRate(index_temperature, k, iCell) = config_cvmix_WSwSBF_interior_temperature_restoring_rate
-              end if
+           ! now loop from the bottom of the mixed layer thru to the bottom of the domain
+           do k = kML, nVertLevels
+              temperature = activeTracers(index_temperature, kML-1, iCell) + (refZMid(k) - BLdepth) * &
+              config_cvmix_WSwSBF_temperature_gradient
+              activeTracers(index_temperature, k, iCell) = temperature
            enddo
 
-           ! Set interior salinity restoring value and rate
-           do k = 1, nVertLevels
-              if ( associated(activeTracersInteriorRestoringValue) ) then
-                 activeTracersInteriorRestoringValue(index_salinity, k, iCell) = activeTracers(index_salinity, k, iCell)
-              end if
-              if ( associated(activeTracersInteriorRestoringRate) ) then
-                 activeTracersInteriorRestoringRate(index_salinity, k, iCell) = config_cvmix_WSwSBF_interior_salinity_restoring_rate
-              end if
+           !
+           ! next compute the salinity profile
+           !
+
+           ! Loop from surface through surface layer depth
+           k=1
+           do while (k .le. nVertLevels .and. refZMid(k) > - config_cvmix_WSwSBF_mixed_layer_depth_salinity)
+              salinity = config_cvmix_WSwSBF_surface_salinity + refZMid(k) * config_cvmix_WSwSBF_salinity_gradient_mixed_layer
+              activeTracers(index_salinity, k, iCell) = salinity
+              k = k + 1
            enddo
-
-           ! Set Coriolis parameter
-           fCell(iCell) = config_cvmix_WSwSBF_coriolis_parameter
-
-           ! Set bottomDepth
-           bottomDepth(iCell) = config_cvmix_WSwSBF_bottom_depth
-
-           ! Set maxLevelCell
-           maxLevelCell(iCell) = nVertLevels
+             	
+           ! the value of k is now the first layer below the surface layer
+            if ( k > 1 ) then
+               salinity = activeTracers(index_salinity, k-1, iCell) + config_cvmix_WSwSBF_mixed_layer_salinity_change
+               activeTracers(index_salinity, k, iCell) = salinity
+               BLdepth = refZMid(k)
+            else
+               activeTracers(index_salinity, k, iCell) = config_cvmix_WSwSBF_surface_salinity
+               BLdepth = 0.0
+            endif
+                
+            ! find the first level below the mixed layer
+            kML = k + 1
+                
+            ! now loop from the bottom of the mixed layer thru to the bottom of the domain
+            do k = kML, nVertLevels
+               salinity = activeTracers(index_salinity, kML-1, iCell) + (refZMid(k) - BLdepth) *  &
+               config_cvmix_WSwSBF_salinity_gradient
+               activeTracers(index_salinity, k, iCell) = salinity
+            enddo
+                	
+        endif ! if (associated(activeTracer))
+       
+        ! as a place holder, have some debug tracer in the top few layers and zero below
+        if ( associated(debugTracers) ) then
+           debugTracers(index_tracer1, k, iCell) = 0.0_RKIND
+           do k=1,min(4,nVertLevels)
+              debugTracers(index_tracer1, k, iCell) = 1.0_RKIND   
+           enddo
+        endif
+      
+        ! Set layerThickness
+        do k = 1, nVertLevels
+           layerThickness(k, iCell) = config_cvmix_WSwSBF_bottom_depth * (interfaceLocations(k+1) - interfaceLocations(k))
+           restingThickness(k, iCell) = layerThickness(k, iCell)
         end do
 
-        do iCell = 1, nCellsSolve
-           windStressZonal(iCell) = config_cvmix_WSwSBF_max_windstress
-           windStressMeridional(iCell) = 0.0_RKIND
+        ! Set surface temperature restoring value and rate
+        ! Value in units of C, piston velocity in units of m/s
+        if ( associated(activeTracersSurfaceRestoringValue) ) then
+           activeTracersSurfaceRestoringValue(index_temperature, iCell) = config_cvmix_WSwSBF_surface_restoring_temperature
+        end if
+        if ( associated(activeTracersPistonVelocity) ) then
+           activeTracersPistonVelocity(index_temperature, iCell) = config_cvmix_WSwSBF_temperature_piston_velocity
+        end if
+
+        ! Set surface salinity restoring value and rate
+        ! Value in units of PSU, piston velocity in units of m/s
+        if ( associated(activeTracersSurfaceRestoringValue) ) then
+           activeTracersSurfaceRestoringValue(index_salinity, iCell) = config_cvmix_WSwSBF_surface_restoring_salinity
+        end if
+        if ( associated(activeTracersPistonVelocity) ) then
+           activeTracersPistonVelocity(index_salinity, iCell) = config_cvmix_WSwSBF_salinity_piston_velocity
+        end if
+
+        ! Set sensible heat flux
+        sensibleHeatFlux(iCell) = config_cvmix_WSwSBF_sensible_heat_flux
+
+        ! Set latent heat flux
+        latentHeatFlux(iCell) = config_cvmix_WSwSBF_latent_heat_flux
+
+        ! Set shortwave heat flux
+        shortWaveHeatFlux(iCell) = config_cvmix_WSwSBF_shortwave_heat_flux
+
+        ! Set precipation and evaporation
+        rainFlux(iCell) = config_cvmix_WSwSBF_rain_flux
+        evaporationFlux(iCell) = config_cvmix_WSwSBF_evaporation_flux
+
+        ! Set interior temperature restoring value and rate
+        do k = 1, nVertLevels
+           if ( associated(activeTracersInteriorRestoringValue) ) then
+              activeTracersInteriorRestoringValue(index_temperature, k, iCell) = activeTracers(index_temperature, k, iCell)
+           end if
+           if ( associated(activeTracersInteriorRestoringRate) ) then
+              activeTracersInteriorRestoringRate(index_temperature, k, iCell) = config_cvmix_WSwSBF_interior_temperature_restoring_rate
+           end if
         enddo
 
-        do iEdge = 1, nEdgesSolve
-           fEdge(iEdge) = config_cvmix_WSwSBF_coriolis_parameter
-        end do
- 
-        do iVertex=1, nVerticesSolve
-           fVertex(iVertex) = config_cvmix_WSwSBF_coriolis_parameter
-        end do
+        ! Set interior salinity restoring value and rate
+        do k = 1, nVertLevels
+           if ( associated(activeTracersInteriorRestoringValue) ) then
+              activeTracersInteriorRestoringValue(index_salinity, k, iCell) = activeTracers(index_salinity, k, iCell)
+           end if
+           if ( associated(activeTracersInteriorRestoringRate) ) then
+              activeTracersInteriorRestoringRate(index_salinity, k, iCell) = config_cvmix_WSwSBF_interior_salinity_restoring_rate
+           end if
+        enddo
 
-        block_ptr => block_ptr % next
-      end do
+        ! Set Coriolis parameter
+        fCell(iCell) = config_cvmix_WSwSBF_coriolis_parameter
 
-      deallocate(interfaceLocations)
+        ! Set bottomDepth
+        bottomDepth(iCell) = config_cvmix_WSwSBF_bottom_depth
+
+        ! Set maxLevelCell
+        maxLevelCell(iCell) = nVertLevels
+
+     end do  ! do iCell
+
+     do iCell = 1, nCellsSolve
+        windStressZonal(iCell) = config_cvmix_WSwSBF_max_windstress
+        windStressMeridional(iCell) = 0.0_RKIND
+     enddo
+
+     do iEdge = 1, nEdgesSolve
+        fEdge(iEdge) = config_cvmix_WSwSBF_coriolis_parameter
+     end do
+
+     do iVertex=1, nVerticesSolve
+        fVertex(iVertex) = config_cvmix_WSwSBF_coriolis_parameter
+     end do
+
+     block_ptr => block_ptr % next
+   end do
+
+   deallocate(interfaceLocations)
 
    !--------------------------------------------------------------------
 


### PR DESCRIPTION
The primary update is the extension of the cvmix test case to include pre-existing mixed layers in temperature and/or salinity.  The functionality is general enough to allow for stratification in the mixed layer (with different mixed layer depths for salinity and temperature) and deeper ocean (example below).  The user can also specify a temperature and/or salinity jump across the mixed layer.

I also added a KPP testing stream for CVMIX/SCM tests

Finally, there was a small big in the mixed layer depth analysis member that has been fixed.  num_tracers was referenced without being defined, but the analysis member didn't need this variable so it was deleted.

![screen shot 2015-09-25 at 11 18 39 am](https://cloud.githubusercontent.com/assets/13662545/10107272/325bb19a-6377-11e5-8cde-127eb2c1fa0c.png)
