### PR TITLE
Add missing package to bulk forcing fields

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2445,7 +2445,7 @@
 		/>
 		<var name="iceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from ice runoff at cell centers from coupler. Positive into the ocean."
-			 packages="activeTracersBulkRestoringPKG"
+			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
 		/>
 		<var name="rainFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from rain at cell centers from coupler. Positive into the ocean."


### PR DESCRIPTION
This merge adds a missing package to one of the fields used in bulk
forcing. Previously if the bulk thickness flux namelist option was
turned on but the active tracers bulk surface forcing was disabled, the
model would die with a segfault. This allows thickness fluxes without
tracer fluxes, and vice versa.
