### PR TITLE
Adding templates for ocean analysis members

### DIFF
--- a/test_cases/ocean/templates/ocean/eliassen_palm.xml
+++ b/test_cases/ocean/templates/ocean/eliassen_palm.xml
@@ -1,0 +1,90 @@
+<template>
+	<namelist>
+		<option name="config_AM_eliassenPalm_enable">.true.</option>
+		<option name="config_AM_eliassenPalm_compute_interval">'output_interval'</option>
+		<option name="config_AM_eliassenPalm_stream_name">'eliassenPalmOutput'</option>
+		<option name="config_AM_eliassenPalm_compute_on_startup">.true.</option>
+		<option name="config_AM_eliassenPalm_write_on_startup">.true.</option>
+		<option name="config_AM_eliassenPalm_do_restart">.false.</option>
+		<option name="config_AM_eliassenPalm_debug">.false.</option>
+		<option name="config_AM_eliassenPalm_nBuoyancyLayers">45</option>
+		<option name="config_AM_eliassenPalm_rhomin_buoycoor">900</option>
+		<option name="config_AM_eliassenPalm_rhomax_buoycoor">1080</option>
+	</namelist>
+
+	<streams>
+		<stream name="eliassenPalmOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">eliassenPalmOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/eliassenPalm.$Y-$M-$D.nc</attribute>
+			<attribute name="packages">eliassenPalmAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="potentialDensityMidRef" type="var"/>
+				<member name="potentialDensityTopRef" type="var"/>
+				<member name="nSamplesEA" type="var"/>
+				<member name="buoyancyMaskEA" type="var"/>
+				<member name="sigmaEA" type="var"/>
+				<member name="heightMidBuoyCoorEA" type="var"/>
+				<member name="heightMidBuoyCoorSqEA" type="var"/>
+				<member name="montgPotBuoyCoorEA" type="var"/>
+				<member name="montgPotGradZonalEA" type="var"/>
+				<member name="montgPotGradMeridEA" type="var"/>
+				<member name="heightMGradZonalEA" type="var"/>
+				<member name="heightMGradMeridEA" type="var"/>
+				<member name="uusigmaEA" type="var"/>
+				<member name="vvsigmaEA" type="var"/>
+				<member name="uvsigmaEA" type="var"/>
+				<member name="uvarpisigmaEA" type="var"/>
+				<member name="vvarpisigmaEA" type="var"/>
+				<member name="uTWA" type="var"/>
+				<member name="vTWA" type="var"/>
+				<member name="varpiTWA" type="var"/>
+				<member name="EPFT" type="var"/>
+				<member name="divEPFT" type="var"/>
+				<member name="ErtelPVFlux" type="var"/>
+				<member name="ErtelPVTendency" type="var"/>
+				<member name="ErtelPV" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+	<streams>
+		<stream name="eliassenPalmRestart">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">eliassenPalmRestart</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="filename_template">restarts/eliassenPalm_restart.$Y-$M-$D.nc</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="packages">eliassenPalmAMPKG</attribute>
+			<attribute name="type">input;output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="nSamplesEA" type="var"/>
+				<member name="buoyancyMaskEA" type="var"/>
+				<member name="sigmaEA" type="var"/>
+				<member name="heightMidBuoyCoorEA" type="var"/>
+				<member name="heightMidBuoyCoorSqEA" type="var"/>
+				<member name="montgPotBuoyCoorEA" type="var"/>
+				<member name="montgPotGradZonalEA" type="var"/>
+				<member name="montgPotGradMeridEA" type="var"/>
+				<member name="heightMGradZonalEA" type="var"/>
+				<member name="heightMGradMeridEA" type="var"/>
+				<member name="usigmaEA" type="var"/>
+				<member name="vsigmaEA" type="var"/>
+				<member name="varpisigmaEA" type="var"/>
+				<member name="uusigmaEA" type="var"/>
+				<member name="vvsigmaEA" type="var"/>
+				<member name="uvsigmaEA" type="var"/>
+				<member name="uvarpisigmaEA" type="var"/>
+				<member name="vvarpisigmaEA" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/global_stats.xml
+++ b/test_cases/ocean/templates/ocean/global_stats.xml
@@ -1,0 +1,34 @@
+<template>
+	<namelist>
+		<option name="config_AM_globalStats_enable">.true.</option>
+		<option name="config_AM_globalStats_compute_interval">'output_interval'</option>
+		<option name="config_AM_globalStats_compute_on_startup">.false.</option>
+		<option name="config_AM_globalStats_write_on_startup">.false.</option>
+		<option name="config_AM_globalStats_text_file">.false.</option>
+		<option name="config_AM_globalStats_directory">'analysis_members'</option>
+		<option name="config_AM_globalStats_stream_name">'globalStatsOutput'</option>
+	</namelist>
+
+	<streams>
+		<stream name="globalStatsOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">globalStatsOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0000_01:00:00</attribute>
+			<attribute name="filename_template">analysis_members/globalStats.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">globalStatsAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="minGlobalStats" type="var_array"/>
+				<member name="maxGlobalStats" type="var_array"/>
+				<member name="sumGlobalStats" type="var_array"/>
+				<member name="rmsGlobalStats" type="var_array"/>
+				<member name="avgGlobalStats" type="var_array"/>
+				<member name="vertSumMinGlobalStats" type="var_array"/>
+				<member name="vertSumMaxGlobalStats" type="var_array"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/high_frequency_output.xml
+++ b/test_cases/ocean/templates/ocean/high_frequency_output.xml
@@ -1,0 +1,30 @@
+<template>
+	<namelist>
+		<option name="config_AM_highFrequencyOutput_enable">.true.</option>
+		<option name="config_AM_highFrequencyOutput_compute_interval">'output_interval'</option>
+		<option name="config_AM_highFrequencyOutput_stream_name">'highFrequencyOutput'</option>
+		<option name="config_AM_highFrequencyOutput_compute_on_startup">.true.</option>
+		<option name="config_AM_highFrequencyOutput_write_on_startup">.true.</option>
+	</namelist>
+
+	<streams>
+		<stream name="highFrequencyOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">highFrequencyOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/highFrequencyOutput.$Y-$M-$D.nc</attribute>
+			<attribute name="packages">highFrequencyOutputAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="kineticEnergyAt100m" type="var"/>
+				<member name="relativeVorticityAt100m" type="var"/>
+				<member name="activeTracersAtSurface" type="var_array"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/lagrangian_particle_tracking.xml
+++ b/test_cases/ocean/templates/ocean/lagrangian_particle_tracking.xml
@@ -1,0 +1,124 @@
+<template>
+	<namelist>
+		<option name="config_AM_lagrPartTrack_enable">.true.</option>
+		<option name="config_AM_lagrPartTrack_compute_interval">'dt'</option>
+		<option name="config_AM_lagrPartTrack_compute_on_startup">.true.</option>
+		<option name="config_AM_lagrPartTrack_stream_name">'lagrPartTrackOutput'</option>
+		<option name="config_AM_lagrPartTrack_write_on_startup">.true.</option>
+		<option name="config_AM_lagrPartTrack_filter_number">0</option>
+	</namelist>
+
+	<streams>
+		<stream name="lagrPartTrackOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">lagrPartTrackOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0002_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/lagrPartTrack.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">lagrPartTrackAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="indexToParticleID" type="var"/>
+				<member name="currentBlock" type="var"/>
+				<member name="currentCell" type="var"/>
+				<member name="xParticle" type="var"/>
+				<member name="yParticle" type="var"/>
+				<member name="zParticle" type="var"/>
+				<member name="zLevelParticle" type="var"/>
+				<member name="buoyancyParticle" type="var"/>
+				<member name="vertexReconstMethod" type="var"/>
+				<member name="horizontalTreatment" type="var"/>
+				<member name="verticalTreatment" type="var"/>
+				<member name="dtParticle" type="var"/>
+				<member name="timeIntegration" type="var"/>
+				<member name="indexLevel" type="var"/>
+				<member name="uVertexVelocity" type="var"/>
+				<member name="vVertexVelocity" type="var"/>
+				<member name="wVertexVelocity" type="var"/>
+				<member name="filteredVelocityU" type="var"/>
+				<member name="filteredVelocityV" type="var"/>
+				<member name="filteredVelocityW" type="var"/>
+				<member name="cellOwnerBlock" type="var"/>
+				<member name="transfered" type="var"/>
+				<member name="lonVel" type="var"/>
+				<member name="latVel" type="var"/>
+				<member name="sumU" type="var"/>
+				<member name="sumV" type="var"/>
+				<member name="sumUU" type="var"/>
+				<member name="sumUV" type="var"/>
+				<member name="sumVV" type="var"/>
+				<member name="buoyancySurfaceValues" type="var"/>
+				<member name="buoyancySurfaceVelocityMeridional" type="var"/>
+				<member name="buoyancySurfaceVelocityZonal" type="var"/>
+				<member name="buoyancySurfaceDepth" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+	<streams>
+		<stream name="lagrPartTrackRestart">
+			<attribute name="name">lagrPartTrackRestart</attribute>
+			<attribute name="filename_interval">output_interval</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="filename_template">analysis_members/lagrangianParticleTrackingRestart.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="packages">lagrPartTrackAMPKG</attribute>
+			<attribute name="type">input;output</attribute>
+			<attribute name="immutable">true</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="indexToParticleID" type="var"/>
+				<member name="currentBlock" type="var"/>
+				<member name="currentCell" type="var"/>
+				<member name="xParticle" type="var"/>
+				<member name="yParticle" type="var"/>
+				<member name="zParticle" type="var"/>
+				<member name="zLevelParticle" type="var"/>
+				<member name="buoyancyParticle" type="var"/>
+				<member name="vertexReconstMethod" type="var"/>
+				<member name="horizontalTreatment" type="var"/>
+				<member name="verticalTreatment" type="var"/>
+				<member name="dtParticle" type="var"/>
+				<member name="timeIntegration" type="var"/>
+				<member name="indexLevel" type="var"/>
+				<member name="transfered" type="var"/>
+				<member name="sumU" type="var"/>
+				<member name="sumV" type="var"/>
+				<member name="sumUU" type="var"/>
+				<member name="sumUV" type="var"/>
+				<member name="sumVV" type="var"/>
+				<member name="buoyancySurfaceValues" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+	<streams>
+		<stream name="lagrPartTrackInput">
+			<attribute name="filename_template">analysis_members/lagrangianParticleTrackingInput.nc</attribute>
+			<attribute name="name">lagrPartTrackInput</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="packages">lagrPartTrackAMPKG</attribute>
+			<attribute name="type">input</attribute>
+			<attribute name="immutable">true</attribute>
+			<add_contents>
+				<member name="indexToParticleID" type="var"/>
+				<member name="currentBlock" type="var"/>
+				<member name="currentCell" type="var"/>
+				<member name="xParticle" type="var"/>
+				<member name="yParticle" type="var"/>
+				<member name="zParticle" type="var"/>
+				<member name="zLevelParticle" type="var"/>
+				<member name="buoyancyParticle" type="var"/>
+				<member name="vertexReconstMethod" type="var"/>
+				<member name="horizontalTreatment" type="var"/>
+				<member name="verticalTreatment" type="var"/>
+				<member name="dtParticle" type="var"/>
+				<member name="timeIntegration" type="var"/>
+				<member name="indexLevel" type="var"/>
+				<member name="transfered" type="var"/>
+				<member name="buoyancySurfaceValues" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/layer_volume_weighted_averages.xml
+++ b/test_cases/ocean/templates/ocean/layer_volume_weighted_averages.xml
@@ -1,0 +1,31 @@
+<template>
+	<namelist>
+		<option name="config_AM_layerVolumeWeightedAverage_enable">.true.</option>
+		<option name="config_AM_layerVolumeWeightedAverage_compute_interval">'output_interval'</option>
+		<option name="config_AM_layerVolumeWeightedAverage_compute_on_startup">.false.</option>
+		<option name="config_AM_layerVolumeWeightedAverage_write_on_startup">.false.</option>
+		<option name="config_AM_layerVolumeWeightedAverage_stream_name">'layerVolumeWeightedAverageOutput'</option>
+	</namelist>
+
+	<streams>
+		<stream name="layerVolumeWeightedAverageOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">layerVolumeWeightedAverageOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-05_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/layerVolumeWeightedAverage.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">layerVolumeWeightedAverageAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="minValueWithinOceanLayerRegion" type="var_array"/>
+				<member name="maxValueWithinOceanLayerRegion" type="var_array"/>
+				<member name="avgValueWithinOceanLayerRegion" type="var_array"/>
+				<member name="minValueWithinOceanVolumeRegion" type="var_array"/>
+				<member name="maxValueWithinOceanVolumeRegion" type="var_array"/>
+				<member name="avgValueWithinOceanVolumeRegion" type="var_array"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/meridional_heat_transport.xml
+++ b/test_cases/ocean/templates/ocean/meridional_heat_transport.xml
@@ -1,0 +1,34 @@
+<template>
+	<namelist>
+		<option name="config_AM_meridionalHeatTransport_enable">.true.</option>
+		<option name="config_AM_meridionalHeatTransport_compute_interval">'output_interval'</option>
+		<option name="config_AM_meridionalHeatTransport_compute_on_startup">.true.</option>
+		<option name="config_AM_meridionalHeatTransport_write_on_startup">.true.</option>
+		<option name="config_AM_meridionalHeatTransport_stream_name">'meridionalHeatTransportOutput'</option>
+		<option name="config_AM_meridionalHeatTransport_num_bins">180</option>
+		<option name="config_AM_meridionalHeatTransport_min_bin">-1.0e34</option>
+		<option name="config_AM_meridionalHeatTransport_max_bin">-1.0e34</option>
+	</namelist>
+
+	<streams>
+		<stream name="meridionalHeatTransportOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">meridionalHeatTransportOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">0001_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/meridionalHeatTransport.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">meridionalHeatTransportAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="binBoundaryMerHeatTrans" type="var"/>
+				<member name="meridionalHeatTransportLatZ" type="var"/>
+				<member name="meridionalHeatTransportLat" type="var"/>
+				<member name="refZMid" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/mixed_layer_depths.xml
+++ b/test_cases/ocean/templates/ocean/mixed_layer_depths.xml
@@ -1,0 +1,41 @@
+<template>
+	<namelist>
+		<option name="config_AM_mixedLayerDepths_enable">.true.</option>
+		<option name="config_AM_mixedLayerDepths_compute_interval">'output_interval'</option>
+		<option name="config_AM_mixedLayerDepths_stream_name">'mixedLayerDepthsOutput'</option>
+		<option name="config_AM_mixedLayerDepths_write_on_startup">.true.</option>
+		<option name="config_AM_mixedLayerDepths_compute_on_startup">.true.</option>
+		<option name="config_AM_mixedLayerDepths_Tthreshold">.true.</option>
+		<option name="config_AM_mixedLayerDepths_Dthreshold">.true.</option>
+		<option name="config_AM_mixedLayerDepths_crit_temp_threshold">0.2</option>
+		<option name="config_AM_mixedLayerDepths_crit_dens_threshold">0.03</option>
+		<option name="config_AM_mixedLayerDepths_reference_pressure">1.0E5</option>
+		<option name="config_AM_mixedLayerDepths_Tgradient">.true.</option>
+		<option name="config_AM_mixedLayerDepths_Dgradient">.true.</option>
+		<option name="config_AM_mixedLayerDepths_temp_gradient_threshold">5E-7</option>
+		<option name="config_AM_mixedLayerDepths_den_gradient_threshold">5E-8</option>
+		<option name="config_AM_mixedLayerDepths_interp_method">1</option>
+	</namelist>
+
+	<streams>
+		<stream name="mixedLayerDepthsOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">mixedLayerDepthsOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/mixedLayerDepths.$Y-$M-$D.nc</attribute>
+			<attribute name="packages">mixedLayerDepthsAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="tThreshMLD" type="var"/>
+				<member name="dThreshMLD" type="var"/>
+				<member name="tGradMLD" type="var"/>
+				<member name="dGradMLD" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/okubo_weiss.xml
+++ b/test_cases/ocean/templates/ocean/okubo_weiss.xml
@@ -1,0 +1,36 @@
+<template>
+	<namelist>
+		<option name="config_AM_okuboWeiss_enable">.true.</option>
+		<option name="config_AM_okuboWeiss_compute_on_startup">.true.</option>
+		<option name="config_AM_okuboWeiss_write_on_startup">.true.</option>
+		<option name="config_AM_okuboWeiss_compute_interval">'output_interval'</option>
+		<option name="config_AM_okuboWeiss_stream_name">'okuboWeissOutput'</option>
+		<option name="config_AM_okuboWeiss_directory">'analysis_members'</option>
+		<option name="config_AM_okuboWeiss_threshold_value">-0.2</option>
+		<option name="config_AM_okuboWeiss_normalization">1e-10</option>
+		<option name="config_AM_okuboWeiss_lambda2_normalization">1e-10</option>
+		<option name="config_AM_okuboWeiss_use_lat_lon_coords">.true.</option>
+		<option name="config_AM_okuboWeiss_compute_eddy_census">.true.</option>
+		<option name="config_AM_okuboWeiss_eddy_min_cells">20</option>
+	</namelist>
+
+	<streams>
+		<stream name="okuboWeissOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">okuboWeissOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-05_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/okuboWeiss.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">okuboWeissAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="okuboWeiss" type="var"/>
+				<member name="vorticity" type="var"/>
+				<member name="eddyID" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/surface_area_weighted_averages.xml
+++ b/test_cases/ocean/templates/ocean/surface_area_weighted_averages.xml
@@ -1,0 +1,28 @@
+<template>
+	<namelist>
+		<option name="config_AM_surfaceAreaWeightedAverages_enable">.true.</option>
+		<option name="config_AM_surfaceAreaWeightedAverages_compute_on_startup">.true.</option>
+		<option name="config_AM_surfaceAreaWeightedAverages_write_on_startup">.true.</option>
+		<option name="config_AM_surfaceAreaWeightedAverages_compute_interval">'output_interval'</option>
+		<option name="config_AM_surfaceAreaWeightedAverages_stream_name">'surfaceAreaWeightedAveragesOutput'</option>
+	</namelist>
+
+	<streams>
+		<stream name="surfaceAreaWeightedAveragesOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">surfaceAreaWeightedAveragesOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-05_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/surfaceAreaWeightedAverages.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">surfaceAreaWeightedAveragesAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="minValueWithinOceanRegion" type="var_array"/>
+				<member name="maxValueWithinOceanRegion" type="var_array"/>
+				<member name="avgValueWithinOceanRegion" type="var_array"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/test_compute_interval.xml
+++ b/test_cases/ocean/templates/ocean/test_compute_interval.xml
@@ -1,0 +1,26 @@
+<template>
+	<namelist>
+		<option name="config_AM_testComputeInterval_enable">.true.</option>
+		<option name="config_AM_testComputeInterval_compute_interval">'00-00-01_00:00:00'</option>
+		<option name="config_AM_testComputeInterval_compute_on_startup">.true.</option>
+		<option name="config_AM_testComputeInterval_write_on_startup">.true.</option>
+		<option name="config_AM_testComputeInterval_stream_name">'testComputeIntervalOutput'</option>
+	</namelist>
+
+	<streams>
+		<stream name="testComputeIntervalOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">testComputeIntervalOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/testComputeInterval.$Y-$M-$D.nc</attribute>
+			<attribute name="packages">testComputeIntervalAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="testComputeIntervalCounter" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/time_filters.xml
+++ b/test_cases/ocean/templates/ocean/time_filters.xml
@@ -1,0 +1,51 @@
+<template>
+	<namelist>
+		<option name="config_AM_timeFilters_enable">.true.</option>
+		<option name="config_AM_timeFilters_compute_interval">'dt'</option>
+		<option name="config_AM_timeFilters_stream_name">'timeFiltersOutput'</option>
+		<option name="config_AM_timeFilters_compute_on_startup">.true.</option>
+		<option name="config_AM_timeFilters_write_on_startup">.true.</option>
+		<option name="config_AM_timeFilters_do_restart">.false.</option>
+		<option name="config_AM_timeFilters_initialize_filters">.true.</option>
+		<option name="config_AM_timeFilters_tau">'90_00:00:00'</option>
+	</namelist>
+
+	<streams>
+		<stream name="timeFiltersOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">timeFiltersOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/timeFilters.$Y-$M-$D_$h.nc</attribute>
+			<attribute name="packages">timeFiltersAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocityLowPass" type="var"/>
+				<member name="normalVelocityHighPass" type="var"/>
+				<member name="normalVelocityFilterTest" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+	<streams>
+		<stream name="timeFiltersRestart">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">timeFiltersRestart</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="filename_template">restarts/timeFiltersRestart.$Y-$M-$D_$h.nc</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="packages">timeFiltersAMPKG</attribute>
+			<attribute name="type">input;output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocityLowPass" type="var"/>
+				<member name="normalVelocityHighPass" type="var"/>
+				<member name="normalVelocityFilterTest" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/time_series_stats.xml
+++ b/test_cases/ocean/templates/ocean/time_series_stats.xml
@@ -1,0 +1,58 @@
+<template>
+	<namelist>
+		<option name="config_AM_timeSeriesStats_enable">.true.</option>
+		<option name="config_AM_timeSeriesStats_compute_on_startup">.false.</option>
+		<option name="config_AM_timeSeriesStats_write_on_startup">.false.</option>
+		<option name="config_AM_timeSeriesStats_compute_interval">'dt'</option>
+		<option name="config_AM_timeSeriesStats_stream_name">'timeSeriesStatsOutput'</option>
+		<option name="config_AM_timeSeriesStats_restart_name">'timeSeriesStatsRestart'</option>
+		<option name="config_AM_timeSeriesStats_add_mesh">.true.</option>
+		<option name="config_AM_timeSeriesStats_operation">'avg'</option>
+		<option name="config_AM_timeSeriesStats_reference_times">'initial_time'</option>
+		<option name="config_AM_timeSeriesStats_duration_intervals">'repeat_interval'</option>
+		<option name="config_AM_timeSeriesStats_repeat_intervals">'reset_interval'</option>
+		<option name="config_AM_timeSeriesStats_reset_intervals">'00-00-01_00:00:00'</option>
+	</namelist>
+
+	<streams>
+		<stream name="timeSeriesStatsOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">timeSeriesStatsOutput</attribute>
+			<attribute name="filename_interval">00-01-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/timeSeriesStats.$Y-$M-$D.nc</attribute>
+			<attribute name="packages">timeSeriesStatsAMPKG</attribute>
+			<attribute name="type">none</attribute>
+			<add_contents>
+				<member name="tracersSurfaceValue" type="var_array"/>
+				<member name="surfaceVelocity" type="var_array"/>
+				<member name="SSHGradient" type="var_array"/>
+				<member name="ssh" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="vertVelocityTop" type="var"/>
+				<member name="normalTransportVelocity" type="var"/>
+				<member name="transportVelocityZonal" type="var"/>
+				<member name="transportVelocityMeridional" type="var"/>
+				<member name="vertTransportVelocityTop" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+	<streams>
+		<stream name="timeSeriesStatsRestart">
+			<attribute name="name">timeSeriesStatsRestart</attribute>
+			<attribute name="filename_interval">output_interval</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="filename_template">restarts/restart.AM.timeSeriesStats.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="type">input;output</attribute>
+			<attribute name="immutable">true</attribute>
+			<add_contents>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/water_mass_census.xml
+++ b/test_cases/ocean/templates/ocean/water_mass_census.xml
@@ -1,0 +1,34 @@
+<template>
+	<namelist>
+		<option name="config_AM_waterMassCensus_enable">.true.</option>
+		<option name="config_AM_waterMassCensus_compute_interval">'output_interval'</option>
+		<option name="config_AM_waterMassCensus_stream_name">'waterMassCensusOutput'</option>
+		<option name="config_AM_waterMassCensus_compute_on_startup">.false.</option>
+		<option name="config_AM_waterMassCensus_write_on_startup">.false.</option>
+		<option name="config_AM_waterMassCensus_minTemperature">-2.0</option>
+		<option name="config_AM_waterMassCensus_maxTemperature">30.0</option>
+		<option name="config_AM_waterMassCensus_minSalinity">32.0</option>
+		<option name="config_AM_waterMassCensus_maxSalinity">37.0</option>
+	</namelist>
+
+	<streams>
+		<stream name="waterMassCensusOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">waterMassCensusOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">00-00-05_00:00:00</attribute>
+			<attribute name="filename_template">analysis_members/waterMassCensus.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">waterMassCensusAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="xtime" type="var"/>
+				<member name="waterMassCensusTemperatureValues" type="var_array"/>
+				<member name="waterMassCensusSalinityValues" type="var_array"/>
+				<member name="waterMassFractionalDistribution" type="var_array"/>
+				<member name="potentialDensityOfTSDiagram" type="var_array"/>
+				<member name="zPositionOfTSDiagram" type="var_array"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/templates/ocean/zonal_mean.xml
+++ b/test_cases/ocean/templates/ocean/zonal_mean.xml
@@ -1,0 +1,35 @@
+<template>
+	<namelist>
+		<option name="config_AM_zonalMean_enable">.true.</option>
+		<option name="config_AM_zonalMean_compute_on_startup">.true.</option>
+		<option name="config_AM_zonalMean_write_on_startup">.true.</option>
+		<option name="config_AM_zonalMean_compute_interval">'output_interval'</option>
+		<option name="config_AM_zonalMean_stream_name">'zonalMeanOutput'</option>
+		<option name="config_AM_zonalMean_num_bins">180</option>
+		<option name="config_AM_zonalMean_min_bin">-1.0e34</option>
+		<option name="config_AM_zonalMean_max_bin">-1.0e34</option>
+	</namelist>
+
+	<streams>
+		<stream name="zonalMeanOutput">
+			<attribute name="runtime_format">single_file</attribute>
+			<attribute name="name">zonalMeanOutput</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0000_12:00:00</attribute>
+			<attribute name="filename_template">analysis_members/zonalMeans.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="packages">zonalMeanAMPKG</attribute>
+			<attribute name="type">output</attribute>
+			<add_contents>
+				<member name="tracersZonalMean" type="var_array"/>
+				<member name="xtime" type="var"/>
+				<member name="binCenterZonalMean" type="var"/>
+				<member name="binBoundaryZonalMean" type="var"/>
+				<member name="velocityZonalZonalMean" type="var"/>
+				<member name="velocityMeridionalZonalMean" type="var"/>
+				<member name="refZMid" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+</template>


### PR DESCRIPTION
This merge adds template definitions for the ocean analysis members, so
they can be used in setting up test case configurations.
