### PR TITLE
Fix initialization / read of global attributes

### DIFF
--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -66,6 +66,11 @@ module mpas_bootstrapping
    !>  Attributes required to be present in the grid file:
    !>      on_a_sphere
    !>      sphere_radius
+   !>      parent_id
+   !>      mesh_spec
+   !>      is_periodic
+   !>      x_period
+   !>      y_period
    !>      ***** these are needed by mpas_block_creator_finalize_block_init()
    !>            so they can be set in the mesh pool and queried by, e.g.,
    !>            mpas_initialize_vectors()
@@ -86,7 +91,7 @@ module mpas_bootstrapping
       integer :: ierr
       type (MPAS_IO_Handle_type) :: inputHandle
 
-      character (len=StrKIND) :: c_on_a_sphere, c_is_periodic
+      character (len=StrKIND) :: c_on_a_sphere, c_is_periodic, c_parent_id, c_file_id, c_mesh_spec
       real (kind=RKIND) :: r_sphere_radius, r_x_period, r_y_period
 
       type (field1dInteger), pointer :: indexToCellIDField
@@ -277,6 +282,39 @@ module mpas_bootstrapping
          domain % sphere_radius = 1.0
       else
          domain % sphere_radius = r_sphere_radius
+      end if
+
+      !
+      ! We need to read in the file_id, parent_id, and mesh spec attributes as well, to
+      ! set them appropriately in the output files.
+      !
+      call MPAS_io_get_att(inputHandle, 'file_id', c_file_id, ierr=ierr)
+      if ( ierr /= MPAS_IO_NOERR) then
+         write(stderrUnit, *) 'Warning: Attribute file_id not found in '//trim(mesh_filename)
+         write(stderrUnit, *) '  Using '''' for the previous file_id.'
+         c_file_id = ''
+      end if
+
+      call MPAS_io_get_att(inputHandle, 'parent_id', c_parent_id, ierr=ierr)
+      if ( ierr /= MPAS_IO_NOERR) then
+         write(stderrUnit, *) 'Warning: Attribute parent_id not found in '//trim(mesh_filename)
+         write(stderrUnit, *) '  Setting parent_id to '''''
+         c_parent_id = ''
+      end if
+
+      if ( trim(c_file_id) == '' ) then
+         domain % parent_id = c_parent_id
+      else
+         domain % parent_id = trim(c_file_id) // NEW_LINE('A') // trim(c_parent_id)
+      end if
+
+      call MPAS_io_get_att(inputHandle, 'mesh_spec', c_mesh_spec, ierr=ierr)
+      if ( ierr /= MPAS_IO_NOERR) then
+         write(stderrUnit, *) 'Warning: Attribute mesh_spec not found in '//trim(mesh_filename)
+         write(stderrUnit, *) '  Setting mesh_spec to ''0.0'''
+         domain % mesh_spec = '0.0'
+      else
+        domain % mesh_spec = c_mesh_spec
       end if
 
       !

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -12,15 +12,15 @@
       type (dm_info), pointer :: dminfo
 
       ! Domain specific constants
-      logical :: on_a_sphere
-      logical :: is_periodic
-      real (kind=RKIND) :: sphere_radius
-      real (kind=RKIND) :: x_period
-      real (kind=RKIND) :: y_period
-      character (len=StrKIND) :: namelist_filename !< Constant: Name of namelist file
-      character (len=StrKIND) :: streams_filename !< Constant: Name of stream configuration file
-      character (len=StrKIND) :: mesh_spec !< mesh_spec attribute, read in from input file.
-      character (len=StrKIND) :: parent_id !< parent_id attribute, read in from input file.
+      logical :: on_a_sphere = .true.
+      logical :: is_periodic = .false.
+      real (kind=RKIND) :: sphere_radius = 1.0_RKIND
+      real (kind=RKIND) :: x_period = 0.0_RKIND
+      real (kind=RKIND) :: y_period = 0.0_RKIND
+      character (len=StrKIND) :: namelist_filename = '' !< Constant: Name of namelist file
+      character (len=StrKIND) :: streams_filename = '' !< Constant: Name of stream configuration file
+      character (len=StrKIND) :: mesh_spec = '' !< mesh_spec attribute, read in from input file.
+      character (len=StrKIND) :: parent_id = '' !< parent_id attribute, read in from input file.
 
       ! Back pointer to core
       type (core_type), pointer :: core => null()

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -3352,7 +3352,7 @@ module mpas_io
    end subroutine MPAS_io_get_att_text
 
 
-   subroutine MPAS_io_put_att_int0d(handle, attName, attValue, fieldname, ierr)
+   subroutine MPAS_io_put_att_int0d(handle, attName, attValue, fieldname, syncVal, ierr)
 
       implicit none
 
@@ -3360,12 +3360,16 @@ module mpas_io
       character (len=*), intent(in) :: attName
       integer, intent(in) :: attValue
       character (len=*), intent(in), optional :: fieldname
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
       integer :: varid
+      integer :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: attlist_cursor, new_attlist_node
+
+      attValueLocal = attValue
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_att_int0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -3478,7 +3482,13 @@ module mpas_io
          end if
       end if
 
-      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValue) 
+      if ( present(syncVal) ) then
+         if ( syncVal ) then
+            call mpas_dmpar_bcast_int(handle % iocontext % dminfo, attValueLocal, IO_NODE)
+         end if
+      end if
+
+      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
@@ -3489,7 +3499,7 @@ module mpas_io
    end subroutine MPAS_io_put_att_int0d
 
 
-   subroutine MPAS_io_put_att_int1d(handle, attName, attValue, fieldname, ierr)
+   subroutine MPAS_io_put_att_int1d(handle, attName, attValue, fieldname, syncVal, ierr)
 
       implicit none
 
@@ -3497,12 +3507,17 @@ module mpas_io
       character (len=*), intent(in) :: attName
       integer, dimension(:), intent(in) :: attValue
       character (len=*), intent(in), optional :: fieldname
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
       integer :: varid
+      integer, dimension(:), pointer :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: attlist_cursor, new_attlist_node
+
+      allocate(attValueLocal(size(attValue, dim=1)))
+      attValueLocal(:) = attValue(:)
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_att_int1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -3624,18 +3639,26 @@ module mpas_io
          end if
       end if
 
-      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValue) 
+      if ( present(syncVal) ) then
+         if ( syncVal ) then
+            call mpas_dmpar_bcast_ints(handle % iocontext % dminfo, size(attValueLocal, dim=1), attValueLocal, IO_NODE)
+         end if
+      end if
+
+      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+
+      deallocate(attValueLocal)
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
    end subroutine MPAS_io_put_att_int1d
 
 
-   subroutine MPAS_io_put_att_real0d(handle, attName, attValue, fieldname, ierr)
+   subroutine MPAS_io_put_att_real0d(handle, attName, attValue, fieldname, syncVal, ierr)
 
       implicit none
 
@@ -3643,12 +3666,16 @@ module mpas_io
       character (len=*), intent(in) :: attName
       real (kind=RKIND), intent(in) :: attValue
       character (len=*), intent(in), optional :: fieldname
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
       integer :: varid
+      real (kind=RKIND) :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: attlist_cursor, new_attlist_node
+
+      attValueLocal = attValue
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_att_real0d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -3761,7 +3788,13 @@ module mpas_io
          end if
       end if
 
-      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValue) 
+      if ( present(syncVal) ) then
+         if ( syncVal ) then
+            call mpas_dmpar_bcast_real(handle % iocontext % dminfo, attValueLocal, IO_NODE)
+         end if
+      end if
+
+      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
@@ -3772,7 +3805,7 @@ module mpas_io
    end subroutine MPAS_io_put_att_real0d
 
 
-   subroutine MPAS_io_put_att_real1d(handle, attName, attValue, fieldname, ierr)
+   subroutine MPAS_io_put_att_real1d(handle, attName, attValue, fieldname, syncVal, ierr)
 
       implicit none
 
@@ -3780,12 +3813,18 @@ module mpas_io
       character (len=*), intent(in) :: attName
       real (kind=RKIND), dimension(:), intent(in) :: attValue
       character (len=*), intent(in), optional :: fieldname
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
       integer :: varid
+      real (kind=RKIND), dimension(:), allocatable :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: attlist_cursor, new_attlist_node
+
+      allocate(attValueLocal( size(attValue, dim=1) ) )
+
+      attValueLocal(:) = attValue(:)
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_att_real1d()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -3907,18 +3946,26 @@ module mpas_io
          end if
       end if
 
-      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValue) 
+      if ( present(syncVal) ) then
+         if ( syncVal ) then
+            call mpas_dmpar_bcast_reals(handle % iocontext % dminfo, size(attValueLocal, dim=1), attValueLocal, IO_NODE)
+         end if
+      end if
+
+      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+
+      deallocate(attValueLocal)
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
    end subroutine MPAS_io_put_att_real1d
 
 
-   subroutine MPAS_io_put_att_text(handle, attName, attValue, fieldname, ierr)
+   subroutine MPAS_io_put_att_text(handle, attName, attValue, fieldname, syncVal, ierr)
 
       implicit none
 
@@ -3926,12 +3973,25 @@ module mpas_io
       character (len=*), intent(in) :: attName
       character (len=*), intent(in) :: attValue
       character (len=*), intent(in), optional :: fieldname
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
       integer :: varid
+      integer :: valLen
+      character (len=StrKind) :: attValueLocal, trimmedVal
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: attlist_cursor, new_attlist_node
+
+      valLen = len_trim(attValue)
+      trimmedVal = trim(attValue)
+
+      if ( valLen > StrKind ) then
+         write(stderrUnit, *) ' WARNING: Attribute ''' // trim(attName) // ''' has a value longer than StrKIND. It will be cut to a length of ', StrKIND
+         attValueLocal = trimmedVal(1:StrKIND)
+      else
+         attValueLocal = trimmedVal
+      end if
 
 !      write(stderrUnit,*) 'Called MPAS_io_put_att_text()'
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -4044,7 +4104,13 @@ module mpas_io
          end if
       end if
 
-      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValue)) 
+      if ( present(syncVal) ) then
+         if ( syncVal ) then
+            call mpas_dmpar_bcast_char(handle % iocontext % dminfo, attValueLocal, IO_NODE)
+         end if
+      end if
+
+      pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
 
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -4061,7 +4127,7 @@ module mpas_io
                return
             end if
 
-            pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValue)) 
+            pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
             if (pio_ierr /= PIO_noerr) then
                return
             end if

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -3746,13 +3746,14 @@ module mpas_io_streams
    end subroutine MPAS_readStreamAtt_text
 
 
-   subroutine MPAS_writeStreamAtt_0dInteger(stream, attName, attValue, ierr)
+   subroutine MPAS_writeStreamAtt_0dInteger(stream, attName, attValue, syncVal, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       character (len=*), intent(in) :: attName
       integer, intent(in) :: attValue
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -3767,20 +3768,21 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dInteger
 
 
-   subroutine MPAS_writeStreamAtt_1dInteger(stream, attName, attValue, ierr)
+   subroutine MPAS_writeStreamAtt_1dInteger(stream, attName, attValue, syncVal, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       character (len=*), intent(in) :: attName
       integer, dimension(:), intent(in) :: attValue
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -3795,20 +3797,21 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dInteger
 
 
-   subroutine MPAS_writeStreamAtt_0dReal(stream, attName, attValue, ierr)
+   subroutine MPAS_writeStreamAtt_0dReal(stream, attName, attValue, syncVal, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       character (len=*), intent(in) :: attName
       real (kind=RKIND), intent(in) :: attValue
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -3823,20 +3826,21 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dReal
 
 
-   subroutine MPAS_writeStreamAtt_1dReal(stream, attName, attValue, ierr)
+   subroutine MPAS_writeStreamAtt_1dReal(stream, attName, attValue, syncVal, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       character (len=*), intent(in) :: attName
       real (kind=RKIND), dimension(:), intent(in) :: attValue
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -3851,20 +3855,21 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dReal
 
 
-   subroutine MPAS_writeStreamAtt_text(stream, attName, attValue, ierr)
+   subroutine MPAS_writeStreamAtt_text(stream, attName, attValue, syncVal, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       character (len=*), intent(in) :: attName
       character (len=*), intent(in) :: attValue
+      logical, intent(in), optional :: syncVal
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -3879,7 +3884,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -3493,19 +3493,19 @@ module mpas_stream_manager
                 if ( itr % memberType == MPAS_POOL_CONFIG) then
                     if ( itr % dataType == MPAS_POOL_REAL ) then
                         call mpas_pool_get_config(stream % att_pool, itr % memberName, realAtt)
-                        call mpas_writeStreamAtt(stream % stream, itr % memberName, realAtt, local_ierr)
+                        call mpas_writeStreamAtt(stream % stream, itr % memberName, realAtt, syncVal=.false., ierr=local_ierr)
                     else if ( itr % dataType == MPAS_POOL_INTEGER ) then
                         call mpas_pool_get_config(stream % att_pool, itr % memberName, intAtt)
-                        call mpas_writeStreamAtt(stream % stream, itr % memberName, intAtt, local_ierr)
+                        call mpas_writeStreamAtt(stream % stream, itr % memberName, intAtt, syncVal=.false., ierr=local_ierr)
                     else if ( itr % dataType == MPAS_POOL_CHARACTER ) then
                         call mpas_pool_get_config(stream % att_pool, itr % memberName, charAtt)
-                        call mpas_writeStreamAtt(stream % stream, itr % memberName, charAtt, local_ierr)
+                        call mpas_writeStreamAtt(stream % stream, itr % memberName, charAtt, syncVal=.false., ierr=local_ierr)
                     else if ( itr % dataType == MPAS_POOL_LOGICAL ) then
                         call mpas_pool_get_config(stream % att_pool, itr % memberName, logAtt)
                         if (logAtt) then
-                            call mpas_writeStreamAtt(stream % stream, itr % memberName, 'YES', local_ierr)
+                            call mpas_writeStreamAtt(stream % stream, itr % memberName, 'YES', syncVal=.false., ierr=local_ierr)
                         else
-                            call mpas_writeStreamAtt(stream % stream, itr % memberName, 'NO', local_ierr)
+                            call mpas_writeStreamAtt(stream % stream, itr % memberName, 'NO', syncVal=.false., ierr=local_ierr)
                         end if
                     end if
 
@@ -3520,7 +3520,7 @@ module mpas_stream_manager
             ! Generate file_id and write to stream
             !
             call gen_random(idLength, file_id)
-            call mpas_writeStreamAtt(stream % stream, 'file_id', file_id, local_ierr)
+            call mpas_writeStreamAtt(stream % stream, 'file_id', file_id, syncVal=.true., ierr=local_ierr)
             if (local_ierr /= MPAS_STREAM_NOERR) then
                 ierr = MPAS_STREAM_MGR_ERROR
                 return


### PR DESCRIPTION
This merge fixes two issues related to global attributes.
 1) parent_id and mesh_spec should be read in from the input file,
    to initialize their values
 2) All global attribute values should be initialized to some value
    before trying to write the mesh.
 3) Allowing synchronization of attribute values prior to writing them
    to the output file

When global attributes are not initialized properly, they have
(potentially) different values on each processor that will be writing a
file. If they do have different values on each processor, pnetcdf and
thus pio thinks there was an error in defining the file.

When this happens, the first field that is going to be written is
skipped, causing it to be filled with zeroes.

This merge also introduces the ability to optionally synchronize the
value of global attributes prior to writing them out. This is useful for
attributes that likely have different values on each processor, such as
file_id.
