### PR TITLE
Add option to disable name mangling in interface

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <map>
 
+#ifndef MPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING
 #define velocity_solver_init_mpi velocity_solver_init_mpi_
 #define velocity_solver_finalize velocity_solver_finalize_
 #define velocity_solver_init_l1l2 velocity_solver_init_l1l2_
@@ -50,6 +51,7 @@
 #define velocity_solver_export_2d_data velocity_solver_export_2d_data_
 #define velocity_solver_export_fo_velocity velocity_solver_export_fo_velocity_
 #define velocity_solver_estimate_SS_SMB velocity_solver_estimate_ss_smb_
+#endif
 
 //#include <lifev/core/algorithm/PreconditionerIfpack.hpp>
 //#include <lifev/core/algorithm/PreconditionerML.hpp>


### PR DESCRIPTION
Currently the Fortran to C++ interface for external velocity solvers
uses a series of preprocessor #define's to deal with the different way
that Fortran and C++ use underscores in routine/function names.

However, on some machine configurations it may be required to NOT do
this, namely, on Mira where the Fortran and C++ compilers that must be
used are from different vendors.

This commit adds "#ifndef MPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING"
around the #define's to provide the possibility for avoiding this.
Currently this variable is only set within ACME and is not used at all
in standalone MPAS.
