### PR TITLE
Ocean/cvmix debug cleanup

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1143,7 +1143,8 @@
                         <var name="velocityZonal"/>
                         <var name="velocityMeridional"/>
                         <var name="bulkRichardsonNumber"/>
-                        <var name="bulkRichardsonNumberBuoy"/>
+			<var name="bulkRichardsonNumberBuoy"/>
+			<var name="potentialDensity"/>
                         <var name="unresolvedShear"/>
                         <var name="boundaryLayerDepth"/>
                         <var name="boundaryLayerDepthEdge"/>
@@ -2047,7 +2048,7 @@
 		<var name="bulkRichardsonNumber" type="real" dimensions="nVertLevels nCells Time" units="nondimensional"
 			 description="CVMix/KPP: bulk Richardson number"
 			 packages="forwardMode;analysisMode"
-		/>
+			 />
 		<var name="bulkRichardsonNumberBuoy" type="real" dimensions="nVertLevels nCells Time" units="nondimensional"
 			 description="CVMix/KPP: contribution of buoyancy to bulk Richardson number"
 			 packages="forwardMode;analysisMode"

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -165,14 +165,19 @@ module ocn_forward_mode
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
       end if
 
-      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
-      ierr = ior(ierr, err_tmp)
-
       call mpas_timer_stop('io_read')
       call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='input', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
+      call mpas_timer_stop('reset_io_alarms')
+
+      ! Read the remaining input streams
+      call mpas_timer_start('io_read', .false.)
+      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
+      ierr = ior(ierr, err_tmp)
+      call mpas_timer_stop('io_read')
+      call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
       ierr = ior(ierr, err_tmp)
       call mpas_timer_stop('reset_io_alarms')

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1250,39 +1250,9 @@ contains
        ! compute surface friction velocity
          surfaceFrictionVelocity(iCell) = sqrt(surfaceStressMagnitude(iCell) / rho_sw)
 
-       ! zero the bulk Richardson number within the ocean surface layer
-       ! this prevent CVMix/KPP from mis-diagnosing the OBL to be within the surface layer
-        bulkRichardsonNumberBuoy (:,iCell) = 1.0e8_RKIND
-        bulkRichardsonNumberShear(:,iCell) = 1.0_RKIND
-
-       ! loop over vertical to compute bulk Richardson number
-        do k=1,maxLevelCell(iCell)
-
-        ! find deltaVelocitySquared defined at cell centers based on velocity at levels 1 and k
-         deltaVelocitySquared = 0.0_RKIND
-         do i = 1, nEdgesOnCell(iCell)
-           iEdge = edgesOnCell(i, iCell)
-           factor = 0.5 * dcEdge(iEdge) * dvEdge(iEdge) * invAreaCell
-           delU2 = (normalVelocitySurfaceLayer(iEdge) - normalVelocity(k,iEdge))**2 
-           deltaVelocitySquared = deltaVelocitySquared + factor * delU2
-         enddo
-
-         buoyContribution = gravity * (density(k,iCell) - densitySurfaceDisplaced(k,iCell)) / rho_sw
-         shearContribution = max(deltaVelocitySquared,1.0e-15_RKIND)
-
-         ! store the buoyancy and resolved shear contributions to bulk Richardson number
-         bulkRichardsonNumberBuoy(k,iCell) = buoyContribution
-         bulkRichardsonNumberShear(k,iCell) = shearContribution
-
-        enddo ! do k=1,maxLevelCell(iCell)
-
-       ! set bulkRichardsonNumberBuoy to a negative value within surface layer to prevent CVMix/KPP from
-       ! incorrectly diagnosing OBL to be within surface layer
-       ! require boundary layer to be below the top layer
-       k=max(int(indexSurfaceLayerDepth(iCell)),1)
-       bulkRichardsonNumberBuoy(1:k,iCell) = 0.0_RKIND
 
       enddo
+
 
       ! deallocate scratch space
       call mpas_deallocate_scratch_field(densitySurfaceDisplacedField, .true.)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -17,7 +17,7 @@ module ocn_vmix_cvmix
    use mpas_pool_routines
    use mpas_timer
    use mpas_io_units
-
+   use mpas_constants
    use ocn_constants
 
    use cvmix_kinds_and_types
@@ -121,30 +121,32 @@ contains
       !-----------------------------------------------------------------
 
       integer, dimension(:), pointer :: &
-        maxLevelCell
+        maxLevelCell, nEdgesOnCell
 
       real (kind=RKIND), dimension(:), pointer :: &
         latCell, lonCell, bottomDepth, surfaceBuoyancyForcing, surfaceFrictionVelocity, fCell, &
-        boundaryLayerDepth, ssh, indexBoundaryLayerDepth
+        boundaryLayerDepth, ssh, indexBoundaryLayerDepth, dcEdge, dvEdge, areaCell
 
       real (kind=RKIND), dimension(:,:), pointer :: &
         vertViscTopOfCell, vertDiffTopOfCell, layerThickness, &
         zMid, zTop, density, displacedDensity, potentialDensity, &
         bulkRichardsonNumber, RiTopOfCell, BruntVaisalaFreqTop, &
-        bulkRichardsonNumberBuoy, bulkRichardsonNumberShear, unresolvedShear
+        bulkRichardsonNumberBuoy, bulkRichardsonNumberShear, unresolvedShear, normalVelocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
       integer, pointer :: index_vertNonLocalFluxTemp
-
+      integer, dimension(:,:), pointer :: edgesOnCell
+      
       logical, pointer :: config_use_cvmix_shear, config_use_cvmix_convection, config_use_cvmix_kpp
       logical, pointer :: config_use_cvmix_fixed_boundary_layer
       real (kind=RKIND), pointer :: config_cvmix_kpp_stop_OBL_search, config_cvmix_kpp_criticalBulkRichardsonNumber
-      real (kind=RKIND), pointer :: config_cvmix_kpp_boundary_layer_depth
+      real (kind=RKIND), pointer :: config_cvmix_kpp_boundary_layer_depth, config_cvmix_kpp_surface_layer_extent
       character (len=StrKIND), pointer :: config_cvmix_shear_mixing_scheme, config_cvmix_kpp_matching
 
-      integer :: k, iCell, jCell, iNeighbor, iter, timeLevel, kIndexOBL
+      integer :: k, iCell, jCell, iNeighbor, iter, timeLevel, kIndexOBL, kav, iEdge, iEdgeVal
       integer, pointer :: nVertLevels, nCells
-      real (kind=RKIND) :: r, layerSum, bulkRichardsonNumberStop
+      real (kind=RKIND) :: r, layerSum, bulkRichardsonNumberStop, sfc_layer_depth, invAreaCell, deltaVelocitySquared
+      real (kind=RKIND) :: normalVelocityAv, factor, delU2
       real (kind=RKIND) :: sigma, turbulentScalarVelocityScalePoint
       real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, turbulentScalarVelocityScale, tmp
       real (kind=RKIND), dimension(:), allocatable, target :: RiSmoothed, BVFSmoothed
@@ -190,10 +192,16 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_matching', config_cvmix_kpp_matching)
       call mpas_pool_get_config(ocnConfigs, 'config_use_cvmix_fixed_boundary_layer', config_use_cvmix_fixed_boundary_layer)
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_boundary_layer_depth', config_cvmix_kpp_boundary_layer_depth)
-
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_surface_layer_extent', config_cvmix_kpp_surface_layer_extent)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      
       !
       ! set pointers for fields related to position on sphere
       !
@@ -324,8 +332,8 @@ contains
          cvmix_variables%ShearRichardson_iface => RiSmoothed
 
          ! fill BVF
-         BVFSmoothed(1:nVertLevels) = BruntVaisalaFreqTop(1:nVertLevels,iCell)
-         BVFSmoothed(nVertLevels+1) = BVFSmoothed(nVertLevels)
+         BVFSmoothed(1:nVertLevels) = max(0.0_RKIND,BruntVaisalaFreqTop(1:nVertLevels,iCell))
+         BVFSmoothed(nVertLevels+1) = max(0.0_RKIND,BVFSmoothed(nVertLevels))
          cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed
 
          ! fill the intent(in) KPP
@@ -342,6 +350,10 @@ contains
 
             if (config_use_cvmix_fixed_boundary_layer) then
                cvmix_variables % BoundaryLayerDepth = config_cvmix_kpp_boundary_layer_depth
+               cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(1:nVertLevels+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(1:nVertLevels),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
 
             else
 
@@ -355,14 +367,12 @@ contains
               ! compute bulk Richardson number
               ! assume boundary layer depth is at bottom of every kIndexOBL cell
               bulkRichardsonNumberStop = config_cvmix_kpp_stop_OBL_search * config_cvmix_kpp_criticalBulkRichardsonNumber
-              bulkRichardsonNumber(:,iCell) = bulkRichardsonNumberStop - 1.0
-              kIndexOBL=1
+              bulkRichardsonNumber(:,iCell) = bulkRichardsonNumberStop - 1.0_RKIND
               bulkRichardsonFlag = .false.
               do kIndexOBL = 1, maxLevelCell(iCell)
 
-                 ! set OBL at bottome of kIndexOBL cell for computation of bulk Richardson number
-                 cvmix_variables % BoundaryLayerDepth = cvmix_variables % zw_iface(kIndexOBL+1)
-
+                 ! set OBL at bottom of kIndexOBL cell for computation of bulk Richardson number
+                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables % zw_iface(kIndexOBL+1))
                  sigma = -cvmix_variables % zt_cntr(kIndexOBL) / cvmix_variables % BoundaryLayerDepth
 
                  ! compute the turbulent scales in order to compute the bulk Richardson number
@@ -373,8 +383,33 @@ contains
                       surf_fric_vel = cvmix_variables % SurfaceFriction, &
                       w_s = turbulentScalarVelocityScale(kIndexOBL))
 
-              enddo ! do kIndexOBL
+                 ! averaging over a surface layer assuming that BLdepth is cell bottom
 
+                 ! move progressively downward to find the bottom most layer within the surface layer
+                 sfc_layer_depth = cvmix_variables % BoundaryLayerDepth * config_cvmix_kpp_surface_layer_extent
+                 do kav=1,kIndexOBL
+                    if(cvmix_variables%zw_iface(kav+1) < -sfc_layer_depth) exit
+                 enddo   
+
+                !compute shear contribution assuming BLdepth is cell bottom
+                
+                invAreaCell = 1.0 / areaCell(iCell)
+                deltaVelocitySquared = 0.0_RKIND
+                do iEdge=1,nEdgesOnCell(iCell)
+                   normalVelocityAv = sum(normalVelocity(1:kav,iEdge))/float(kav)
+
+                   iEdgeVal = edgesOnCell(iEdge,iCell)
+                   factor = 0.5 * dcEdge(iEdgeVal) * dvEdge(iEdgeVal) * invAreaCell
+                   delU2 = (normalVelocityAv - normalVelocity(kIndexOBL,iEdgeVal))**2
+                   deltaVelocitySquared = deltaVelocitySquared + factor * delU2
+               enddo
+
+               bulkRichardsonNumberShear(kIndexOBL,iCell) = max(deltaVelocitySquared, 1.0e-15_RKIND)
+                 
+               bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity * (density(kIndexOBL,iCell) - &
+                                 sum(density(1:kav,iCell))/float(kav)) / rho_sw
+            
+              enddo ! do kIndexOBL
               cvmix_variables % bulkRichardson_cntr(:) = cvmix_kpp_compute_bulk_Richardson( &
                    zt_cntr = cvmix_variables % zt_cntr(1:nVertLevels), &
                    delta_buoy_cntr = bulkRichardsonNumberBuoy(1:nVertLevels,iCell), &
@@ -384,18 +419,13 @@ contains
 
               ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
 
-              unresolvedShear(:,iCell) = cvmix_kpp_compute_unresolved_shear( &
-                   zt_cntr = cvmix_variables % zt_cntr(1:nVertLevels), &
-                   ws_cntr = turbulentScalarVelocityScale(1:nVertLevels), &
-                   Nsqr_iface = Nsqr_iface(1:nVertLevels+1))
-
               call cvmix_kpp_compute_OBL_depth(  &
                    Ri_bulk = bulkRichardsonNumber(1:nVertLevels,iCell), &
                    zw_iface = cvmix_variables % zw_iface(1:nVertLevels+1), &
                    OBL_depth = cvmix_variables % BoundaryLayerDepth, &
                    kOBL_depth = cvmix_variables % kOBL_depth, &
                    zt_cntr = cvmix_variables % zt_cntr(1:nVertLevels), &
-                    surf_fric = cvmix_variables % SurfaceFriction, &
+                   surf_fric = cvmix_variables % SurfaceFriction, &
                    surf_buoy = cvmix_variables % SurfaceBuoyancyForcing, &
                    Coriolis = cvmix_variables % Coriolis)
 
@@ -410,11 +440,6 @@ contains
              if(cvmix_variables % BoundaryLayerDepth .gt. abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))) then
                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))
              endif
-
-            cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:nVertLevels+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(1:nVertLevels),    &
-                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
 
             call cvmix_coeffs_kpp(                                              &
                           Mdiff_out = cvmix_variables % Mdiff_iface(1:nVertLevels+1),       &
@@ -525,11 +550,13 @@ contains
       ! dellocate cmvix variables
       deallocate(cvmix_variables % Mdiff_iface)
       deallocate(cvmix_variables % Tdiff_iface)
+      deallocate(cvmix_variables % Sdiff_iface)
       deallocate(cvmix_variables % zw_iface)
       deallocate(cvmix_variables % dzw)
       deallocate(cvmix_variables % zt_cntr)
       deallocate(cvmix_variables % dzt)
       deallocate(cvmix_variables % kpp_Tnonlocal_iface)
+      deallocate(cvmix_variables % kpp_Snonlocal_iface)
 
       deallocate(Nsqr_iface)
       deallocate(turbulentScalarVelocityScale)


### PR DESCRIPTION
This PR fixes a few small bugs in mpas_ocn_vmix_cvmix.F .  Further, the computation of surface layer average normal velocity and buoyancy is moved to this routine from ocean_diagnostics.  This makes the computation of boundary layer depth consistent with CVMIX repository documentation.  As of now, I've run the CVMIX SCM test case in a purely convective simulation.  The plot shows the vertical structure of temperature within a single column over 8 days making the bug fix described in https://github.com/MPAS-Dev/MPAS/issues/588.  The Black line is the CVMIX/KPP diagnosed boundary layer depth and the blue is the mixed layer depth diagnosed via a temperature threshold criteria.  The dashed black line shows the analytic solution.

<img width="859" alt="kpp_theta_new" src="https://cloud.githubusercontent.com/assets/13662545/10380267/27c77f3a-6dd0-11e5-941c-f7196814c0a0.png">

The next figure is the same test, but with the bulk richardson number surface layer averaging fix (the red line is the analytic solution).   The comparison is quite good.

![screen shot 2015-10-08 at 11 11 07 am](https://cloud.githubusercontent.com/assets/13662545/10380299/502014d8-6dd0-11e5-87f3-2fee7bf9718b.png)

This corresponding LES result is below (the green line is the diagnosed MLD).

<img width="861" alt="les_theta" src="https://cloud.githubusercontent.com/assets/13662545/10380323/6a3e4e16-6dd0-11e5-854b-5f0fb095b912.png">

A test with surface wind stress is underway.
