### PR TITLE
Fix intel build since analysis_members

### DIFF
--- a/src/core_landice/build_options.mk
+++ b/src/core_landice/build_options.mk
@@ -3,7 +3,7 @@ ifeq "$(ROOT_DIR)" ""
 endif
 EXE_NAME=landice_model
 NAMELIST_SUFFIX=landice
-FCINCLUDES += -I$(ROOT_DIR)/core_landice/mode_forward -I$(ROOT_DIR)/core_landice/shared
+FCINCLUDES += -I$(ROOT_DIR)/core_landice/mode_forward -I$(ROOT_DIR)/core_landice/shared -I$(ROOT_DIR)/core_landice/analysis_members
 override CPPFLAGS += -DCORE_LANDICE
 
 # ===================================


### PR DESCRIPTION
986572f introduced analysis members into MPAS-LI.  However
build_options.mk was not updated to add the new analysis_members directory
into the FC includes list of directories.  This prevented the code from
compiling with Intel.  (GCC worked fine.)

This merge adds the new directory to the includes list so that Intel
will compile.
