### PR TITLE
Allow vector reconstruction to happen in halo regions

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -1034,7 +1034,7 @@ contains
          !-------------------------------------------------------------
          call mpas_reconstruct(meshPool, montgPotNormalGradOnEdge, &
             montgPotGradX, montgPotGradY, montgPotGradZ, &
-            montgPotGradZonal, montgPotGradMerid)
+            montgPotGradZonal, montgPotGradMerid, includeHalos=.true.)
 
          !-------------------------------------------------------------
          ! Increment first-order running ensemble average fields
@@ -1194,7 +1194,7 @@ contains
          ! reconstruct full gradient vector at cell centers
          !-------------------------------------------------------------
          call mpas_reconstruct(meshPool, ErtelPVNormalGradOnEdge, &
-            ErtelPVGradX, ErtelPVGradY, ErtelPVGradZ, ErtelPVGradZonal, ErtelPVGradMerid)
+            ErtelPVGradX, ErtelPVGradY, ErtelPVGradZ, ErtelPVGradZonal, ErtelPVGradMerid, includeHalos=.true.)
 
          !-------------------------------------------------------------
          ! compute the vertical derivative of uTWA
@@ -2691,7 +2691,7 @@ contains
         meshPool, uCell, velNormalGradOnEdge)
       call mpas_reconstruct(meshPool, velNormalGradOnEdge, &
         velGradX, velGradY, velGradZ, &
-        velGradZonal, velGradMerid)
+        velGradZonal, velGradMerid, includeHalos=.true.)
       uGradMerid = velGradMerid
 
       ! calculate derivative of vTWA with respect to the zonal direction
@@ -2699,7 +2699,7 @@ contains
         meshPool, vCell, velNormalGradOnEdge)
       call mpas_reconstruct(meshPool, velNormalGradOnEdge, &
         velGradX, velGradY, velGradZ, &
-        velGradZonal, velGradMerid)
+        velGradZonal, velGradMerid, includeHalos=.true.)
       vGradZonal = velGradZonal
 
       ErtelPV = 0.0

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -855,10 +855,10 @@ module ocn_time_integration_rk4
          ! End: Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
 
-         call mpas_reconstruct(meshPool,  normalVelocityNew,                 &
-                          velocityX, velocityY, velocityZ, &
-                          velocityZonal, velocityMeridional      &
-                         )
+         call mpas_reconstruct(meshPool,  normalVelocityNew,  &
+                          velocityX, velocityY, velocityZ,    &
+                          velocityZonal, velocityMeridional,  &
+                          includeHalos = .true.)
 
          call mpas_reconstruct(meshPool, gradSSH,         &
                           gradSSHX, gradSSHY, gradSSHZ,   &

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1607,10 +1607,10 @@ module ocn_time_integration_split
             call ocn_gm_compute_Bolus_velocity(diagnosticsPool, meshPool, scratchPool)
          end if
 
-         call mpas_reconstruct(meshPool, normalVelocityNew,                  &
-                          velocityX, velocityY, velocityZ, &
-                          velocityZonal, velocityMeridional      &
-                         )
+         call mpas_reconstruct(meshPool, normalVelocityNew,  &
+                          velocityX, velocityY, velocityZ,   &
+                          velocityZonal, velocityMeridional, &
+                          includeHalos = .true. )
 
          call mpas_reconstruct(meshPool, gradSSH,         &
                           gradSSHX, gradSSHY, gradSSHZ,   &

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -633,7 +633,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_rbf_interp_initialize(meshPool)
       call mpas_initialize_tangent_vectors(meshPool, edgeTangentVectors)
 
-      call mpas_init_reconstruct(meshPool)
+      call mpas_init_reconstruct(meshPool, includeHalos=.true.)
 
       call mpas_reconstruct(meshPool, normalVelocity,        &
                        velocityX,            &


### PR DESCRIPTION
This merge updates specific vector reconstruction calls to compute
vector reconstruction fields in halo regions. This is necessary to allow
operators (such as the EPFT AM) to be bit-reproducible.
