### PR TITLE
Add isActive tests to tracers halo exchanges

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -479,7 +479,9 @@ module ocn_time_integration_rk4
         do while ( mpas_pool_get_next_member(tracersTendPool, groupItr) )
            if ( groupItr % memberType == MPAS_POOL_FIELD ) then
               call mpas_pool_get_field(tracersTendPool, trim(groupItr % memberName), tracersGroupField)
-              call mpas_dmpar_exch_halo_field(tracersGroupField)
+              if ( tracersGroupField % isActive ) then
+                 call mpas_dmpar_exch_halo_field(tracersGroupField)
+              end if
            end if
         end do
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1278,7 +1278,9 @@ module ocn_time_integration_split
             if ( groupItr % memberType == MPAS_POOL_FIELD ) then
                call mpas_pool_get_field(tracersTendPool, groupItr % memberName, tracersGroupField)
 
-               call mpas_dmpar_exch_halo_field(tracersGroupField)
+               if ( tracersGroupField % isActive ) then
+                  call mpas_dmpar_exch_halo_field(tracersGroupField)
+               end if
             end if
          end do
          call mpas_timer_stop("se halo tracers", timer_halo_tracers)
@@ -1536,7 +1538,10 @@ module ocn_time_integration_split
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
             call mpas_pool_get_field(tracersPool, groupItr % memberName, tracersGroupField, 2)
-            call mpas_dmpar_exch_halo_field(tracersGroupField)
+
+            if ( tracersGroupField % isActive ) then
+               call mpas_dmpar_exch_halo_field(tracersGroupField)
+            end if
          end if
       end do
       call mpas_timer_stop("se implicit vert mix halos")

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -1229,7 +1229,9 @@ contains
              call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
              call mpas_pool_get_field(tracersPool, 'activeTracers', activeTracersField,1)
 
-             call mpas_dmpar_exch_halo_field(activeTracersField)
+             if ( activeTracersField % isActive ) then
+                call mpas_dmpar_exch_halo_field(activeTracersField)
+             end if
 
           end do ! iSmooth
 


### PR DESCRIPTION
This merge adds tests to see if a tracers group is active prior to
performing a halo exchange. Without this test, halo exchanges can cause
a segfault if a tracer group is deactivated, as the halo exchange will
still be executed with an unallocated array.
