### PR TITLE
Updated parameters for planar periodic test case

### DIFF
--- a/test_cases/ocean/ocean/periodic_planar/20km/config_forward.xml
+++ b/test_cases/ocean/ocean/periodic_planar/20km/config_forward.xml
@@ -9,6 +9,12 @@
 		<mirror protocol="local" path_name="mesh_database" file_name="particle_full.151029.nc"/>	
 	</get_file>
 
+  <get_file dest="graph.info.part.16">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging" file_name="graph.info.part.16.doubly_periodic_20km_1000x2000km_planar.151106"/>	
+		<mirror protocol="local" path_name="mesh_database" file_name="graph.info.part.16.doubly_periodic_20km_1000x2000km_planar.151106"/>	
+  </get_file>
+
+
 	<add_executable source="model" dest="ocean_model"/>
 	<add_executable source="metis" dest="metis"/>
 
@@ -69,11 +75,11 @@
 	<!--  Currently, this will only run with 16 processors because
 	      the particle file is decomposed with 16 processors and we
 	      currently do not have an online way of redecomposing particles.
+	      Therefore, a graph file is also used because different versions
+	      of metis produce different graph files and the particle file is
+	      tied to a particular version of the graph file.
 	-->
 	<run_script name="run.py">
-		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
-		</step>
 		<step executable="mpirun">
 			<argument flag="-n">16</argument>
 			<argument flag="">./ocean_model</argument>


### PR DESCRIPTION
Fixes a bug preventing the planar periodic test case from running.  Output can be visualized with script at https://www.dropbox.com/s/fh5kcs96hwn41vr/plot_particles.py?dl=0 via

./plot_particles.py analysis_members/lagrPartTrack.0000-01-01_00.00.00.nc 

with output of
![screenshot 2015-10-29 17 06 42](https://cloud.githubusercontent.com/assets/4295853/10834510/78ca42b0-7e5f-11e5-837c-b3f9f1f54c2a.png)

indicating that particles on the interior start ('o') and end ('x') at the same point.
