### PR TITLE
Update analysis member templates based on restart capabilities

### DIFF
--- a/test_cases/ocean/templates/ocean/eliassen_palm.xml
+++ b/test_cases/ocean/templates/ocean/eliassen_palm.xml
@@ -2,10 +2,10 @@
 	<namelist>
 		<option name="config_AM_eliassenPalm_enable">.true.</option>
 		<option name="config_AM_eliassenPalm_compute_interval">'output_interval'</option>
-		<option name="config_AM_eliassenPalm_stream_name">'eliassenPalmOutput'</option>
+		<option name="config_AM_eliassenPalm_output_stream">'eliassenPalmOutput'</option>
+		<option name="config_AM_eliassenPalm_restart_stream">'eliassenPalmRestart'</option>
 		<option name="config_AM_eliassenPalm_compute_on_startup">.true.</option>
 		<option name="config_AM_eliassenPalm_write_on_startup">.true.</option>
-		<option name="config_AM_eliassenPalm_do_restart">.false.</option>
 		<option name="config_AM_eliassenPalm_debug">.false.</option>
 		<option name="config_AM_eliassenPalm_nBuoyancyLayers">45</option>
 		<option name="config_AM_eliassenPalm_rhomin_buoycoor">900</option>

--- a/test_cases/ocean/templates/ocean/global_stats.xml
+++ b/test_cases/ocean/templates/ocean/global_stats.xml
@@ -6,7 +6,7 @@
 		<option name="config_AM_globalStats_write_on_startup">.false.</option>
 		<option name="config_AM_globalStats_text_file">.false.</option>
 		<option name="config_AM_globalStats_directory">'analysis_members'</option>
-		<option name="config_AM_globalStats_stream_name">'globalStatsOutput'</option>
+		<option name="config_AM_globalStats_output_stream">'globalStatsOutput'</option>
 	</namelist>
 
 	<streams>

--- a/test_cases/ocean/templates/ocean/high_frequency_output.xml
+++ b/test_cases/ocean/templates/ocean/high_frequency_output.xml
@@ -2,7 +2,7 @@
 	<namelist>
 		<option name="config_AM_highFrequencyOutput_enable">.true.</option>
 		<option name="config_AM_highFrequencyOutput_compute_interval">'output_interval'</option>
-		<option name="config_AM_highFrequencyOutput_stream_name">'highFrequencyOutput'</option>
+		<option name="config_AM_highFrequencyOutput_output_stream">'highFrequencyOutput'</option>
 		<option name="config_AM_highFrequencyOutput_compute_on_startup">.true.</option>
 		<option name="config_AM_highFrequencyOutput_write_on_startup">.true.</option>
 	</namelist>

--- a/test_cases/ocean/templates/ocean/lagrangian_particle_tracking.xml
+++ b/test_cases/ocean/templates/ocean/lagrangian_particle_tracking.xml
@@ -3,7 +3,9 @@
 		<option name="config_AM_lagrPartTrack_enable">.true.</option>
 		<option name="config_AM_lagrPartTrack_compute_interval">'dt'</option>
 		<option name="config_AM_lagrPartTrack_compute_on_startup">.true.</option>
-		<option name="config_AM_lagrPartTrack_stream_name">'lagrPartTrackOutput'</option>
+		<option name="config_AM_lagrPartTrack_output_stream">'lagrPartTrackOutput'</option>
+		<option name="config_AM_lagrPartTrack_restart_stream">'lagrPartTrackRestart'</option>
+		<option name="config_AM_lagrPartTrack_input_stream">'lagrPartTrackInput'</option>
 		<option name="config_AM_lagrPartTrack_write_on_startup">.true.</option>
 		<option name="config_AM_lagrPartTrack_filter_number">0</option>
 	</namelist>

--- a/test_cases/ocean/templates/ocean/layer_volume_weighted_averages.xml
+++ b/test_cases/ocean/templates/ocean/layer_volume_weighted_averages.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_layerVolumeWeightedAverage_compute_interval">'output_interval'</option>
 		<option name="config_AM_layerVolumeWeightedAverage_compute_on_startup">.false.</option>
 		<option name="config_AM_layerVolumeWeightedAverage_write_on_startup">.false.</option>
-		<option name="config_AM_layerVolumeWeightedAverage_stream_name">'layerVolumeWeightedAverageOutput'</option>
+		<option name="config_AM_layerVolumeWeightedAverage_output_stream">'layerVolumeWeightedAverageOutput'</option>
 	</namelist>
 
 	<streams>

--- a/test_cases/ocean/templates/ocean/meridional_heat_transport.xml
+++ b/test_cases/ocean/templates/ocean/meridional_heat_transport.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_meridionalHeatTransport_compute_interval">'output_interval'</option>
 		<option name="config_AM_meridionalHeatTransport_compute_on_startup">.true.</option>
 		<option name="config_AM_meridionalHeatTransport_write_on_startup">.true.</option>
-		<option name="config_AM_meridionalHeatTransport_stream_name">'meridionalHeatTransportOutput'</option>
+		<option name="config_AM_meridionalHeatTransport_output_stream">'meridionalHeatTransportOutput'</option>
 		<option name="config_AM_meridionalHeatTransport_num_bins">180</option>
 		<option name="config_AM_meridionalHeatTransport_min_bin">-1.0e34</option>
 		<option name="config_AM_meridionalHeatTransport_max_bin">-1.0e34</option>

--- a/test_cases/ocean/templates/ocean/mixed_layer_depths.xml
+++ b/test_cases/ocean/templates/ocean/mixed_layer_depths.xml
@@ -2,7 +2,7 @@
 	<namelist>
 		<option name="config_AM_mixedLayerDepths_enable">.true.</option>
 		<option name="config_AM_mixedLayerDepths_compute_interval">'output_interval'</option>
-		<option name="config_AM_mixedLayerDepths_stream_name">'mixedLayerDepthsOutput'</option>
+		<option name="config_AM_mixedLayerDepths_output_stream">'mixedLayerDepthsOutput'</option>
 		<option name="config_AM_mixedLayerDepths_write_on_startup">.true.</option>
 		<option name="config_AM_mixedLayerDepths_compute_on_startup">.true.</option>
 		<option name="config_AM_mixedLayerDepths_Tthreshold">.true.</option>

--- a/test_cases/ocean/templates/ocean/okubo_weiss.xml
+++ b/test_cases/ocean/templates/ocean/okubo_weiss.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_okuboWeiss_compute_on_startup">.true.</option>
 		<option name="config_AM_okuboWeiss_write_on_startup">.true.</option>
 		<option name="config_AM_okuboWeiss_compute_interval">'output_interval'</option>
-		<option name="config_AM_okuboWeiss_stream_name">'okuboWeissOutput'</option>
+		<option name="config_AM_okuboWeiss_output_stream">'okuboWeissOutput'</option>
 		<option name="config_AM_okuboWeiss_directory">'analysis_members'</option>
 		<option name="config_AM_okuboWeiss_threshold_value">-0.2</option>
 		<option name="config_AM_okuboWeiss_normalization">1e-10</option>

--- a/test_cases/ocean/templates/ocean/surface_area_weighted_averages.xml
+++ b/test_cases/ocean/templates/ocean/surface_area_weighted_averages.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_surfaceAreaWeightedAverages_compute_on_startup">.true.</option>
 		<option name="config_AM_surfaceAreaWeightedAverages_write_on_startup">.true.</option>
 		<option name="config_AM_surfaceAreaWeightedAverages_compute_interval">'output_interval'</option>
-		<option name="config_AM_surfaceAreaWeightedAverages_stream_name">'surfaceAreaWeightedAveragesOutput'</option>
+		<option name="config_AM_surfaceAreaWeightedAverages_output_stream">'surfaceAreaWeightedAveragesOutput'</option>
 	</namelist>
 
 	<streams>

--- a/test_cases/ocean/templates/ocean/test_compute_interval.xml
+++ b/test_cases/ocean/templates/ocean/test_compute_interval.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_testComputeInterval_compute_interval">'00-00-01_00:00:00'</option>
 		<option name="config_AM_testComputeInterval_compute_on_startup">.true.</option>
 		<option name="config_AM_testComputeInterval_write_on_startup">.true.</option>
-		<option name="config_AM_testComputeInterval_stream_name">'testComputeIntervalOutput'</option>
+		<option name="config_AM_testComputeInterval_output_stream">'testComputeIntervalOutput'</option>
 	</namelist>
 
 	<streams>

--- a/test_cases/ocean/templates/ocean/time_filters.xml
+++ b/test_cases/ocean/templates/ocean/time_filters.xml
@@ -2,10 +2,10 @@
 	<namelist>
 		<option name="config_AM_timeFilters_enable">.true.</option>
 		<option name="config_AM_timeFilters_compute_interval">'dt'</option>
-		<option name="config_AM_timeFilters_stream_name">'timeFiltersOutput'</option>
+		<option name="config_AM_timeFilters_output_stream">'timeFiltersOutput'</option>
+		<option name="config_AM_timeFilters_restart_stream">'timeFiltersRestart'</option>
 		<option name="config_AM_timeFilters_compute_on_startup">.true.</option>
 		<option name="config_AM_timeFilters_write_on_startup">.true.</option>
-		<option name="config_AM_timeFilters_do_restart">.false.</option>
 		<option name="config_AM_timeFilters_initialize_filters">.true.</option>
 		<option name="config_AM_timeFilters_tau">'90_00:00:00'</option>
 	</namelist>

--- a/test_cases/ocean/templates/ocean/time_series_stats.xml
+++ b/test_cases/ocean/templates/ocean/time_series_stats.xml
@@ -4,8 +4,8 @@
 		<option name="config_AM_timeSeriesStats_compute_on_startup">.false.</option>
 		<option name="config_AM_timeSeriesStats_write_on_startup">.false.</option>
 		<option name="config_AM_timeSeriesStats_compute_interval">'dt'</option>
-		<option name="config_AM_timeSeriesStats_stream_name">'timeSeriesStatsOutput'</option>
-		<option name="config_AM_timeSeriesStats_restart_name">'timeSeriesStatsRestart'</option>
+		<option name="config_AM_timeSeriesStats_output_stream">'timeSeriesStatsOutput'</option>
+		<option name="config_AM_timeSeriesStats_restart_stream">'timeSeriesStatsRestart'</option>
 		<option name="config_AM_timeSeriesStats_add_mesh">.true.</option>
 		<option name="config_AM_timeSeriesStats_operation">'avg'</option>
 		<option name="config_AM_timeSeriesStats_reference_times">'initial_time'</option>

--- a/test_cases/ocean/templates/ocean/water_mass_census.xml
+++ b/test_cases/ocean/templates/ocean/water_mass_census.xml
@@ -2,7 +2,7 @@
 	<namelist>
 		<option name="config_AM_waterMassCensus_enable">.true.</option>
 		<option name="config_AM_waterMassCensus_compute_interval">'output_interval'</option>
-		<option name="config_AM_waterMassCensus_stream_name">'waterMassCensusOutput'</option>
+		<option name="config_AM_waterMassCensus_output_stream">'waterMassCensusOutput'</option>
 		<option name="config_AM_waterMassCensus_compute_on_startup">.false.</option>
 		<option name="config_AM_waterMassCensus_write_on_startup">.false.</option>
 		<option name="config_AM_waterMassCensus_minTemperature">-2.0</option>

--- a/test_cases/ocean/templates/ocean/zonal_mean.xml
+++ b/test_cases/ocean/templates/ocean/zonal_mean.xml
@@ -4,7 +4,7 @@
 		<option name="config_AM_zonalMean_compute_on_startup">.true.</option>
 		<option name="config_AM_zonalMean_write_on_startup">.true.</option>
 		<option name="config_AM_zonalMean_compute_interval">'output_interval'</option>
-		<option name="config_AM_zonalMean_stream_name">'zonalMeanOutput'</option>
+		<option name="config_AM_zonalMean_output_stream">'zonalMeanOutput'</option>
 		<option name="config_AM_zonalMean_num_bins">180</option>
 		<option name="config_AM_zonalMean_min_bin">-1.0e34</option>
 		<option name="config_AM_zonalMean_max_bin">-1.0e34</option>


### PR DESCRIPTION
This merge updates the analysis member templates in the testing
infrastructure to have the correct namelist option names, given the
recent modifications to analysis members to support restart / input
capabilities.
