### PR TITLE
seaSurfacePressure becomes sum of landIcePressure and atmosphericPressure fields

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -619,17 +619,9 @@
 		/>
 	</nml_record>
 	<nml_record name="land_ice_fluxes" mode="forward">
-		<nml_option name="config_use_land_ice_fluxes" type="logical" default_value=".false." units="unitless"
-					description="Controls if land-ice fluxes are computed under ice shelves."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_use_land_ice_pressure" type="logical" default_value=".false." units="unitless"
-					description="Controls if pressure from the weight of land ice is added to the seaSurfacePressure."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_compute_land_ice_fluxes_in_ocean" type="logical" default_value=".true." units="unitless"
-					description="Controls if land-ice fluxes are computed in MPAS-O (as opposed to in the coupler)."
-					possible_values=".true. or .false."
+		<nml_option name="config_land_ice_flux_mode" type="character" default_value="off" units="unitless"
+					description="Selects the mode in which land-ice fluxes are computed."
+					possible_values="'off','pressure_only','standalone','coupled'"
 		/>
 		<nml_option name="config_land_ice_flux_formulation" type="character" default_value="Jenkins" units="unitless"
 					description="Name of land-ice flux formulation."

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -143,8 +143,7 @@ module ocn_core_interface
       character (len=StrKIND), pointer :: config_pressure_gradient_type
       logical, pointer :: config_use_bulk_wind_stress
       logical, pointer :: config_use_bulk_thickness_flux
-      logical, pointer :: config_use_land_ice_fluxes
-      logical, pointer :: config_use_land_ice_pressure
+      character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
        type (mpas_pool_iterator_type) :: groupItr
        character (len=StrKIND) :: tracerGroupName, configName, packageName
@@ -213,21 +212,19 @@ module ocn_core_interface
 
       !
       ! test for land ice fluxes, landIceFluxesPKG
-      !
-      call mpas_pool_get_package(packagePool, 'landIceFluxesPKGActive', landIceFluxesPKGActive)
-      call mpas_pool_get_config(configPool, 'config_use_land_ice_fluxes', config_use_land_ice_fluxes)
-      if ( config_use_land_ice_fluxes ) then
-         landIceFluxesPKGActive = .true.
-      end if
-
-      !
       ! test for land ice pressure, landIcePressurePKG
       !
+      call mpas_pool_get_package(packagePool, 'landIceFluxesPKGActive', landIceFluxesPKGActive)
       call mpas_pool_get_package(packagePool, 'landIcePressurePKGActive', landIcePressurePKGActive)
-      call mpas_pool_get_config(configPool, 'config_use_land_ice_pressure', config_use_land_ice_pressure)
-      if ( config_use_land_ice_pressure ) then
+      call mpas_pool_get_config(configPool, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      if ( (trim(config_land_ice_flux_mode) == 'standalone')  &
+           .or. (trim(config_land_ice_flux_mode) == 'coupled') ) then
+         landIceFluxesPKGActive = .true.
+      end if
+      if ( trim(config_land_ice_flux_mode) .ne. 'off' ) then
          landIcePressurePKGActive = .true.
       end if
+
 
       !
       ! test for use of frazil ice formation, frazilIceActive

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -140,9 +140,9 @@ contains
 
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
-      logical, pointer :: config_use_cvmix_kpp, config_use_land_ice_fluxes
+      logical, pointer :: config_use_cvmix_kpp
       real (kind=RKIND), pointer :: config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
-      character (len=StrKIND), pointer :: config_pressure_gradient_type
+      character (len=StrKIND), pointer :: config_pressure_gradient_type, config_land_ice_flux_mode
 
       real (kind=RKIND), pointer :: config_flux_attenuation_coefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
@@ -159,7 +159,7 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_surface_layer_averaging', config_cvmix_kpp_surface_layer_averaging)
       call mpas_pool_get_config(ocnConfigs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
       call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_land_ice_fluxes', config_use_land_ice_fluxes)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
 
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
@@ -224,7 +224,7 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'seaSurfacePressure', seaSurfacePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      if (config_use_land_ice_fluxes) then
+      if (trim(config_land_ice_flux_mode) .ne. 'off') then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
       end if
                   
@@ -501,7 +501,7 @@ contains
       call mpas_timer_stop("equation of state", diagEOSTimer)
 
       seaSurfacePressure(1:nCells) = atmosphericPressure(1:nCells)
-      if (config_use_land_ice_fluxes) then
+      if (trim(config_land_ice_flux_mode) .ne. 'off') then
          seaSurfacePressure(1:nCells) = seaSurfacePressure(1:nCells) &
             + landIcePressure(1:nCells)
       end if
@@ -1348,8 +1348,7 @@ contains
 
       integer, pointer :: indexT, indexS
 
-      character (len=StrKIND), pointer :: config_land_ice_flux_formulation
-      logical, pointer :: config_use_land_ice_fluxes
+      character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
 
       real (kind=RKIND), pointer :: config_land_ice_flux_boundaryLayerThickness, &
                                     config_land_ice_flux_boundaryLayerNeighborWeight, &
@@ -1388,8 +1387,12 @@ contains
          xiN = 0.052_RKIND              ! dimensionless planetary boundary layer constant
 
 
-      call mpas_pool_get_config(ocnConfigs, 'config_use_land_ice_fluxes', config_use_land_ice_fluxes)
-      if(.not. config_use_land_ice_fluxes) return
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      if ( (trim(config_land_ice_flux_mode) .ne. 'standalone')  &
+           .and. (trim(config_land_ice_flux_mode) .ne. 'coupled') ) then
+         return
+      end if
+
 
       jenkinsOn = .false.
       hollandJenkinsOn = .false.

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -54,7 +54,7 @@ module ocn_surface_land_ice_fluxes
    !
    !--------------------------------------------------------------------
 
-   logical :: landIceFluxesOn, isomipOn, jenkinsOn, hollandJenkinsOn
+   logical :: landIceFluxesOn, standaloneOn, isomipOn, jenkinsOn, hollandJenkinsOn
 
    real (kind=RKIND) :: Tf0, dTf_dp, dTf_dS, cp_land_ice, rho_land_ice
 
@@ -402,7 +402,7 @@ contains
 
       err = 0
 
-      if ( .not. landIceFluxesOn ) return
+      if ( .not. standaloneOn ) return
 
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_ISOMIP_gammaT', config_land_ice_flux_ISOMIP_gammaT)
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_useHollandJenkinsAdvDiff', config_land_ice_flux_useHollandJenkinsAdvDiff)
@@ -571,8 +571,7 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
-      character (len=StrKIND), pointer :: config_land_ice_flux_formulation
-      logical, pointer :: config_use_land_ice_fluxes
+      character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
 
       real (kind=RKIND), pointer :: config_land_ice_flux_Tf0, &
                                     config_land_ice_flux_dTf_dp, &
@@ -586,9 +585,12 @@ contains
       jenkinsOn = .false.
       hollandJenkinsOn = .false.
 
-      call mpas_pool_get_config(ocnConfigs, 'config_use_land_ice_fluxes', config_use_land_ice_fluxes)
-      landIceFluxesOn = config_use_land_ice_fluxes
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      landIceFluxesOn = (trim(config_land_ice_flux_mode) == 'standalone')  &
+           .or. (trim(config_land_ice_flux_mode) == 'coupled')
       if(.not. landIceFluxesOn) return
+
+      standaloneOn = trim(config_land_ice_flux_mode) == 'standalone'
 
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
 


### PR DESCRIPTION
seaSurfacePressure is computed in ocn_diagonstic_solve as the sum of atmosphericPressure and landIcePressure.

This change is needed so that atmospheric and land-ice pressures can be updated separately by the coupler and at different coupling frequencies.

I have tested this run on the isomip test case and have found differences that are at machine round-off (but not bit-identical).  I would expect bit-identical results for any test cases with seaSurfacePressure = 0.

This PR requires that #574 be fulfilled first.
