### PR TITLE
Add time-averaged land-ice coupling fields (notably effective density) to MPAS-O

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -618,72 +618,72 @@
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
-        <nml_record name="land_ice_fluxes" mode="forward">
+	<nml_record name="land_ice_fluxes" mode="forward">
 		<nml_option name="config_land_ice_flux_mode" type="character" default_value="off" units="unitless"
 					description="Selects the mode in which land-ice fluxes are computed."
-					possible_values="'off','pressure_only','standalone','coupled'"
+					possible_values="'off','standalone','coupled'"
 		/>
 		<nml_option name="config_land_ice_flux_formulation" type="character" default_value="Jenkins" units="unitless"
 					description="Name of land-ice flux formulation."
 					possible_values="'ISOMIP', 'Jenkins', 'HollandJenkins'"
 		/>
-                <nml_option name="config_land_ice_flux_useHollandJenkinsAdvDiff" type="logical" default_value=".false." units="unitless"
-                                        description="If .true. then uses the advection/diffusion scheme of Holland and Jenkins (1999) for ice-shelf heat fluxes"
-                                        possible_values=".true. and .false."
-                />
+		<nml_option name="config_land_ice_flux_useHollandJenkinsAdvDiff" type="logical" default_value=".false." units="unitless"
+					description="If .true. then uses the advection/diffusion scheme of Holland and Jenkins (1999) for ice-shelf heat fluxes"
+					possible_values=".true. and .false."
+		/>
 		<nml_option name="config_land_ice_flux_attenuation_coefficient" type="real" default_value="10.0" units="m"
 					description="The vertical length scale of exponential decay for surface fluxes under land ice."
 					possible_values="Any positive real number."
 		/>
-                <nml_option name="config_land_ice_flux_boundaryLayerThickness" type="real" default_value="10.0" units="m"
-                                        description="The thickness of the sub-ice-shelf boundary layer, over which T and S will be averaged."
-                                        possible_values="Any non-negative real number.  A value of 0 means that T and S are taken top level."
-                />
-                <nml_option name="config_land_ice_flux_boundaryLayerNeighborWeight" type="real" default_value="0.0" units="unitless"
-                                        description="The for horizontal neighbors used to horizontally smooth boundary layer T and S."
-                                        possible_values="Most likely a value between 0 (no smoothing) and 1 (neighbors get same weight as this cell)."
-                />
-                <nml_option name="config_land_ice_flux_Tf0" type="real" default_value="9.39e-2" units="C"
-                                        description="The constant term in the linearization of the freezing temperature."
-                                        possible_values="Any real number"
-                />
-                <nml_option name="config_land_ice_flux_dTf_dS" type="real" default_value="-5.73e-2" units="C PSU^{-1}"
-                                        description="The salinity coefficient in the linearization of the freezing temperature."
-                                        possible_values="Any real number"
-                />
-                <nml_option name="config_land_ice_flux_dTf_dp" type="real" default_value="-7.53e-8" units="C Pa^{-1}"
-                                        description="The pressure coefficient in the linearization of the freezing temperature."
-                                        possible_values="Any real number"
-                />
-                <nml_option name="config_land_ice_flux_cp_ice" type="real" default_value="2.009e3" units="J C^{-1} kg^{-1}"
-                                        description="The specific heat capacity for ice."
-                                        possible_values="Any positive real number"
-                />
-                <nml_option name="config_land_ice_flux_rho_ice" type="real" default_value="918" units="kg m^{-3}"
-                                        description="The density of land ice."
-                                        possible_values="Any positive real number"
-                />
-                <nml_option name="config_land_ice_flux_topDragCoeff" type="real" default_value="2.5e-3" units="unitless"
-                                        description="The top drag coefficient."
-                                        possible_values="Any positive real number"
-                />
-                <nml_option name="config_land_ice_flux_ISOMIP_gammaT" type="real" default_value="1e-4" units="m s^{-1}"
-                                        description="The constant heat transport velocity through the boundary layer under land ice used in the ISOMIP test cases."
-                                        possible_values="Any positive real number"
-                />
-                <nml_option name="config_land_ice_flux_rms_tidal_velocity" type="real" default_value="5e-2" units="m s^{-1}"
-                                        description="Parameterization of tidal velocity used in computing the sub-ice-shelf friction velocity"
-                                        possible_values="Any non-negative real number"
-                />
-                <nml_option name="config_land_ice_flux_jenkins_heat_transfer_coefficient" type="real" default_value="0.011" units="unitless"
-                                        description="constant nondimensional heat transfer coefficient across the ice-ocean boundary layer"
-                                        possible_values="Any positive real number"
-                />
-                <nml_option name="config_land_ice_flux_jenkins_salt_transfer_coefficient" type="real" default_value="3.1e-4" units="unitless"
-                                        description="constant nondimensional salt transfer coefficient across the ice-ocean boundary layer"
-                                        possible_values="Any positive real number"
-                />
-        </nml_record>
+		<nml_option name="config_land_ice_flux_boundaryLayerThickness" type="real" default_value="10.0" units="m"
+					description="The thickness of the sub-ice-shelf boundary layer, over which T and S will be averaged."
+					possible_values="Any non-negative real number.  A value of 0 means that T and S are taken top level."
+		/>
+		<nml_option name="config_land_ice_flux_boundaryLayerNeighborWeight" type="real" default_value="0.0" units="unitless"
+					description="The for horizontal neighbors used to horizontally smooth boundary layer T and S."
+					possible_values="Most likely a value between 0 (no smoothing) and 1 (neighbors get same weight as this cell)."
+		/>
+		<nml_option name="config_land_ice_flux_Tf0" type="real" default_value="9.39e-2" units="C"
+					description="The constant term in the linearization of the freezing temperature."
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_land_ice_flux_dTf_dS" type="real" default_value="-5.73e-2" units="C PSU^{-1}"
+					description="The salinity coefficient in the linearization of the freezing temperature."
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_land_ice_flux_dTf_dp" type="real" default_value="-7.53e-8" units="C Pa^{-1}"
+					description="The pressure coefficient in the linearization of the freezing temperature."
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_land_ice_flux_cp_ice" type="real" default_value="2.009e3" units="J C^{-1} kg^{-1}"
+					description="The specific heat capacity for ice."
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_land_ice_flux_rho_ice" type="real" default_value="918" units="kg m^{-3}"
+					description="The density of land ice."
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_land_ice_flux_topDragCoeff" type="real" default_value="2.5e-3" units="unitless"
+					description="The top drag coefficient."
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_land_ice_flux_ISOMIP_gammaT" type="real" default_value="1e-4" units="m s^{-1}"
+					description="The constant heat transport velocity through the boundary layer under land ice used in the ISOMIP test cases."
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_land_ice_flux_rms_tidal_velocity" type="real" default_value="5e-2" units="m s^{-1}"
+					description="Parameterization of tidal velocity used in computing the sub-ice-shelf friction velocity"
+					possible_values="Any non-negative real number"
+		/>
+		<nml_option name="config_land_ice_flux_jenkins_heat_transfer_coefficient" type="real" default_value="0.011" units="unitless"
+					description="constant nondimensional heat transfer coefficient across the ice-ocean boundary layer"
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_land_ice_flux_jenkins_salt_transfer_coefficient" type="real" default_value="3.1e-4" units="unitless"
+					description="constant nondimensional salt transfer coefficient across the ice-ocean boundary layer"
+					possible_values="Any positive real number"
+		/>
+	</nml_record>
 	<nml_record name="advection" mode="forward">
 		<nml_option name="config_vert_tracer_adv" type="character" default_value="stencil" units="unitless"
 					description="Method for interpolating tracer values from layer centers to layer edges"
@@ -939,7 +939,8 @@
 		<package name="thicknessFilter" description="This package includes variables required for frequency filtered thickness."/>
 		<package name="windStressBulkPKG" description="This package includes varibles required for bulk wind stress forcing."/>
 		<package name="thicknessBulkPKG" description="This package includes varibles required for bulk thickness forcing."/>
-                <package name="landIceFluxesPKG" description="This package includes varibles required for land ice thickness, momentum and tracer fluxes."/>
+		<package name="landIceFluxesPKG" description="This package includes varibles required for land ice thickness, momentum and tracer fluxes."/>
+		<package name="landIceCouplingPKG" description="This package includes varibles required for land ice coupling but not land ice fluxes in standalone mode."/>
 		<package name="frazilIce" description="This package includes variables required for frazil ice formation."/>
 		<package name="inSituEOS" description="This package includes variables required for to compute in situ equation of state derivatives, like thermal expansion and haline contraction."/>
 		<package name="forwardMode" description="This package controls variables that are intended to be used within the forward run mode of the ocean model."/>
@@ -1012,8 +1013,6 @@
 			<var name="normalVelocity"/>
 			<var name="layerThickness"/>
 			<var name="restingThickness"/>
-			<var name="surfaceStress"/>
-			<var name="seaSurfacePressure"/>
 			<var name="boundaryLayerDepth"/>
 			<var name="refBottomDepth"/>
 			<var name="bottomDepth"/>
@@ -1022,6 +1021,7 @@
 			<var name="vertCoordMovementWeights"/>
 			<var name="edgeMask"/>
 			<var name="cullCell"/>
+			<var name="effectiveDensityInLandIce"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -1032,6 +1032,8 @@
 				runtime_format="single_file"
 				mode="init">
 
+			<var name="surfaceStress"/>
+			<var name="seaSurfacePressure"/>
 			<var name="windStressZonal"/>
 			<var name="windStressMeridional"/>
 			<var_struct name="tracersSurfaceRestoringFields"/>
@@ -1039,19 +1041,19 @@
 			<var_struct name="tracersExponentialDecayFields"/>
 			<var_struct name="tracersIdealAgeFields"/>
 			<var_struct name="tracersTTDFields"/>
-                        <var name="landIceFraction"/>
+			<var name="landIceFraction"/>
 			<var name="landIceSurfaceTemperature"/>
-                        <var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
-                        <var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
-                        <var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
-                        <var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
-                        <var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
-                        <var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
-                        <var name="latentHeatFlux"/>
-                        <var name="sensibleHeatFlux"/>
-                        <var name="shortWaveHeatFlux"/>
-                        <var name="evaporationFlux"/>
-                        <var name="rainFlux"/>
+			<var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
+			<var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
+			<var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
+			<var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
+			<var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
+			<var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
+			<var name="latentHeatFlux"/>
+			<var name="sensibleHeatFlux"/>
+			<var name="shortWaveHeatFlux"/>
+			<var name="evaporationFlux"/>
+			<var name="rainFlux"/>
 		</stream>
 
 		<!-- Forward mode streams -->
@@ -1120,38 +1122,38 @@
 			<var name="layerThickness"/>
 			<var name="highFreqThickness"/>
 			<var name="lowFreqDivergence"/>
-			<var name="seaSurfacePressure"/>
+			<var name="effectiveDensityInLandIce"/>
 		</stream>
-                <stream name="KPP_testing"
-                                type="output"
-                                filename_template="output/KPP_test.$Y-$M-$D_$h.$m.$s.nc"
-                                filename_interval="00-01-00_00:00:00"
-                                reference_time="0000-01-01_00:00:00"
-                                clobber_mode="truncate"
-                                output_interval="0000_01:00:00" 
+		<stream name="KPP_testing"
+				type="output"
+				filename_template="output/KPP_test.$Y-$M-$D_$h.$m.$s.nc"
+				filename_interval="00-01-00_00:00:00"
+				reference_time="0000-01-01_00:00:00"
+				clobber_mode="truncate"
+				output_interval="0000_01:00:00" 
 				runtime_format="single_file" >
 
-                        <stream name="mesh"/>
+			<stream name="mesh"/>
 			<var name="xtime"/>
 			<var_struct name="tracers"/>
-                        <var name="zMid"/>
-                        <var name="zTop"/>
-                        <var name="velocityZonal"/>
-                        <var name="velocityMeridional"/>
-                        <var name="bulkRichardsonNumber"/>
-                        <var name="bulkRichardsonNumberBuoy"/>
-                        <var name="unresolvedShear"/>
-                        <var name="boundaryLayerDepth"/>
-                        <var name="boundaryLayerDepthEdge"/>
-                        <var_array name="vertNonLocalFlux"/>
-                        <var name="surfaceFrictionVelocity"/>
-                        <var name="penetrativeTemperatureFluxOBL"/>
-                        <var name="surfaceBuoyancyForcing"/>
-                        <var name="windStressZonalDiag"/>
-                        <var name="windStressMeridionalDiag"/>
-                        <var name="transportVelocityZonal"/>
-                        <var name="transportVelocityMeridional"/>
-                        <var name="RiTopOfCell"/>
+			<var name="zMid"/>
+			<var name="zTop"/>
+			<var name="velocityZonal"/>
+			<var name="velocityMeridional"/>
+			<var name="bulkRichardsonNumber"/>
+			<var name="bulkRichardsonNumberBuoy"/>
+			<var name="unresolvedShear"/>
+			<var name="boundaryLayerDepth"/>
+			<var name="boundaryLayerDepthEdge"/>
+			<var_array name="vertNonLocalFlux"/>
+			<var name="surfaceFrictionVelocity"/>
+			<var name="penetrativeTemperatureFluxOBL"/>
+			<var name="surfaceBuoyancyForcing"/>
+			<var name="windStressZonalDiag"/>
+			<var name="windStressMeridionalDiag"/>
+			<var name="transportVelocityZonal"/>
+			<var name="transportVelocityMeridional"/>
+			<var name="RiTopOfCell"/>
 			<var name="vertViscTopOfCell"/>
 			<var name="vertDiffTopOfCell"/>
 		</stream>
@@ -1176,12 +1178,12 @@
 			<var name="normalBarotropicVelocity"/>
 			<var name="vertCoordMovementWeights"/>
 			<var name="xtime"/>
-			<var name="seaSurfacePressure"/>
 			<var name="boundaryLayerDepth"/>
 			<var_array name="tracersSurfaceValue"/>
 			<var_array name="surfaceVelocity"/>
 			<var_array name="SSHGradient"/>
 			<var_array name="vertNonLocalFlux"/>
+			<var name="effectiveDensityInLandIce"/>
 		</stream>
 
 		<stream name="output" 
@@ -1225,6 +1227,7 @@
 				runtime_format="single_file"
 				mode="forward">
 
+			<var name="seaSurfacePressure"/>
 			<var name="windStressZonal"/>
 			<var name="windStressMeridional"/>
 			<var_struct name="tracersSurfaceRestoringFields"/>
@@ -1232,19 +1235,19 @@
 			<var_struct name="tracersExponentialDecayFields"/>
 			<var_struct name="tracersIdealAgeFields"/>
 			<var_struct name="tracersTTDFields"/>
-                        <var name="landIceFraction"/>
+			<var name="landIceFraction"/>
 			<var name="landIceSurfaceTemperature"/>
-                        <var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
-                        <var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
-                        <var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
-                        <var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
-                        <var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
-                        <var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
-                        <var name="latentHeatFlux"/>
-                        <var name="sensibleHeatFlux"/>
-                        <var name="shortWaveHeatFlux"/>
-                        <var name="evaporationFlux"/>
-                        <var name="rainFlux"/>
+			<var_array name="activeTracersPistonVelocity" packages="activeTracersSurfaceRestoringPKG"/>
+			<var_array name="activeTracersSurfaceRestoringValue" packages="activeTracersSurfaceRestoringPKG"/>
+			<var_array name="activeTracersInteriorRestoringRate" packages="activeTracersInteriorRestoringPKG"/>
+			<var_array name="activeTracersInteriorRestoringValue" packages="activeTracersInteriorRestoringPKG"/>
+			<var_array name="debugTracersPistonVelocity" packages="debugTracersSurfaceRestoringPKG"/>
+			<var_array name="debugTracersSurfaceRestoringValue" packages="debugTracersSurfaceRestoringPKG"/>
+			<var name="latentHeatFlux"/>
+			<var name="sensibleHeatFlux"/>
+			<var name="shortWaveHeatFlux"/>
+			<var name="evaporationFlux"/>
+			<var name="rainFlux"/>
 		</stream>
 
 		<!-- Diagnostics streams for forward mode -->
@@ -1327,6 +1330,9 @@
 			<var name="varNormalVelocity"/>
 			<var name="varVelocityZonal"/>
 			<var name="varVelocityMeridional"/>
+			<var_array name="avgLandIceBoundaryLayerTracers"/>
+			<var_array name="avgLandIceTracerTransferVelocities"/>
+			<var name="avgEffectiveDensityInLandIce"/>
 		</stream>
 
 		<stream name="Cartesian"
@@ -1393,6 +1399,13 @@
 			<var name="nAccumulatedCoupled"/>
 			<var name="thermalExpansionCoeff"/>
 			<var name="salineContractionCoeff"/>
+			<var name="landIceFraction"/>
+			<var_array name="landIceInterfaceTracers"/>
+			<var_array name="landIceBoundaryLayerTracers"/>
+			<var name="landIceFrictionVelocity"/>
+			<var name="topDragMagnitude"/>
+			<var name="landIceFreshwaterFlux"/>
+			<var name="landIceHeatFlux"/>
 		</stream>
 
 		<stream name="Gent_McWilliams_spherical"
@@ -1487,6 +1500,12 @@
 		<var name="normalBaroclinicVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="baroclinic velocity, used in split-explicit time-stepping"
 			 packages="splitTimeIntegrator"
+		/>
+
+		<!-- FIELD FOR LAND-ICE COUPLING -->
+		<var name="effectiveDensityInLandIce" type="real" dimensions="nCells Time" units="kg m^{-3}"
+			description="The effective ocean density within ice shelves based on Archimedes' principle."
+			packages="landIceCouplingPKG"
 		/>
 	</var_struct>
 	<var_struct name="mesh" time_levs="1">
@@ -2191,37 +2210,35 @@
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of surface fluxes. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 		/>
-                <!-- diagnostic fields for land-ice fluxes -->
-                <var name="landIceBoundaryLayerTemperature" type="real" dimensions="nCells Time" units="C"
-                         description="The temperature averaged over the sub-ice-shelf boundary layer"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceBoundaryLayerSalinity" type="real" dimensions="nCells Time" units="PSU"
-                         description="The salinity averaged over the sub-ice-shelf boundary layer"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^{-1}"
-                         description="The friction velocity $u_*$ under land ice"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceHeatTransferVelocity" 
-                         type="real" dimensions="nCells" units="m s^{-1}"
-                         description="friction velocity times nondimensional heat transfer coefficient"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceSaltTransferVelocity" 
-                         type="real" dimensions="nCells" units="m s^{-1}"
-                         description="friction velocity times nondimensional salt transfer coefficient"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="topDrag" type="real" dimensions="nEdges Time" units="N m^{-2}"
-                         description="Top drag at the surface of the ocean defined at edge midpoints. Magintude in direction of edge normal."
-                         packages="landIceFluxesPKG"
-                />
-                <var name="topDragMagnitude" type="real" dimensions="nCells Time" units="N m^{-2}"
-                         description="Magnitude of top drag at the surface of the ocean, at cell centers."
-                         packages="landIceFluxesPKG"
-                />
+		<!-- diagnostic fields for land-ice fluxes -->
+		<var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^{-1}"
+			description="The friction velocity $u_*$ under land ice"
+			packages="landIceFluxesPKG"
+		/>
+		<var name="topDrag" type="real" dimensions="nEdges Time" units="N m^{-2}"
+			description="Top drag at the surface of the ocean defined at edge midpoints. Magintude in direction of edge normal."
+			packages="landIceFluxesPKG"
+		/>
+		<var name="topDragMagnitude" type="real" dimensions="nCells Time" units="N m^{-2}"
+			description="Magnitude of top drag at the surface of the ocean, at cell centers."
+			packages="landIceFluxesPKG"
+		/>
+		<var_array name="landIceBoundaryLayerTracers" type="real" dimensions="nCells Time" packages="landIceFluxesPKG">
+			<var name="landIceBoundaryLayerTemperature" array_group="landIceBoundaryLayerValues" units="C"
+				description="The temperature averaged over the sub-ice-shelf boundary layer"
+			/>
+			<var name="landIceBoundaryLayerSalinity" array_group="landIceBoundaryLayerValues" units="PSU"
+				description="The salinity averaged over the sub-ice-shelf boundary layer"
+			/>
+		</var_array>
+		<var_array name="landIceTracerTransferVelocities" type="real" dimensions="nCells Time" packages="landIceFluxesPKG">
+			<var name="landIceHeatTransferVelocity" array_group="landIceTransferVelocityValues" units="m s^{-1}"
+				description="friction velocity times nondimensional heat transfer coefficient"
+			/>
+			<var name="landIceSaltTransferVelocity" array_group="landIceTransferVelocityValues" units="m s^{-1}"
+				description="friction velocity times nondimensional salt transfer coefficient"
+			/>
+		</var_array>
 	</var_struct>
 	<var_struct name="average" time_levs="1">
 		<var name="nAverage" type="real" dimensions="Time" units="unitless"
@@ -2465,36 +2482,59 @@
 			/>
 		</var_array>
 
-                <!-- Input fields for forcing under land ice -->
-                <var name="landIceFraction" type="real" dimensions="nCells Time" units="unitless"
-                         description="The fraction of each cell covered by land ice"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceSurfaceTemperature" type="real" dimensions="nCells Time" units="C"
-                         description="temperature at the surface of land ice"
-                         packages="landIceFluxesPKG"
-                />
-                <!-- Output fields for forcing under land ice -->
-                <var name="landIceInterfaceTemperature" type="real" dimensions="nCells Time" units="C"
-                         description="The temperature at the land ice-ocean interface (the local freezing temperature)"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceInterfaceSalinity" type="real" dimensions="nCells Time" units="PSU"
-                         description="The salinity at the land ice-ocean interface"
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
-                         description="Flux of mass through the ocean surface. Positive into ocean."
-                         packages="landIceFluxesPKG"
-                />
-                <var name="landIceHeatFlux"  type="real" dimensions="nCells Time" units="W s^{-1}"
-                         description="Flux of heat into the ocean at land ice-ocean interface. Positive into ocean."
-                         packages="landIceFluxesPKG"
-                />
-                <var name="heatFluxToLandIce"  type="real" dimensions="nCells Time" units="W s^{-1}"
-                         description="Flux of heat out of ice at land ice-ocean interface. Positive into ocean."
-                         packages="landIceFluxesPKG"
-                />
+		<!-- Input fields from coupler or initial condition for forcing under land ice -->
+		<var name="landIceFraction" type="real" dimensions="nCells Time" units="unitless"
+			description="The fraction of each cell covered by land ice"
+			packages="landIceFluxesPKG"
+		/>
+		<!-- Input fields from initial condition for standalone land-ice fluxes -->
+		<var name="landIceSurfaceTemperature" type="real" dimensions="nCells Time" units="C"
+			description="temperature at the surface of land ice"
+			packages="landIceFluxesPKG"
+		/>
+		<!-- Input fields from land-ice coupling or output fields from standalone land-ice flux computaiton -->
+		<var_array name="landIceInterfaceTracers" type="real" dimensions="nCells Time" packages="landIceFluxesPKG">
+			<var name="landIceInterfaceTemperature" array_group="landIceInterfaceValues" units="C"
+				description="The temperature at the land ice-ocean interface (the local freezing temperature)"
+			/>
+			<var name="landIceInterfaceSalinity" array_group="landIceInterfaceValues" units="PSU"
+				description="The salinity at the land ice-ocean interface"
+			/>
+		</var_array>
+		<var name="landIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+			description="Flux of mass through the ocean surface. Positive into ocean."
+			packages="landIceFluxesPKG"
+		/>
+		<var name="landIceHeatFlux"  type="real" dimensions="nCells Time" units="W s^{-1}"
+			description="Flux of heat into the ocean at land ice-ocean interface. Positive into ocean."
+			packages="landIceFluxesPKG"
+		/>
+		<!-- Output fields from standalone land-ice flux computaiton -->
+		<var name="heatFluxToLandIce"  type="real" dimensions="nCells Time" units="W s^{-1}"
+			description="Flux of heat out of ice at land ice-ocean interface. Positive into ocean."
+			packages="landIceFluxesPKG"
+		/>
+		<!-- Output fields for land-ice coupling -->
+		<var_array name="avgLandIceBoundaryLayerTracers" type="real" dimensions="nCells Time" packages="landIceCouplingPKG">
+			<var name="avgLandIceBoundaryLayerTemperature" array_group="landIceBoundaryLayerValues" units="C"
+				description="The time-averaged temperature averaged over the sub-ice-shelf boundary layer"
+			/>
+			<var name="avgLandIceBoundaryLayerSalinity" array_group="landIceBoundaryLayerValues" units="PSU"
+				description="The time-averaged salinity averaged over the sub-ice-shelf boundary layer"
+			/>
+		</var_array>
+		<var_array name="avgLandIceTracerTransferVelocities" type="real" dimensions="nCells Time" packages="landIceCouplingPKG">
+			<var name="avgLandIceHeatTransferVelocity" array_group="landIceTransferVelocityValues" units="m s^{-1}"
+				description="time-averaged friction velocity times nondimensional heat transfer coefficient"
+			/>
+			<var name="avgLandIceSaltTransferVelocity" array_group="landIceTransferVelocityValues" units="m s^{-1}"
+				description="time-averaged friction velocity times nondimensional salt transfer coefficient"
+			/>
+		</var_array>
+		<var name="avgEffectiveDensityInLandIce" type="real" dimensions="nCells Time" units="kg m^{-3}"
+			description="The time-averaged effective ocean density within ice shelves based on Archimedes' principle."
+			packages="landIceCouplingPKG"
+		/>
 	</var_struct>
 	<var_struct name="scratch" time_levs="1">
 		<var name="normalThicknessFlux" persistence="scratch" type="real" dimensions="nVertLevels nEdges Time"
@@ -2744,42 +2784,47 @@
 		<var name="highOrderVertFlux" persistence="scratch" type="real" dimensions="nVertLevelsP1 nCells" units=""
 			 description="High order vertical flux for advection"
 		/>
-                <!-- FIELDS FOR LAND-ICE FORCING -->
-                <var name="boundaryLayerTemperatureScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="^\circ C"
-                         description="temperature averaged vertically over the sub-ice-shelf boundary layer"
-                />
-                <var name="boundaryLayerSalinityScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="PSU"
-                         description="salinity averaged vertically over the sub-ice-shelf boundary layer"
-                />
-                <var name="freezeInterfaceSalinityScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="PSU"
-                         description="salinity at land ice-ocean interface where freezing is occurring"
-                />
-                <var name="freezeInterfaceTemperatureScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="^\circ C"
-                         description="temperature at land ice-ocean interface where freezing is occurring"
-                />
-                <var name="freezeThicknessFluxScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="m s^{-1}"
-                         description="thickness flux at land ice-ocean interface where freezing is occurring"
-                />
-                <var name="freezeTemperatureFluxScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="^\circ C m s^{-1}"
-                         description="ocean temperature flux at land ice-ocean interface where freezing is occurring"
-                />
-                <var name="freezeIceTemperatureFluxScratch" 
-                         persistence="scratch" 
-                         type="real" dimensions="nCells" units="^\circ C m s^{-1}"
-                         description="ice temperature flux at land ice-ocean interface where freezing is occurring"
-                />
+		<!-- FIELDS FOR LAND-ICE FORCING -->
+		<var name="boundaryLayerTemperatureScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="^\circ C"
+			description="temperature averaged vertically over the sub-ice-shelf boundary layer"
+		/>
+		<var name="boundaryLayerSalinityScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="PSU"
+			description="salinity averaged vertically over the sub-ice-shelf boundary layer"
+		/>
+		<var name="freezeInterfaceSalinityScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="PSU"
+			description="salinity at land ice-ocean interface where freezing is occurring"
+		/>
+		<var name="freezeInterfaceTemperatureScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="^\circ C"
+			description="temperature at land ice-ocean interface where freezing is occurring"
+		/>
+		<var name="freezeThicknessFluxScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="m s^{-1}"
+			description="thickness flux at land ice-ocean interface where freezing is occurring"
+		/>
+		<var name="freezeTemperatureFluxScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="^\circ C m s^{-1}"
+			description="ocean temperature flux at land ice-ocean interface where freezing is occurring"
+		/>
+		<var name="freezeIceTemperatureFluxScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="^\circ C m s^{-1}"
+			description="ice temperature flux at land ice-ocean interface where freezing is occurring"
+		/>
+		<var name="effectiveDensityScratch" 
+			persistence="scratch" 
+			type="real" dimensions="nCells" units="kg m^{-3}"
+			description="effective seawater density in land ice before horizontal averaging"
+		/>
 	</var_struct>
 
 <!-- Include init mode's registry file -->

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -112,6 +112,7 @@ module ocn_core_interface
       logical, pointer :: splitTimeIntegratorActive
       logical, pointer :: windStressBulkPKGActive
       logical, pointer :: landIceFluxesPKGActive
+      logical, pointer :: landIceCouplingPKGActive
       logical, pointer :: thicknessBulkPKGActive
       logical, pointer :: frazilIceActive
       logical, pointer :: inSituEOSActive
@@ -211,14 +212,16 @@ module ocn_core_interface
 
       !
       ! test for land ice fluxes, landIceFluxesPKG
-      ! test for land ice pressure, landIcePressurePKG
+      ! test for land ice coupling, landIceCouplingPKG
       !
       call mpas_pool_get_package(packagePool, 'landIceFluxesPKGActive', landIceFluxesPKGActive)
-      call mpas_pool_get_package(packagePool, 'landIcePressurePKGActive', landIcePressurePKGActive)
+      call mpas_pool_get_package(packagePool, 'landIceCouplingPKGActive', landIceCouplingPKGActive)
       call mpas_pool_get_config(configPool, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
-      if ( (trim(config_land_ice_flux_mode) == 'standalone')  &
-           .or. (trim(config_land_ice_flux_mode) == 'coupled') ) then
+      if ( trim(config_land_ice_flux_mode) == 'standalone' ) then
          landIceFluxesPKGActive = .true.
+      else if ( trim(config_land_ice_flux_mode) == 'coupled' ) then
+         landIceFluxesPKGActive = .true.
+         landIceCouplingPKGActive = .true.
       end if
 
       !

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -38,6 +38,8 @@ module ocn_time_integration_rk4
    use ocn_time_average_coupled
    use ocn_sea_ice
 
+   use ocn_effective_density_in_land_ice
+
    implicit none
    private
    save
@@ -124,6 +126,7 @@ module ocn_time_integration_rk4
       logical, pointer :: config_use_cvmix_kpp
       logical, pointer :: config_use_tracerGroup
       real (kind=RKIND), pointer :: config_mom_del4
+      character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
       ! State indices
       integer, pointer :: indexTemperature
@@ -170,7 +173,7 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:), pointer :: seaIceEnergy
 
       ! Diagnostics Field Pointers
-      type (field1DReal), pointer :: boundaryLayerDepthField
+      type (field1DReal), pointer :: boundaryLayerDepthField, effectiveDensityField
       type (field2DReal), pointer :: normalizedRelativeVorticityEdgeField, divergenceField, relativeVorticityField
 
       ! State/Tend Field Pointers
@@ -191,6 +194,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_config(domain % configs, 'config_use_freq_filtered_thickness', config_use_freq_filtered_thickness)
       call mpas_pool_get_config(domain % configs, 'config_use_standardGM', config_use_standardGM)
       call mpas_pool_get_config(domain % configs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
+      call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
 
       !
       ! Initialize time_levs(2) with state at current time
@@ -831,6 +835,9 @@ module ocn_time_integration_rk4
 
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
+         ! Update the effective desnity in land ice if we're coupling to land ice
+         call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, scratchPool, err)
+
          ! ------------------------------------------------------------------
          ! Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
@@ -865,7 +872,7 @@ module ocn_time_integration_rk4
          SSHGradient(indexSSHGradientMeridional, :) = gradSSHMeridional(1, :)
 
          call ocn_time_average_accumulate(averagePool, statePool, diagnosticsPool, 2)
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, forcingPool)
+         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 
          if (config_use_standardGM) then
             call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
@@ -873,6 +880,15 @@ module ocn_time_integration_rk4
 
          block => block % next
       end do
+
+      if (trim(config_land_ice_flux_mode) == 'coupled') then
+         call mpas_timer_start("RK4-effective density halo")
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
+         call mpas_pool_get_field(statePool, 'effectiveDensityInLandIce', effectiveDensityField, 2)
+         call mpas_dmpar_exch_halo_field(effectiveDensityField)
+         call mpas_timer_stop("RK4-effective density halo")
+      end if
+
       call mpas_timer_stop("RK4-cleaup phase")
 
       block => domain % blocklist

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -40,6 +40,8 @@ module ocn_time_integration_split
 
    use ocn_sea_ice
 
+   use ocn_effective_density_in_land_ice
+
    implicit none
    private
    save
@@ -132,6 +134,7 @@ module ocn_time_integration_split
       logical, pointer :: config_vel_correction, config_prescribe_velocity, config_prescribe_thickness
       logical, pointer :: config_use_cvmix_kpp
       logical, pointer :: config_use_tracerGroup
+      character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
       real (kind=RKIND), pointer :: config_mom_del4, config_btr_gam1_velWt1, config_btr_gam2_SSHWt1
       real (kind=RKIND), pointer :: config_btr_gam3_velWt2
@@ -186,7 +189,7 @@ module ocn_time_integration_split
 
       ! Diagnostics Field Pointers
       type (field2DReal), pointer :: normalizedRelativeVorticityEdgeField, divergenceField, relativeVorticityField
-      type (field1DReal), pointer :: barotropicThicknessFluxField, boundaryLayerDepthField
+      type (field1DReal), pointer :: barotropicThicknessFluxField, boundaryLayerDepthField, effectiveDensityField
 
       ! State/Tend Field Pointers
       type (field1DReal), pointer :: normalBarotropicVelocitySubcycleField, sshSubcycleField
@@ -228,6 +231,7 @@ module ocn_time_integration_split
 
       call mpas_pool_get_config(domain % configs, 'config_use_standardGM', config_use_standardGM)
       call mpas_pool_get_config(domain % configs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
+      call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
 
       allocate(n_bcl_iter(config_n_ts_iter))
 
@@ -1595,6 +1599,9 @@ module ocn_time_integration_split
 
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
+         ! Update the effective desnity in land ice if we're coupling to land ice
+         call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, scratchPool, err)
+
          ! Compute normalGMBolusVelocity; it will be added to normalVelocity in Stage 2 of the next cycle. 
          if (config_use_standardGM) then
             call ocn_gm_compute_Bolus_velocity(diagnosticsPool, meshPool, scratchPool)
@@ -1617,7 +1624,7 @@ module ocn_time_integration_split
          SSHGradient(indexSSHGradientMeridional, :) = gradSSHMeridional(1, :)
 
          call ocn_time_average_accumulate(averagePool, statePool, diagnosticsPool, 2)
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, forcingPool)
+         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 
          if (config_use_standardGM) then
             call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
@@ -1625,6 +1632,14 @@ module ocn_time_integration_split
 
          block => block % next
       end do
+
+      if (trim(config_land_ice_flux_mode) == 'coupled') then
+         call mpas_timer_start("se effective density halo")
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
+         call mpas_pool_get_field(statePool, 'effectiveDensityInLandIce', effectiveDensityField, 2)
+         call mpas_dmpar_exch_halo_field(effectiveDensityField)
+         call mpas_timer_stop("se effective density halo")
+      end if
 
       call mpas_timer_stop("se timestep", timer_main)
 

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -49,6 +49,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_forcing.o \
 	   mpas_ocn_surface_bulk_forcing.o \
 	   mpas_ocn_surface_land_ice_fluxes.o \
+	   mpas_ocn_effective_density_in_land_ice.o \
 	   mpas_ocn_forcing_restoring.o \
 	   mpas_ocn_time_average.o \
 	   mpas_ocn_time_average_coupled.o \
@@ -150,10 +151,11 @@ mpas_ocn_surface_bulk_forcing.o:
 
 mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o
 
+mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o
+
 mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o
 
 mpas_ocn_sea_ice.o: mpas_ocn_constants.o
-
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1329,11 +1329,11 @@ contains
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
       integer, pointer :: nCells, nEdges
 
-      integer, dimension(:,:), pointer :: cellsOnCell, cellsOnEdge
+      integer, dimension(:,:), pointer :: cellsOnCell, cellsOnEdge, cellMask
 
       integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
 
-      integer, pointer :: indexT, indexS
+      integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
       character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
 
@@ -1345,21 +1345,18 @@ contains
                                     config_land_ice_flux_jenkins_salt_transfer_coefficient, &
                                     config_land_ice_flux_attenuation_coefficient
 
-      real (kind=RKIND) :: blThickness, dz, blWeightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
+      real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
       real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
                                                   landIceFrictionVelocity, &
-                                                  landIceBoundaryLayerTemperature, &
-                                                  landIceBoundaryLayerSalinity, &
-                                                  landIceHeatTransferVelocity, &
-                                                  landIceSaltTransferVelocity, &
                                                   topDrag, &
                                                   topDragMagnitude, &
                                                   fCell, &
                                                   blTempScratch, blSaltScratch, &
                                                   surfaceFluxAttenuationCoefficient
 
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity, &
+                                                    landIceBoundaryLayerTracers, landIceTracerTransferVelocities
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       type (field1DReal), pointer :: boundaryLayerTemperatureField, boundaryLayerSalinityField
 
@@ -1375,8 +1372,7 @@ contains
 
 
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
-      if ( (trim(config_land_ice_flux_mode) .ne. 'standalone')  &
-           .and. (trim(config_land_ice_flux_mode) .ne. 'coupled') ) then
+      if ( trim(config_land_ice_flux_mode) == 'off') then
          return
       end if
 
@@ -1408,6 +1404,7 @@ contains
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -1421,13 +1418,17 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
 
       call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTemperature', landIceBoundaryLayerTemperature)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerSalinity', landIceBoundaryLayerSalinity)
       call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
       call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
+
+      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
+
       if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceHeatTransferVelocity', landIceHeatTransferVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'landIceSaltTransferVelocity', landIceSaltTransferVelocity)
+        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
       end if
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
@@ -1437,6 +1438,7 @@ contains
       call mpas_allocate_scratch_field(boundaryLayerSalinityField, .true.)
       blTempScratch => boundaryLayerTemperatureField % array
       blSaltScratch => boundaryLayerSalinityField % array
+
       if(hollandJenkinsOn) then
          call mpas_pool_get_array(meshPool, 'fCell', fCell)
       end if
@@ -1486,32 +1488,28 @@ contains
          end if
       end do
       do iCell = 1, nCells
-         landIceBoundaryLayerTemperature(iCell) = blTempScratch(iCell)
-         landIceBoundaryLayerSalinity(iCell) = blSaltScratch(iCell)
+         landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
+         landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
          if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
-            blWeightSum = 1.0_RKIND
+            weightSum = 1.0_RKIND
             do i = 1, nEdgesOnCell(iCell)
                cell2 = cellsOnCell(i,iCell)
-               if(cell2 <= 0 .or. cell2 > nCells) cycle
 
-               landIceBoundaryLayerTemperature(iCell) = landIceBoundaryLayerTemperature(iCell) &
-                 + config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
-               landIceBoundaryLayerSalinity(iCell) = landIceBoundaryLayerSalinity(iCell) &
-                 + config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
-               blWeightSum = blWeightSum + config_land_ice_flux_boundaryLayerNeighborWeight
+               landIceBoundaryLayerTracers(indexBLT, iCell) = landIceBoundaryLayerTracers(indexBLT, iCell) &
+                 + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
+               landIceBoundaryLayerTracers(indexBLS, iCell) = landIceBoundaryLayerTracers(indexBLS, iCell) &
+                 + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
+               weightSum = weightSum + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
             end do
-            if(blWeightSum > 0.0_RKIND) then
-               landIceBoundaryLayerTemperature(iCell) = landIceBoundaryLayerTemperature(iCell)/blWeightSum
-               landIceBoundaryLayerSalinity(iCell) = landIceBoundaryLayerSalinity(iCell)/blWeightSum
-            end if
+            landIceBoundaryLayerTracers(:, iCell) = landIceBoundaryLayerTracers(:, iCell)/weightSum
          end if
       end do
 
       if(jenkinsOn) then
          do iCell = 1, nCells
             ! transfer coefficients from namelist
-            landIceHeatTransferVelocity(iCell) = landIceFrictionVelocity(iCell)*config_land_ice_flux_jenkins_heat_transfer_coefficient
-            landIceSaltTransferVelocity(iCell) = landIceFrictionVelocity(iCell)*config_land_ice_flux_jenkins_salt_transfer_coefficient
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell)*config_land_ice_flux_jenkins_heat_transfer_coefficient
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = landIceFrictionVelocity(iCell)*config_land_ice_flux_jenkins_salt_transfer_coefficient
          end do
       else if(hollandJenkinsOn) then
          do iCell = 1, nCells
@@ -1525,8 +1523,8 @@ contains
                 *xiN/(abs(fCell(iCell))*h_nu))
             end if
      
-            landIceHeatTransferVelocity(iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND*Pr**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
-            landIceSaltTransferVelocity(iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND*Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND*Pr**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND*Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
          end do
       end if
 
@@ -1535,7 +1533,7 @@ contains
 
       ! recompute the spatially-varying attenuation coefficient based on landIceFraction
       do iCell = 1, nCells
-        surfaceFluxAttenuationCoefficient(iCell) = landIceFraction(iCell)*config_land_ice_flux_attenuation_coefficient &
+         surfaceFluxAttenuationCoefficient(iCell) = landIceFraction(iCell)*config_land_ice_flux_attenuation_coefficient &
            + (1.0_RKIND - landIceFraction(iCell))*surfaceFluxAttenuationCoefficient(iCell)
       end do
 

--- a/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -1,0 +1,181 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_effective_density_in_land_ice
+!
+!> \brief MPAS ocean effective density in land ice
+!> \author Xylar Asay-Davis
+!> \date   10/03/2015
+!> \details
+!>  This module contains routines for computing the effective seawater
+!>  density in land ice using Arhimedes' principle.
+!
+!-----------------------------------------------------------------------
+
+module ocn_effective_density_in_land_ice
+
+   use mpas_constants
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+
+   use ocn_constants
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_effective_density_in_land_ice_update
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_effective_density_in_land_ice_update
+!
+!> \brief updates effective density in land ice
+!> \author Xylar Asay-Davis
+!> \date   10/03/2015
+!> \details
+!>  This routine updates the value of the effective seawater density
+!>  displaced by land ice, based on Archimedes' principle.  The effective
+!>  density is smoothed and extrapolated by averaging with nearest neighbors
+!>  (cellsOnCell).
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, scratchPool, ierr)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: state information
+      type (mpas_pool_type), intent(inout) :: scratchPool !< Input/Output: scratch information
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: ierr !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      character (len=StrKIND), pointer :: config_land_ice_flux_mode
+
+      real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
+                                                  seaSurfacePressure, ssh, &
+                                                  effectiveDensityCur, &
+                                                  effectiveDensityNew, &
+                                                  effectiveDensityScratch
+
+      type (field1DReal), pointer :: effectiveDensityField                                                                                              
+
+      real (kind=RKIND) :: weightSum
+
+      integer :: iCell, cell2, i
+      integer, pointer :: nCells, nEdges
+
+      integer, dimension(:,:), pointer :: cellsOnCell, cellMask
+
+      integer, dimension(:), pointer :: nEdgesOnCell
+
+      ierr = 0
+
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      if ( (trim(config_land_ice_flux_mode) .ne. 'coupled') ) then
+         return
+      end if
+
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
+
+      call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+      call mpas_pool_get_array(forcingPool, 'seaSurfacePressure', seaSurfacePressure)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityCur, 1)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityNew, 2)
+
+      call mpas_pool_get_field(scratchPool, 'effectiveDensityScratch', effectiveDensityField)
+      call mpas_allocate_scratch_field(effectiveDensityField, .true.)
+      effectiveDensityScratch => effectiveDensityField % array
+
+      do iCell = 1, nCells
+         ! TODO: should only apply to floating land ice, once wetting/drying is supported
+         if(landIceFraction(iCell) >= 0.5) then
+            ! there is sufficient land ice to update the effective density
+            effectiveDensityScratch(iCell) = -seaSurfacePressure(iCell)/(ssh(iCell)*gravity)
+         else
+            ! we copy the previous effective density
+            effectiveDensityScratch(iCell) = effectiveDensityCur(iCell)
+         end if
+      end do
+      do iCell = 1, nCells
+         ! smooth/extrapolate by averaging with nearest neighbors
+         weightSum = 1.0_RKIND
+         effectiveDensityNew(iCell) = effectiveDensityScratch(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            cell2 = cellsOnCell(i,iCell)
+            effectiveDensityNew(iCell) = effectiveDensityNew(iCell) &
+               + cellMask(1,cell2)*effectiveDensityScratch(cell2)
+            weightSum = weightSum + cellMask(1,cell2)
+         end do
+         effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/weightSum
+      end do
+      call mpas_deallocate_scratch_field(effectiveDensityField, .true.)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_effective_density_in_land_ice_update !}}}
+
+!***********************************************************************
+
+end module ocn_effective_density_in_land_ice
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -382,19 +382,18 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: seaSurfacePressure, landIceFraction, &
                                                   landIceSurfaceTemperature, &
-                                                  landIceInterfaceTemperature, &
-                                                  landIceInterfaceSalinity, landIceFrictionVelocity, &
-                                                  landIceBoundaryLayerTemperature, &
-                                                  landIceBoundaryLayerSalinity, &
+                                                  landIceFrictionVelocity, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce, &
-                                                  landIceHeatTransferVelocity, &
-                                                  landIceSaltTransferVelocity, &
                                                   freezeInterfaceSalinity, freezeInterfaceTemperature, &
                                                   freezeFreshwaterFlux, freezeHeatFlux, &
                                                   freezeIceHeatFlux
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+      real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, &
+                                                    landIceInterfaceTracers, &
+                                                    landIceTracerTransferVelocities
+      integer, pointer :: indexBLT, indexBLS, indexIT, indexIS, indexHeatTrans, indexSaltTrans
+
       type (field1DReal), pointer :: boundaryLayerTemperatureField, boundaryLayerSalinityField, &
                                      freezeInterfaceSalinityField, freezeInterfaceTemperatureField, &
                                      freezeFreshwaterFluxField, freezeHeatFluxField, &
@@ -409,20 +408,28 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTemperature', landIceBoundaryLayerTemperature)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerSalinity', landIceBoundaryLayerSalinity)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceHeatTransferVelocity', landIceHeatTransferVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceSaltTransferVelocity', landIceSaltTransferVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
 
       call mpas_pool_get_array(forcingPool, 'seaSurfacePressure', seaSurfacePressure)
+      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
+                                     
+      if(jenkinsOn .or. hollandJenkinsOn) then
+        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
+      end if
+
       call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
 
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
       call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
       call mpas_pool_get_array(forcingPool, 'heatFluxToLandIce', heatFluxToLandIce)
-      call mpas_pool_get_array(forcingPool, 'landIceInterfaceTemperature', landIceInterfaceTemperature)
-      call mpas_pool_get_array(forcingPool, 'landIceInterfaceSalinity', landIceInterfaceSalinity)
+
+      call mpas_pool_get_array(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracers)
+      call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
+      call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
 
       if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
@@ -447,8 +454,8 @@ contains
       if(isomipOn) then
          do iCell = 1, nCellsSolve
             ! linearized equaiton for the S and p dependent potential freezing temperature
-            landIceInterfaceTemperature(iCell) = Tf0 &
-                                          + dTf_dS*landIceBoundaryLayerSalinity(iCell) &
+            landIceInterfaceTracers(indexIT,iCell) = Tf0 &
+                                          + dTf_dS*landIceBoundaryLayerTracers(indexBLT,iCell) &
                                           + dTf_dp*seaSurfacePressure(iCell)
 
             ! using (3) and (4) from Hunter (2006)
@@ -456,15 +463,15 @@ contains
             ! and no heat flux into ice
             ! freshwater flux = density * melt rate is in kg/m^2/s
             freshwaterFlux = -rho_sw * config_land_ice_flux_ISOMIP_gammaT * (cp_sw/latent_heat_fusion_mks) &
-                       * (landIceInterfaceTemperature(iCell)-landIceBoundaryLayerTemperature(iCell))
+                       * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
             landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
 
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
-            heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTemperature(iCell) &
+            heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
                               + rho_sw*config_land_ice_flux_ISOMIP_gammaT &
-                                * (landIceInterfaceTemperature(iCell)-landIceBoundaryLayerTemperature(iCell)))
+                                * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
             landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
 
             heatFluxToLandIce(iCell) = 0.0_RKIND
@@ -476,14 +483,14 @@ contains
          if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
-               landIceBoundaryLayerTemperature, &
-               landIceBoundaryLayerSalinity, &
-               landIceHeatTransferVelocity, &
-               landIceSaltTransferVelocity, &
+               landIceBoundaryLayerTracers(indexBLT,:), &
+               landIceBoundaryLayerTracers(indexBLS,:), &
+               landIceTracerTransferVelocities(indexHeatTrans,:), &
+               landIceTracerTransferVelocities(indexSaltTrans,:), &
                landIceSurfaceTemperature, &
                seaSurfacePressure, &
-               landIceInterfaceSalinity, &
-               landIceInterfaceTemperature, &
+               landIceInterfaceTracers(indexIT,:), &
+               landIceInterfaceTracers(indexIS,:), &
                landIceFreshwaterFlux, &
                landIceHeatFlux, &
                heatFluxToLandIce, &
@@ -495,13 +502,13 @@ contains
 
             ! freezing solution
             call compute_melt_fluxes( &
-               landIceBoundaryLayerTemperature, &
-               landIceBoundaryLayerSalinity, &
-               landIceHeatTransferVelocity, &
-               landIceSaltTransferVelocity, &
+               landIceBoundaryLayerTracers(indexBLT,:), &
+               landIceBoundaryLayerTracers(indexBLS,:), &
+               landIceTracerTransferVelocities(indexHeatTrans,:), &
+               landIceTracerTransferVelocities(indexSaltTrans,:), &
                seaSurfacePressure, &
-               freezeInterfaceSalinity, &
                freezeInterfaceTemperature, &
+               freezeInterfaceSalinity, &
                freezeFreshwaterFlux, &
                freezeHeatFlux, &
                freezeIceHeatFlux, &
@@ -512,21 +519,21 @@ contains
             end if
 
             where(landIceFreshwaterFlux < 0.0_RKIND)
-               landIceInterfaceSalinity = freezeInterfaceSalinity
-               landIceInterfaceTemperature = freezeInterfaceTemperature
+               landIceInterfaceTracers(indexIS,:) = freezeInterfaceSalinity
+               landIceInterfaceTracers(indexIT,:) = freezeInterfaceTemperature
                landIceFreshwaterFlux = freezeFreshwaterFlux
                landIceHeatFlux = freezeHeatFlux
                heatFluxToLandIce = freezeIceHeatFlux
             end where
          else ! not using Holland and Jenkins advection/diffusion
             call compute_melt_fluxes( &
-               landIceBoundaryLayerTemperature, &
-               landIceBoundaryLayerSalinity, &
-               landIceHeatTransferVelocity, &
-               landIceSaltTransferVelocity, &
+               landIceBoundaryLayerTracers(indexBLT,:), &
+               landIceBoundaryLayerTracers(indexBLS,:), &
+               landIceTracerTransferVelocities(indexHeatTrans,:), &
+               landIceTracerTransferVelocities(indexSaltTrans,:), &
                seaSurfacePressure, &
-               landIceInterfaceSalinity, &
-               landIceInterfaceTemperature, &
+               landIceInterfaceTracers(indexIT,:), &
+               landIceInterfaceTracers(indexIS,:), &
                landIceFreshwaterFlux, &
                landIceHeatFlux, &
                heatFluxToLandIce, &
@@ -655,8 +662,8 @@ contains
     oceanHeatTransferVelocity, &
     oceanSaltTransferVelocity, &
     interfacePressure, &
-    outInterfaceSalinity, &
     outInterfaceTemperature, &
+    outInterfaceSalinity, &
     outFreshwaterFlux, &
     outOceanHeatFlux, &
     outIceHeatFlux, &
@@ -695,8 +702,8 @@ contains
     !-----------------------------------------------------------------
 
     real (kind=RKIND), dimension(:), intent(out) :: &
-      outInterfaceSalinity, &    !< Output: ocean salinity at the interface
       outInterfaceTemperature, & !< Output: ice/ocean temperature at the interface
+      outInterfaceSalinity, &    !< Output: ocean salinity at the interface
       outFreshwaterFlux, &   !< Output: ocean thickness flux (melt rate)
       outOceanHeatFlux, & !< Output: the temperature flux into the ocean
       outIceHeatFlux      !< Output: the temperature flux into the ice
@@ -739,6 +746,7 @@ contains
       ! The positive root is the one we want (salinity is strictly positive)
       outInterfaceSalinity(iCell) = (-b + sqrt(b**2 - 4.0_RKIND*a*c*oceanSalinity(iCell)))/(2.0_RKIND*a)
       if (outInterfaceSalinity(iCell) .le. 0.0_RKIND) then
+         write(stderrUnit, *) "ERROR: interfaceSalinity <= 0", outInterfaceSalinity(iCell), oceanSalinity(iCell), a, b, c
         err = 1
         return
       end if
@@ -805,8 +813,8 @@ contains
     oceanSaltTransferVelocity, &
     iceTemperature, &
     interfacePressure, &
-    outInterfaceSalinity, &
     outInterfaceTemperature, &
+    outInterfaceSalinity, &
     outFreshwaterFlux, &
     outOceanHeatFlux, &
     outIceHeatFlux, &
@@ -842,8 +850,8 @@ contains
     !-----------------------------------------------------------------
 
     real (kind=RKIND), dimension(:), intent(out) :: &
-      outInterfaceSalinity, &    !< Output: ocean salinity at the interface
       outInterfaceTemperature, & !< Output: ice/ocean temperature at the interface
+      outInterfaceSalinity, &    !< Output: ocean salinity at the interface
       outFreshwaterFlux, &   !< Output: ocean thickness flux (melt rate)
       outOceanHeatFlux, & !< Output: the temperature flux into the ocean
       outIceHeatFlux      !< Output: the temperature flux into the ice

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -45,7 +45,11 @@ module ocn_time_average_coupled
     subroutine ocn_time_average_coupled_init(forcingPool)!{{{
         type (mpas_pool_type), intent(inout) :: forcingPool
 
-        real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, avgSSHGradient
+        real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, avgSSHGradient, &
+                                                      avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
+
+        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce
+      character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
         integer, pointer :: nAccumulatedCoupled
 
@@ -57,6 +61,17 @@ module ocn_time_average_coupled
         avgTracersSurfaceValue(:,:) = 0.0_RKIND
         avgSurfaceVelocity(:,:) = 0.0_RKIND
         avgSSHGradient(:,:) = 0.0_RKIND
+
+        call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+        if(trim(config_land_ice_flux_mode) == 'coupled') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
+           call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
+
+           avgLandIceBoundaryLayerTracers(:,:) = 0.0_RKIND
+           avgLandIceTracerTransferVelocities(:,:) = 0.0_RKIND
+           avgEffectiveDensityInLandIce(:) = 0.0_RKIND
+        end if
 
         nAccumulatedCoupled = 0
 
@@ -73,15 +88,21 @@ module ocn_time_average_coupled
 !>  This routine accumulated the coupled time averaging fields
 !
 !-----------------------------------------------------------------------
-    subroutine ocn_time_average_coupled_accumulate(diagnosticsPool, forcingPool)!{{{
+    subroutine ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, timeLevel)!{{{
         type (mpas_pool_type), intent(in) :: diagnosticsPool
+        type (mpas_pool_type), intent(in) :: statePool
         type (mpas_pool_type), intent(inout) :: forcingPool
+        integer, intent(in) :: timeLevel
 
         real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
         real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue, avgTracersSurfaceValue
         real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
         real (kind=RKIND), dimension(:,:), pointer :: gradSSHZonal, gradSSHMeridional
         integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled
+        real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, landIceTracerTransferVelocities, &
+                                                      avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
+        real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce
+        character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
         call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
@@ -98,6 +119,8 @@ module ocn_time_average_coupled
 
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
 
+
+
         avgTracersSurfaceValue(:,:) = avgTracersSurfaceValue(:,:) * nAccumulatedCoupled + tracersSurfaceValue(:,:)
         avgTracersSurfaceValue(index_temperature,:) = avgTracersSurfaceValue(index_temperature,:) + T0_Kelvin
         avgTracersSurfaceValue(:,:) = avgTracersSurfaceValue(:,:) / ( nAccumulatedCoupled + 1 )
@@ -106,6 +129,24 @@ module ocn_time_average_coupled
 
         avgSSHGradient(index_SSHzonal,:)      = ( avgSSHGradient(index_SSHzonal,:)      * nAccumulatedCoupled + gradSSHZonal(1,:) ) / ( nAccumulatedCoupled + 1 )
         avgSSHGradient(index_SSHmeridional,:) = ( avgSSHGradient(index_SSHmeridional,:) * nAccumulatedCoupled + gradSSHMeridional(1,:) ) / ( nAccumulatedCoupled + 1 )
+
+        call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+        if(trim(config_land_ice_flux_mode) == 'coupled') then
+           call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+           call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
+           call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, timeLevel)
+
+           call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
+           call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
+
+           avgLandIceBoundaryLayerTracers(:,:) = ( avgLandIceBoundaryLayerTracers(:,:) * nAccumulatedCoupled &
+              + landIceBoundaryLayerTracers(:,:) ) / ( nAccumulatedCoupled + 1 )
+           avgLandIceTracerTransferVelocities(:,:) = ( avgLandIceTracerTransferVelocities(:,:) * nAccumulatedCoupled &
+              + landIceTracerTransferVelocities(:,:) ) / ( nAccumulatedCoupled + 1)
+           avgEffectiveDensityInLandIce(:) = ( avgEffectiveDensityInLandIce(:) * nAccumulatedCoupled &
+              + effectiveDensityInLandIce(:) ) / ( nAccumulatedCoupled + 1)
+        end if
 
         nAccumulatedCoupled = nAccumulatedCoupled + 1
 


### PR DESCRIPTION
This PR adds 2 time-averaged tracer arrays and fields that are needed for coupling to land ice:
- avgLandIceBoundaryLayerTracers
- avgLandIceTracerTransferVelocities
- avgEffectiveDensityInLandIce

The effective density (and its time average) are new fields that have been added.  These fields are computed from the landIcePressure and the sea-surface height (ssh) following Archimedes' principle: the density is such that p = -rho_eff_g_ssh (where the ssh is always negative under land ice).

The effective density (effectiveDensityInLandIce) has been added as a state variable, since it evolves in time and depends on its state at previous times.  Under ice shelves (defined for now as landIceFraction > 0.5), the effective density is computed using Archimedes' principle as above.  However, at each time step the effective density is also averaged with its nearest neighbors, meaning that effective density will be extrapolated smoothly into areas of open ocean and (in the future) of grounded ice over time.

Tests:
1. I confirmed that the results of the ISOMIP test cases are qualitatively (to an accuracy of 1e-6 in the normal velocity and much higher in other state variables) the same before and after this change.  Operations in the land-ice forcing have been re-ordered so the changes are not expected to be bit-for-bit the same.
2. By temporarily turning on standalone fluxes in coupled land-ice mode (config_land_ice_flux_mode = 'coupled' but standaloneOn = .true. in ocn_surface_land_ice_fluxes), I confirmed that the time-averaged fields produced by this code look sensible in both ISOMIP expt1 and expt2, and that the extrapolation of effective density into regions of open ocean in expt2 are behaving as expected (expt1 has no region of open ocean).

It is not clear to me how I can perform further meaningful tests of this PR in standalone MPAS-O.  Presumably further debugging will be required once this has been merged into ACME.
