### PR TITLE
Add stat=local_err to deallocates in pool routines

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -200,6 +200,7 @@ module mpas_pool_routines
       integer :: i, j
       type (mpas_pool_member_type), pointer :: ptr
       type (mpas_pool_data_type), pointer :: dptr
+      integer :: local_err
 
 
       do i=1,inPool % size
@@ -212,9 +213,9 @@ module mpas_pool_routines
             if (ptr % contentsType == MPAS_POOL_DIMENSION) then
 
                if (ptr % data % contentsDims > 0) then
-                  deallocate(ptr % data % simple_int_arr)
+                  deallocate(ptr % data % simple_int_arr, stat=local_err)
                else
-                  deallocate(ptr % data % simple_int)
+                  deallocate(ptr % data % simple_int, stat=local_err)
                end if
 
             else if (ptr % contentsType == MPAS_POOL_CONFIG) then
@@ -222,13 +223,13 @@ module mpas_pool_routines
                dptr => ptr % data
 
                if (dptr % contentsType == MPAS_POOL_REAL) then
-                  deallocate(dptr % simple_real)
+                  deallocate(dptr % simple_real, stat=local_err)
                else if (dptr % contentsType == MPAS_POOL_INTEGER) then
-                  deallocate(dptr % simple_int)
+                  deallocate(dptr % simple_int, stat=local_err)
                else if (dptr % contentsType == MPAS_POOL_CHARACTER) then
-                  deallocate(dptr % simple_char)
+                  deallocate(dptr % simple_char, stat=local_err)
                else if (dptr % contentsType == MPAS_POOL_LOGICAL) then
-                  deallocate(dptr % simple_logical)
+                  deallocate(dptr % simple_logical, stat=local_err)
                end if
 
             else if (ptr % contentsType == MPAS_POOL_FIELD) then
@@ -237,138 +238,138 @@ module mpas_pool_routines
 
                ! Do this through brute force...
                if (associated(dptr % r0)) then
-                  deallocate(dptr % r0)
+                  deallocate(dptr % r0, stat=local_err)
                else if (associated(dptr % r1)) then
                   if (associated(dptr % r1 % array)) then
-                     deallocate(dptr % r1 % array)
+                     deallocate(dptr % r1 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % r1)
+                  deallocate(dptr % r1, stat=local_err)
                else if (associated(dptr % r2)) then
                   if (associated(dptr % r2 % array)) then
-                     deallocate(dptr % r2 % array)
+                     deallocate(dptr % r2 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % r2)
+                  deallocate(dptr % r2, stat=local_err)
                else if (associated(dptr % r3)) then
                   if (associated(dptr % r3 % array)) then
-                     deallocate(dptr % r3 % array)
+                     deallocate(dptr % r3 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % r3)
+                  deallocate(dptr % r3, stat=local_err)
                else if (associated(dptr % r4)) then
                   if (associated(dptr % r4 % array)) then
-                     deallocate(dptr % r4 % array)
+                     deallocate(dptr % r4 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % r4)
+                  deallocate(dptr % r4, stat=local_err)
                else if (associated(dptr % r5)) then
                   if (associated(dptr % r5 % array)) then
-                     deallocate(dptr % r5 % array)
+                     deallocate(dptr % r5 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % r5)
+                  deallocate(dptr % r5, stat=local_err)
                else if (associated(dptr % i0)) then
-                  deallocate(dptr % i0)
+                  deallocate(dptr % i0, stat=local_err)
                else if (associated(dptr % i1)) then
                   if (associated(dptr % i1 % array)) then
-                     deallocate(dptr % i1 % array)
+                     deallocate(dptr % i1 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % i1)
+                  deallocate(dptr % i1, stat=local_err)
                else if (associated(dptr % i2)) then
                   if (associated(dptr % i2 % array)) then
-                     deallocate(dptr % i2 % array)
+                     deallocate(dptr % i2 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % i2)
+                  deallocate(dptr % i2, stat=local_err)
                else if (associated(dptr % i3)) then
                   if (associated(dptr % i3 % array)) then
-                     deallocate(dptr % i3 % array)
+                     deallocate(dptr % i3 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % i3)
+                  deallocate(dptr % i3, stat=local_err)
                else if (associated(dptr % c0)) then
-                  deallocate(dptr % c0)
+                  deallocate(dptr % c0, stat=local_err)
                else if (associated(dptr % c1)) then
                   if (associated(dptr % c1 % array)) then
-                     deallocate(dptr % c1 % array)
+                     deallocate(dptr % c1 % array, stat=local_err)
                   end if
 
-                  deallocate(dptr % c1)
+                  deallocate(dptr % c1, stat=local_err)
                else if (associated(dptr % l0)) then
-                  deallocate(dptr % l0)
+                  deallocate(dptr % l0, stat=local_err)
                else if (associated(dptr % r0a)) then
-                  deallocate(dptr % r0a)
+                  deallocate(dptr % r0a, stat=local_err)
                else if (associated(dptr % r1a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % r1a(j) % array)) then
-                        deallocate(dptr % r1a(j) % array)
+                        deallocate(dptr % r1a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % r1a)
+                  deallocate(dptr % r1a, stat=local_err)
                else if (associated(dptr % r2a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % r2a(j) % array)) then
-                        deallocate(dptr % r2a(j) % array)
+                        deallocate(dptr % r2a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % r2a)
+                  deallocate(dptr % r2a, stat=local_err)
                else if (associated(dptr % r3a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % r3a(j) % array)) then
-                        deallocate(dptr % r3a(j) % array)
+                        deallocate(dptr % r3a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % r3a)
+                  deallocate(dptr % r3a, stat=local_err)
                else if (associated(dptr % r4a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % r4a(j) % array)) then
-                        deallocate(dptr % r4a(j) % array)
+                        deallocate(dptr % r4a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % r4a)
+                  deallocate(dptr % r4a, stat=local_err)
                else if (associated(dptr % r5a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % r5a(j) % array)) then
-                        deallocate(dptr % r5a(j) % array)
+                        deallocate(dptr % r5a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % r5a)
+                  deallocate(dptr % r5a, stat=local_err)
                else if (associated(dptr % i0a)) then
-                  deallocate(dptr % i0a)
+                  deallocate(dptr % i0a, stat=local_err)
                else if (associated(dptr % i1a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % i1a(j) % array)) then
-                        deallocate(dptr % i1a(j) % array)
+                        deallocate(dptr % i1a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % i1a)
+                  deallocate(dptr % i1a, stat=local_err)
                else if (associated(dptr % i2a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % i2a(j) % array)) then
-                        deallocate(dptr % i2a(j) % array)
+                        deallocate(dptr % i2a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % i2a)
+                  deallocate(dptr % i2a, stat=local_err)
                else if (associated(dptr % i3a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % i3a(j) % array)) then
-                        deallocate(dptr % i3a(j) % array)
+                        deallocate(dptr % i3a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % i3a)
+                  deallocate(dptr % i3a, stat=local_err)
                else if (associated(dptr % c0a)) then
-                  deallocate(dptr % c0a)
+                  deallocate(dptr % c0a, stat=local_err)
                else if (associated(dptr % c1a)) then
                   do j=1,dptr % contentsTimeLevs
                      if (associated(dptr % c1a(j) % array)) then
-                        deallocate(dptr % c1a(j) % array)
+                        deallocate(dptr % c1a(j) % array, stat=local_err)
                      end if
                   end do
-                  deallocate(dptr % c1a)
+                  deallocate(dptr % c1a, stat=local_err)
                else if (associated(dptr % l0a)) then
-                  deallocate(dptr % l0a)
+                  deallocate(dptr % l0a, stat=local_err)
                else
                   call pool_mesg('While destroying pool, member '//trim(ptr % key)//' has no valid field pointers.')
                end if
@@ -378,14 +379,14 @@ module mpas_pool_routines
                call mpas_pool_destroy_pool(ptr % data % p)
 
             end if
-            deallocate(ptr % data)
-            deallocate(ptr)
+            deallocate(ptr % data, stat=local_err)
+            deallocate(ptr, stat=local_err)
          end do
 
       end do
 
-      deallocate(inPool % table)
-      deallocate(inPool)
+      deallocate(inPool % table, stat=local_err)
+      deallocate(inPool, stat=local_err)
 
    end subroutine mpas_pool_destroy_pool!}}}
 
@@ -408,6 +409,7 @@ module mpas_pool_routines
 
       integer :: i
       type (mpas_pool_member_type), pointer :: ptr
+      integer :: local_err
 
 
       do i=1,inPool % size
@@ -418,27 +420,27 @@ module mpas_pool_routines
             inPool % table(i) % head => inPool % table(i) % head % next
             if (ptr % contentsType == MPAS_POOL_DIMENSION) then
                if (ptr % data % contentsDims > 0) then
-                  deallocate(ptr % data % simple_int_arr)
+                  deallocate(ptr % data % simple_int_arr, stat=local_err)
                else
-                  deallocate(ptr % data % simple_int)
+                  deallocate(ptr % data % simple_int, stat=local_err)
                end if
             else if (ptr % contentsType == MPAS_POOL_CONFIG) then
                if (ptr % data % contentsType == MPAS_POOL_REAL) then
-                  deallocate(ptr % data % simple_real)
+                  deallocate(ptr % data % simple_real, stat=local_err)
                else if (ptr % data % contentsType == MPAS_POOL_INTEGER) then
-                  deallocate(ptr % data % simple_int)
+                  deallocate(ptr % data % simple_int, stat=local_err)
                else if (ptr % data % contentsType == MPAS_POOL_CHARACTER) then
-                  deallocate(ptr % data % simple_char)
+                  deallocate(ptr % data % simple_char, stat=local_err)
                else if (ptr % data % contentsType == MPAS_POOL_LOGICAL) then
-                  deallocate(ptr % data % simple_logical)
+                  deallocate(ptr % data % simple_logical, stat=local_err)
                end if
             else if (ptr % contentsType == MPAS_POOL_PACKAGE) then
-               deallocate(ptr % data % simple_logical)
+               deallocate(ptr % data % simple_logical, stat=local_err)
             else if (ptr % contentsType == MPAS_POOL_SUBPOOL) then
                call mpas_pool_empty_pool(ptr % data % p)
-               deallocate(ptr % data % p)
+               deallocate(ptr % data % p, stat=local_err)
             end if
-            deallocate(ptr)
+            deallocate(ptr, stat=local_err)
          end do
 
       end do


### PR DESCRIPTION
This merge updates deallocate statements within the
mpas_pool_destroy_pool and mpas_pool_empty_pool routines to contain a
stat argument. The stat argument causes fatal calls to deallocate to no
longer be fatal (i.e. the calling code can handle the error code however
they want).

On most machines, this won't have any effect. However, on mira, xlf will
successfully complete a run with this change, where previously it would
fail due to an "invalid data object" being passed into the deallocate
call.
