### PR TITLE
Read input streams before first diagnostic solve

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -164,11 +164,17 @@ module ocn_forward_mode
       else
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
       end if
+
+      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
+      ierr = ior(ierr, err_tmp)
+
       call mpas_timer_stop('io_read')
       call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='input', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
+      call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
+      ierr = ior(ierr, err_tmp)
       call mpas_timer_stop('reset_io_alarms')
 
       ! Initialize submodules before initializing blocks.


### PR DESCRIPTION
This is necessary if fields from the forcing input stream are used in diagnostics (e.g. landIceFraction).

I have tested this change on the isomip test case and confirmed that the landIceFraction was now read correctly before the first diagnostic solve.  This was not a bit-for-bit change in this run because this field was previously zero in the first diagonstic solve.

I expect this change to lead to bit-identical results in other tests as long as no fields from input streams other than mesh, input or restart were not used in computing diagnostics.

I'm not sure if this counts as an enhancement or a bug fix so I didn't choose a label (other than Ocean).
