### PR TITLE
Adding a kind specifier in time series stats

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_time_series_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_time_series_stats.F
@@ -65,7 +65,7 @@ module ocn_time_series_stats
       duration_alarm_ID, reset_alarm_ID
 
     ! counter for accumulation
-    real, pointer :: counter
+    real (kind=RKIND), pointer :: counter
   end type time_series_buffer_type
 
   type time_series_type


### PR DESCRIPTION
The time series stats analysis member was previously missing a kind
specifier on a real. This breaks compilation using certain compiler
options, and on certain machines. This merge adds the kind specifier.
