### PR TITLE
Changes for two-way coupling and clean-up.

### DIFF
--- a/src/core_cice/Registry.xml
+++ b/src/core_cice/Registry.xml
@@ -352,7 +352,7 @@
         <!-- forcing streams -->
 	<stream name="LYqSixHourlyForcing"
 	    type="input"
-	    filename_template="/Users/akt/Work/MPAS-CICE/forcing/forcing_creation/atmosphere/perform_remap/120km/LYq_six_hourly.$Y.nc"
+	    filename_template="120km/LYq_six_hourly.$Y.nc"
 	    filename_interval="0001-00-00_00:00:00"
 	    input_interval="none"
 	    immutable="true">
@@ -363,7 +363,7 @@
 	</stream>
 	<stream name="LYqMonthlyForcing"
 	    type="input"
-	    filename_template="/Users/akt/Work/MPAS-CICE/forcing/forcing_creation/atmosphere/perform_remap/120km/LYq_monthly.nc"
+	    filename_template="LYq_monthly.nc"
 	    filename_interval="none"
 	    input_interval="none"
 	    immutable="true">
@@ -372,7 +372,7 @@
 	</stream>
 	<stream name="NCARMonthlySSTForcing"
 	    type="input"
-	    filename_template="/Users/akt/Work/MPAS-CICE/forcing/forcing_creation/atmosphere/perform_remap/120km/LYq_monthly.nc"
+	    filename_template="oceanmixed_ice_depth_mpas.nc"
 	    filename_interval="none"
 	    input_interval="none"
 	    immutable="true">
@@ -380,7 +380,7 @@
 	</stream>
 	<stream name="NCARMonthlyForcing"
 	    type="input"
-	    filename_template="/Users/akt/Work/MPAS-CICE/forcing/forcing_creation/atmosphere/perform_remap/120km/LYq_monthly.nc"
+	    filename_template="oceanmixed_ice_depth_mpas.nc"
 	    filename_interval="none"
 	    input_interval="none"
 	    immutable="true">
@@ -583,9 +583,6 @@
 		<var name="latentTransferCoefficient"         type="real"     dimensions="nCells"                   name_in_code="latentTransferCoefficient"/>
 		<var name="uPOPAlongGridVector"               type="real"     dimensions="TWO nCells"               name_in_code="uPOPAlongGridVector"/>
 		<var name="vPOPAlongGridVector"               type="real"     dimensions="TWO nCells"               name_in_code="vPOPAlongGridVector"/>
-		<var name="airReferenceTemperature2m"         type="real"     dimensions="nCells"                   name_in_code="airReferenceTemperature2m"/>
-		<var name="airReferenceHumidity2m"            type="real"     dimensions="nCells"                   name_in_code="airReferenceHumidity2m"/>
-		<var name="airReferenceSpeed10m"              type="real"     dimensions="nCells"                   name_in_code="airReferenceSpeed10m"/>
 	</var_struct>
 
 	<!--alternative atmos forcing -->

--- a/src/core_cice/forward_model/mpas_cice_column.F
+++ b/src/core_cice/forward_model/mpas_cice_column.F
@@ -942,9 +942,9 @@ contains
          airSpecificHumidity, &
          airDensity, &
          airTemperature, &
-         airReferenceTemperature2m, &
-         airReferenceHumidity2m, &
-         airReferenceSpeed10m, &
+         atmosReferenceTemperature2m, &
+         atmosReferenceHumidity2m, &
+         atmosReferenceSpeed10m, &
          airOceanDragCoefficientRatio, &
          oceanDragCoefficient, &
          oceanDragCoefficientSkin, &
@@ -1151,11 +1151,11 @@ contains
        call MPAS_pool_get_array(atmos_coupling, "snowfallRate", snowfallRate)
        call MPAS_pool_get_array(atmos_coupling, "rainfallRate", rainfallRate)
        call MPAS_pool_get_array(atmos_coupling, "longwaveDown", longwaveDown)
+       call MPAS_pool_get_array(atmos_coupling, "atmosReferenceTemperature2m", atmosReferenceTemperature2m)
+       call MPAS_pool_get_array(atmos_coupling, "atmosReferenceHumidity2m", atmosReferenceHumidity2m)
+       call MPAS_pool_get_array(atmos_coupling, "atmosReferenceSpeed10m", atmosReferenceSpeed10m)
 
        call MPAS_pool_get_array(atmos_forcing, "windSpeed", windSpeed)
-       call MPAS_pool_get_array(atmos_forcing, "airReferenceTemperature2m", airReferenceTemperature2m)
-       call MPAS_pool_get_array(atmos_forcing, "airReferenceHumidity2m", airReferenceHumidity2m)
-       call MPAS_pool_get_array(atmos_forcing, "airReferenceSpeed10m", airReferenceSpeed10m)
 
        call MPAS_pool_get_array(alternative_atmos_forcing, "latentHeatFluxCouple", latentHeatFluxCouple)
        call MPAS_pool_get_array(alternative_atmos_forcing, "sensibleHeatFluxCouple", sensibleHeatFluxCouple)
@@ -1326,9 +1326,9 @@ contains
                airSpecificHumidity(iCell), &
                airDensity(iCell), &
                airTemperature(iCell), &
-               airReferenceTemperature2m(iCell), &
-               airReferenceHumidity2m(iCell), &
-               airReferenceSpeed10m(iCell), &
+               atmosReferenceTemperature2m(iCell), &
+               atmosReferenceHumidity2m(iCell), &
+               atmosReferenceSpeed10m(iCell), &
                airOceanDragCoefficientRatio(iCell), &
                oceanDragCoefficient(iCell), &
                oceanDragCoefficientSkin(iCell), &

--- a/src/core_cice/forward_model/mpas_cice_core.F
+++ b/src/core_cice/forward_model/mpas_cice_core.F
@@ -10,6 +10,7 @@ module cice_core
    use mpas_framework
    use mpas_timekeeping
    use cice_analysis_driver
+   use cice_column
 
    private
    public :: &
@@ -292,6 +293,9 @@ module cice_core
          call mpas_timer_start("time integration")
          call mpas_timestep(domain, itimestep, dt, timeStamp)
          call mpas_timer_stop("time integration")
+
+         ! reinitialize fluxes
+         call cice_column_reinitialize_fluxes(domain)
 
          ! update the restart_timestamp file with the new time if needed
          if ( mpas_stream_mgr_ringing_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_OUTPUT, ierr=ierr) ) then

--- a/src/core_cice/forward_model/mpas_cice_debug.F
+++ b/src/core_cice/forward_model/mpas_cice_debug.F
@@ -2945,12 +2945,12 @@ contains
        call cice_debug_write_out_field(domain, "atmos_coupling", "snowfallRate", "fsnow")
        call cice_debug_write_out_field(domain, "atmos_coupling", "uAirVelocity", "uatm")
        call cice_debug_write_out_field(domain, "atmos_coupling", "vAirVelocity", "vatm")
+       call cice_debug_write_out_field(domain, "atmos_coupling", "atmosReferenceTemperature2m", "")
+       call cice_debug_write_out_field(domain, "atmos_coupling", "atmosReferenceHumidity2m", "")
+       call cice_debug_write_out_field(domain, "atmos_coupling", "atmosReferenceSpeed10m", "")
 
        call cice_debug_write_out_field(domain, "atmos_forcing", "windSpeed", "wind")
        call cice_debug_write_out_field(domain, "atmos_forcing", "shortwaveDown", "fsw")
-       call cice_debug_write_out_field(domain, "atmos_forcing", "airReferenceTemperature2m", "")
-       call cice_debug_write_out_field(domain, "atmos_forcing", "airReferenceHumidity2m", "")
-       call cice_debug_write_out_field(domain, "atmos_forcing", "airReferenceSpeed10m", "")
        !call cice_debug_write_out_field(domain, "atmos_forcing", "sensibleTransferCoefficient", "shcoef")
        !call cice_debug_write_out_field(domain, "atmos_forcing", "latentTransferCoefficient", "lhcoef")
 

--- a/src/core_cice/forward_model/mpas_cice_time_integration.F
+++ b/src/core_cice/forward_model/mpas_cice_time_integration.F
@@ -168,9 +168,6 @@ contains
 
     call cice_debug_write_out_fields(domain, "cice_timestep", 2)
 
-    ! reinitialize fluxes
-    call cice_column_reinitialize_fluxes(domain)
-
 
   end subroutine cice_timestep!}}}
 


### PR DESCRIPTION
This commit contains changes for several reasons, involving support for
two-way coupling and clean-up:
- move the call to cice_column_reinitialize_fluxes from cice_timestep to
  cice_core_run.  The ACME driver calls cice_timestep and the previous
  location of this call set fluxes to zero prior to their export.  The
  driver does not use cice_core_run, but has its own call to the flux
  reinitialize routine.
- remove duplicate airReference arrays from the atmos_forcing pool and
  replaced with atmosReference arrays in the atmos_coupling pool
- removed hardwired paths from the Registry filename_templates
- added check for config_use_forcing to cice_init, and call
  cice_forcing_init only when config_use_forcing is true
