### PR TITLE
LIGHT planar periodic bug fixes

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -1188,8 +1188,14 @@ contains
        ! compute the cross product and dot with normal, if negative we are outside cell
        ! we only need to fail on a single test!
        call mpas_cross_product_in_r3(vec1,vec2,crossProd)
-       if(sum(crossProd*pVertices(:,v0)) < 0) then
-         point_in_cell = .false.
+       if (on_a_sphere) then
+         if(sum(crossProd*pVertices(:,v0)) < 0) then
+           point_in_cell = .false.
+         end if
+       else
+         if(crossProd(3) < 0) then
+           point_in_cell = .false.
+         end if
        end if
 
      end do


### PR DESCRIPTION
This is a collection of two bug fixes related to enabling LIGHT to work with planar periodic meshes:
- areaB cached for Wachspress calculation was not computed correctly
- test to ensure particle is in a cell was not computed correctly for plane (applies only to debug mode)
