### PR TITLE
This fixes a small error in the cvmix interface for debug mode

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -434,11 +434,20 @@ contains
              ! apply minimum limit to OBL
              if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(1,iCell)/2.0) then
                 cvmix_variables % BoundaryLayerDepth = layerThickness(1,iCell)/2.0
+               cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(1:nVertLevels+1),&
+                          zt_cntr = cvmix_variables%zt_cntr(1:nVertLevels),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
              endif
 
              ! apply maximum limit to OBL
              if(cvmix_variables % BoundaryLayerDepth .gt. abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))) then
                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))
+                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = cvmix_variables%zw_iface(1:nVertLevels+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(1:nVertLevels),    &
+                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+
              endif
 
             call cvmix_coeffs_kpp(                                              &


### PR DESCRIPTION
This PR addresses the bug noted by @pwolfram in https://github.com/MPAS-Dev/MPAS/issues/602  In the CVMIX interface, the boundary layer depth was computed.  If it was greater than the bottom depth at that point, the interface would reset the computed boundary layer depth to the bottom depth, but it did not reset the vertical array index of the boundary layer depth, which is required for KPP to compute diffusivities.  I have added the function calls to CVMIX after the BL depth is reset.  I have also added a call if the boundary layer depth becomes too shallow.  This call may not be necessary, however.
