### PR TITLE
Fix first stream read on restart run

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -165,14 +165,19 @@ module ocn_forward_mode
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
       end if
 
-      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
-      ierr = ior(ierr, err_tmp)
-
       call mpas_timer_stop('io_read')
       call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='input', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
+      call mpas_timer_stop('reset_io_alarms')
+
+      ! Read the remaining input streams
+      call mpas_timer_start('io_read', .false.)
+      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
+      ierr = ior(ierr, err_tmp)
+      call mpas_timer_stop('io_read')
+      call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
       ierr = ior(ierr, err_tmp)
       call mpas_timer_stop('reset_io_alarms')


### PR DESCRIPTION
A previous PR (#574) added reading of all streams on initializing a forward run.
This commit moves this read after the alarms for restart and init reading have
already been reset, preventing data from the init stream from reading over
the restart data.

I believe this fixes issue #584 
