### PR TITLE
Fix a memory leak in incremental remapping

### DIFF
--- a/src/core_cice/Registry.xml
+++ b/src/core_cice/Registry.xml
@@ -1419,6 +1419,7 @@
                 <var name="xyyyAvgCell"                       type="real"     dimensions="nCells"                   name_in_code="xyyyAvgCell"/>
                 <var name="yyyyAvgCell"                       type="real"     dimensions="nCells"                   name_in_code="yyyyAvgCell"/>
 	        <var name="workCategoryCell"                  type="real"     dimensions="nCategories nCells"       name_in_code="workCategoryCell"/>
+                <var name="maskCategoryCell"                  type="integer"  dimensions="nCategories nCells"       name_in_code="maskCategoryCell"/>
 	</var_struct>
 
 	<!--atmos coupling -->
@@ -1812,12 +1813,6 @@
 	        <var name="iceVolumeTendencyThermodynamics"        type="real"     dimensions="nCells"              name_in_code="iceVolumeTendencyThermodynamics"/>
 	        <var name="iceAgeTendencyThermodynamics"           type="real"     dimensions="nCells"              name_in_code="iceAgeTendencyThermodynamics"/>
 	        <var name="freezingMeltingPotentialInitial"           type="real"     dimensions="nCells"              name_in_code="freezingMeltingPotentialInitial"/>
-	</var_struct>
-
-	<!-- Scratch arrays -->
-        <var_struct name="scratch" time_levs="1">
-                <var name="iceCellMask"                       type="integer"  dimensions="nCells"                      persistence="scratch"/>
-                <var name="iceCellCategoryMask"               type="integer"  dimensions="nCategories nCells"          persistence="scratch"/>
 	</var_struct>
 
 #include "analysis_members/Registry_cice_analysis_members.xml"

--- a/src/core_cice/shared/mpas_cice_advection_incremental_remap.F
+++ b/src/core_cice/shared/mpas_cice_advection_incremental_remap.F
@@ -2590,6 +2590,9 @@ contains
     real(kind=RKIND), dimension(:,:), pointer ::  &
          workCategoryCell        ! work array with dimensions (nCategories,nCells)
 
+    integer, dimension(:,:), pointer ::  &
+         maskCategoryCell        ! mask array with dimensions (nCategories,nCells)
+
     integer :: timeLevel
 
     logical, parameter :: zapSmallMass = .true.  ! if true, remove mass values (i.e., fractional ice area in CICE)
@@ -2672,6 +2675,7 @@ contains
     call mpas_pool_get_array(incrementalRemapPool, 'transGlobalToCell',   transGlobalToCell)
     call mpas_pool_get_array(incrementalRemapPool, 'minLengthEdgesOnVertex', minLengthEdgesOnVertex)
     call mpas_pool_get_array(incrementalRemapPool, 'workCategoryCell', workCategoryCell)
+    call mpas_pool_get_array(incrementalRemapPool, 'maskCategoryCell', maskCategoryCell)
 
     ! Optional initial diagnostics: Write a list of cells with ice
     ! If verboseGlobal = true, then this info is also written at the end of each time step.
@@ -3019,7 +3023,7 @@ contains
        call zap_small_mass(&
             tracersHead,   &
             nCellsSolve,   &
-            block)
+            maskCategoryCell)
 
     endif
 
@@ -8261,7 +8265,7 @@ contains
   subroutine zap_small_mass(&
        tracersHead,   &
        nCellsSolve,   &
-       block)
+       maskCategoryCell)
 
     type(tracer_type), pointer :: &
          tracersHead     !< Input/output: pointer to first element of linked list of tracers
@@ -8270,21 +8274,17 @@ contains
     integer, intent(in) ::  &
          nCellsSolve     !< Input: number of locally owned cells
 
-    type(block_type), intent(in) :: &
-         block           !< Input: local block (for allocating a scratch field)
+    integer, dimension(:,:), intent(out) ::  &
+         maskCategoryCell   !< Output: work array with dimensions (nCategories,nCells)
+                            !  Here, it is a mask indicating which cells and categories are zeroed out
 
     ! local variables
 
     type(tracer_type), pointer :: thisTracer
 
-    type (mpas_pool_type), pointer :: scratchPool
+    integer :: nCategories
 
-    type (field2dInteger), pointer :: iceCellCategoryMaskField
-    integer, dimension(:,:), pointer :: iceCellCategoryMask
-
-    integer :: nCategories, nLayers
-
-    integer :: iCell, iCat, iLayer
+    integer :: iCell, iCat
 
     ! Make the threshold very small (<< eps11) so as not to sweep potential problems under the rug
 
@@ -8292,14 +8292,7 @@ contains
 !!         smallMassThreshold = eps11
          smallMassThreshold = 1.0e-22_RKIND
 
-    ! allocate and initialize a scratch field with dimensions (nCategories, nCells)
-       
-    call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-    
-    call mpas_pool_get_field(scratchPool, 'iceCellCategoryMask', iceCellCategoryMaskField)
-    call mpas_allocate_scratch_field(iceCellCategoryMaskField, .true.)
-    iceCellCategoryMask => iceCellCategoryMaskField % array
-    iceCellCategoryMask(:,:) = 0
+    maskCategoryCell(:,:) = 0
 
     ! Starting with the mass-like field, loop over each cell and category.
     ! Zap those whose mass is below a small threshold.
@@ -8323,7 +8316,7 @@ contains
                 thisTracer % arrayMask2D(iCat,iCell) = 0
 
                 ! for future reference, set a mask = 1 for this category and cell
-                iceCellCategoryMask(iCat,iCell) = 1
+                maskCategoryCell(iCat,iCell) = 1
 
              endif
 
@@ -8351,7 +8344,7 @@ contains
           do iCell = 1, nCellsSolve
              do iCat = 1, nCategories
                 
-                if (iceCellCategoryMask(iCat,iCell) == 1) then
+                if (maskCategoryCell(iCat,iCell) == 1) then
 
                    ! zero out the tracer and mask
                    thisTracer % array2D(iCat,iCell) = 0.0_RKIND
@@ -8371,7 +8364,7 @@ contains
           do iCell = 1, nCellsSolve
              do iCat = 1, nCategories
 
-                if (iceCellCategoryMask(iCat,iCell) == 1) then
+                if (maskCategoryCell(iCat,iCell) == 1) then
 
                    ! zero the tracer value and mask in each layer
                    thisTracer % array3D(:,iCat,iCell) = 0.0_RKIND
@@ -8389,9 +8382,6 @@ contains
        thisTracer => thisTracer % next
 
     enddo  ! associated(thisTracer)
-
-    ! clean up
-    call mpas_deallocate_scratch_field(iceCellCategoryMaskField, .true.)
 
   end subroutine zap_small_mass
 


### PR DESCRIPTION
This pull request would fix a memory leak in the IR transport scheme. The problem was associated with a pointer "dummyTracer", for which arrays were allocated during each time step. These arrays were not being deallocated before deallocating the pointer.

There are also some changes in loop order in subroutine zap_small_areas, to put loops over cells inside the loop over the tracer linked list.  These changes should improved performance.  They may or may not be related to recent seg faults in this subroutine when running the full ACME model.

[BFB]
