### PR TITLE
Clean constant use in MPAS-CICE

### DIFF
--- a/src/core_cice/forward_model/mpas_cice_column.F
+++ b/src/core_cice/forward_model/mpas_cice_column.F
@@ -39,9 +39,6 @@ module cice_column
        cice_column_aggregate, &
        cice_column_initial_air_drag_coefficient, &
        cice_column_reinitialize_fluxes
-
-  ! constants
-  real(kind=RKIND), parameter :: puny = 1e-11_RKIND
        
   ! tracer object
   type, private :: ciceTracerObjectType
@@ -315,7 +312,11 @@ contains
 
   subroutine cice_init_column_shortwave(domain, clock)
 
-    use ice_colpkg, only: colpkg_init_orbit
+    use ice_colpkg, only: &
+         colpkg_init_orbit
+
+    use cice_constants, only: &
+         cicePuny
 
     type(domain_type), intent(inout) :: domain
 
@@ -468,7 +469,7 @@ contains
           do iCategory = 1, nCategories
 
              ! aggregate albedos
-             if (iceAreaCategory(1,iCategory,iCell) > puny) then
+             if (iceAreaCategory(1,iCategory,iCell) > cicePuny) then
 
                 albedoVisibleDirectCell(iCell)  = albedoVisibleDirectCell(iCell)  + &
                      albedoVisibleDirectCategory(iCategory,iCell)  * iceAreaCategory(1,iCategory,iCell)
@@ -479,7 +480,7 @@ contains
                 albedoIRDiffuseCell(iCell)      = albedoIRDiffuseCell(iCell)      + &
                      albedoIRDiffuseCategory(iCategory,iCell)      * iceAreaCategory(1,iCategory,iCell)
 
-                if (solarZenithAngleCosine(iCell) > puny) then ! sun above horizon
+                if (solarZenithAngleCosine(iCell) > cicePuny) then ! sun above horizon
 
                    bareIceAlbedoCell(iCell) = bareIceAlbedoCell(iCell) + &
                         bareIceAlbedoCategory(iCategory,iCell) * iceAreaCategory(1,iCategory,iCell)
@@ -884,7 +885,11 @@ contains
 
   subroutine column_vertical_thermodynamics(domain, clock)
 
-    use ice_colpkg, only: colpkg_step_therm1
+    use ice_colpkg, only: &
+         colpkg_step_therm1
+
+    use cice_constants, only: &
+         cicePuny
 
     type(domain_type), intent(inout) :: domain
 
@@ -1427,10 +1432,10 @@ contains
              do iCategory = 1, nCategories
                 do iAerosol = 1, nAerosols
 
-                   if (snowVolumeCategory(1,iCategory,iCell) > puny) &
+                   if (snowVolumeCategory(1,iCategory,iCell) > cicePuny) &
                         specificSnowAerosol(iAerosol, :, iCategory) = specificSnowAerosol(iAerosol, :, iCategory) / snowVolumeCategory(1,iCategory,iCell)
 
-                   if (iceVolumeCategory(1,iCategory,iCell) > puny) &
+                   if (iceVolumeCategory(1,iCategory,iCell) > cicePuny) &
                         specificIceAerosol(iAerosol, :, iCategory)  = specificIceAerosol(iAerosol, :, iCategory)  / iceVolumeCategory(1,iCategory,iCell)
 
                    snowScatteringAerosol(iAerosol,iCategory,iCell) = specificSnowAerosol(iAerosol, 1, iCategory)
@@ -4529,6 +4534,9 @@ contains
 
   subroutine check_column_package_configs(domain)
 
+    use cice_constants, only: &
+         cicePuny
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -4683,7 +4691,7 @@ contains
     endif
     
     ! check config_snow_to_ice_transition_depth and level ponds
-    if (config_use_level_meltponds .and. abs(config_snow_to_ice_transition_depth) > puny) then
+    if (config_use_level_meltponds .and. abs(config_snow_to_ice_transition_depth) > cicePuny) then
        COLUMN_ERROR_WRITE("config_use_level_meltponds = .true. and config_snow_to_ice_transition_depth /= 0")
        call MPAS_dmpar_global_abort('Incompatible config_use_level_meltponds and config_snow_to_ice_transition_depth')
     endif

--- a/src/core_cice/forward_model/mpas_cice_constants.F
+++ b/src/core_cice/forward_model/mpas_cice_constants.F
@@ -14,30 +14,61 @@ module cice_constants
 
   use mpas_derived_types
 
+  use ice_constants_colpkg, only: &
+       rhoi, &
+       rhos, &
+       rhow, &
+       puny, &
+       stefan_boltzmann, &
+       emissivity, &
+       Tffresh, &
+       cp_air, &
+       Lsub, &
+       Pstar, &
+       Cstar, &
+       dragio
+
   private
   save
-  
+
+  ! fundamental constants
   real (kind=RKIND), parameter, public :: &
-       pii = 3.141592653589793
-
-  real (kind=RKIND), parameter, public :: &
-       earthRadius = 6371229.0
-
-   real (kind=RKIND), parameter, public :: &
-        omega   = 7.29212e-5 !< Constant: Angular rotation rate of the Earth [s-1]
-
-  character (len=*), public, parameter :: coupleAlarmID = 'coupling'
-
-  real(kind=RKIND), parameter, public :: &
+       pii = 3.141592653589793, &
        ciceDegreesToRadians = pii / 180.0_RKIND, &
-       ciceRadiansToDegrees = 180.0_RKIND / pii
+       ciceRadiansToDegrees = 180.0_RKIND / pii, &
+       ciceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, &
+       ciceSecondsPerDay  = 24.0_RKIND * 3600.0_RKIND
+
+  ! Earth constants
+  real (kind=RKIND), parameter, public :: &
+       earthRadius = 6371229.0, & ! radius of Earth in [m]
+       omega       = 7.29212e-5   ! angular rotation rate of the Earth [s-1]
+
+  character (len=*), public, parameter :: &
+       coupleAlarmID = 'coupling'
 
   real(kind=RKIND), parameter, public :: &
-       ciceDensityIce  = 917.0_RKIND, &
-       ciceDensitySnow = 330.0_RKIND
+       cicePuny = puny
 
+  ! physical constants
   real(kind=RKIND), parameter, public :: &
-       cicePuny = 1.0e-11_RKIND
+       ciceDensityIce      = rhoi, & ! density of ice (kg/m^3)
+       ciceDensitySnow     = rhos, & ! density of snow (kg/m^3)
+       ciceDensitySeaWater = rhow    ! density of seawater (kg/m^3)
+
+  ! thermodynamic constants
+  real(kind=RKIND), parameter, public :: &
+       ciceStefanBoltzmann         = stefan_boltzmann, & ! J m-2 K-4 s-1
+       ciceIceSnowEmissivity       = emissivity, &       ! emissivity of snow and ice
+       ciceFreshWaterFreezingPoint = Tffresh, &          ! freezing temp of fresh ice (K)
+       ciceAirSpecificHeat         = cp_air, &           ! specific heat of air (J/kg/K)
+       ciceLatentHeatSublimation   = Lsub                ! latent heat, sublimation freshwater (J/kg)
+
+  ! dynamics constants
+  real(kind=RKIND), parameter, public :: &
+       ciceIceStrengthConstantHiblerP = Pstar, & ! P* constant in Hibler strength formulation
+       ciceIceStrengthConstantHiblerC = Cstar, & ! C* constant in Hibler strength formulation
+       ciceIceOceanDragCoefficient    = dragio   ! ice ocean drag coefficient
 
   ! minimum sea ice area
   real(kind=RKIND), parameter, public :: &
@@ -45,19 +76,6 @@ module cice_constants
        iceThicknessMinimum  = cicePuny, &
        snowThicknessMinimum = cicePuny
 
-
-  real(kind=RKIND), parameter, public :: &
-       ciceStefanBoltzmann = 5.67e-8_RKIND , & ! J m-2 K-4 s-1
-       ciceIceSnowEmissivity = 0.95_RKIND, & ! emissivity of snow and ice
-       ciceFreshWaterFreezingPoint = 273.15_RKIND, & ! freezing temp of fresh ice (K)
-       ciceAirSpecificHeat = 1005.0_RKIND, & ! specific heat of air (J/kg/K)
-       ciceLatentHeatSublimation = 2.835e6_RKIND ! latent heat, sublimation freshwater (J/kg)
-
-
-
- real(kind=RKIND), parameter, public :: &
-      ciceSecondsPerYear = 365.0_RKIND * 24.0_RKIND * 3600.0_RKIND, &
-      ciceSecondsPerDay = 24.0_RKIND * 3600.0_RKIND
 
 end module cice_constants
 

--- a/src/core_cice/forward_model/mpas_cice_velocity_solver.F
+++ b/src/core_cice/forward_model/mpas_cice_velocity_solver.F
@@ -787,6 +787,10 @@ contains
     use ice_colpkg, only: &
          colpkg_ice_strength
 
+    use cice_constants, only: &
+         ciceIceStrengthConstantHiblerP, &
+         ciceIceStrengthConstantHiblerC
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -826,10 +830,6 @@ contains
     integer :: &
          iCell
 
-    real(kind=RKIND), parameter :: &
-         Pstar = 2.75e4_RKIND, & ! constant in Hibler strength formula 
-         Cstar = 20.0_RKIND      ! constant in Hibler strength formula 
-
     block => domain % blocklist
     do while (associated(block))
 
@@ -862,7 +862,8 @@ contains
 
              if (solveStress(iCell) == 1) then
 
-                icePressure(iCell) = Pstar * iceVolumeCell(iCell) * exp(-Cstar*(1.0_RKIND-iceAreaCell(iCell)))
+                icePressure(iCell) = ciceIceStrengthConstantHiblerP * iceVolumeCell(iCell) * &
+                     exp(-ciceIceStrengthConstantHiblerC*(1.0_RKIND-iceAreaCell(iCell)))
 
              else
 
@@ -1481,6 +1482,10 @@ contains
 
   subroutine ocean_stress_coefficient(domain)
 
+    use cice_constants, only: &
+         ciceDensitySeaWater, &
+         ciceIceOceanDragCoefficient
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -1504,10 +1509,6 @@ contains
 
     logical, pointer :: &
          configUseOceanStress
-
-    real(kind=RKIND), parameter :: &
-         densityWater      = 1026.0_RKIND, &
-         iceOceanDragCoeff = 0.00536_RKIND
 
     integer, pointer :: &
          nVerticesSolve
@@ -1541,7 +1542,7 @@ contains
 
              if (solveVelocity(iVertex) == 1) then
 
-                oceanStressCoeff(iVertex) = iceOceanDragCoeff * densityWater * iceAreaVertex(iVertex) * &
+                oceanStressCoeff(iVertex) = ciceIceOceanDragCoefficient * ciceDensitySeaWater * iceAreaVertex(iVertex) * &
                      sqrt((uOceanVelocityVertex(iVertex) - uVelocity(iVertex))**2 + &
                           (vOceanVelocityVertex(iVertex) - vVelocity(iVertex))**2)
 


### PR DESCRIPTION
Moved column package defined constants to mpas_cice_constants. Cleaned up mpas_cice_constants and pointed column package defined constants to the versions in ice_constants_colpkg.
