### PR TITLE
Add the ability to use case numbers instead of configuration options

### DIFF
--- a/test_cases/ocean/clean_testcase.py
+++ b/test_cases/ocean/clean_testcase.py
@@ -2,16 +2,32 @@
 
 import os, shutil, fnmatch
 import argparse
+import subprocess
 import xml.etree.ElementTree as ET
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
 
-parser.add_argument("-o", "--core", dest="core", help="Core that conatins configurations to clean", metavar="CORE", required=True)
-parser.add_argument("-c", "--configuration", dest="configuration", help="Configuration to clean", metavar="CONFIG", required=True)
-parser.add_argument("-r", "--resolution", dest="resolution", help="Resolution of configuration to clean", metavar="RES", required=True)
+parser.add_argument("-o", "--core", dest="core", help="Core that conatins configurations to clean", metavar="CORE")
+parser.add_argument("-c", "--configuration", dest="configuration", help="Configuration to clean", metavar="CONFIG")
+parser.add_argument("-r", "--resolution", dest="resolution", help="Resolution of configuration to clean", metavar="RES")
+parser.add_argument("-n", "--case_number", dest="case_num", help="Case number to clean, as listed from list_testcases.py.", metavar="NUM")
 
 args = parser.parse_args()
 
+if not args.case_num and ( not args.core and not args.configuration and not args.resolution):
+	print 'Must be run with either the --case_number argument, or the core, configuration, and resolution arguments.'
+	parser.error(' Invalid configuration. Exiting...')
+
+if args.case_num and args.core and args.configuration and args.resoltuion:
+	print 'Can only be configured with either --case_number (-n) or --core (-o), --configuration (-c), and --resolution (-r).'
+	parser.error(' Invalid configuration. Too many options used. Exiting...')
+
+if args.case_num:
+	core_configuration = subprocess.check_output(['./list_testcases.py', '-n', '%d'%(int(args.case_num))])
+	config_options = core_configuration.strip('\n').split(' ')
+	args.core = config_options[1]
+	args.configuration = config_options[3]
+	args.resolution = config_options[5]
 
 base_path = '%s/%s/%s'%(args.core, args.configuration, args.resolution)
 for file in os.listdir('%s'%(base_path)):

--- a/test_cases/ocean/list_testcases.py
+++ b/test_cases/ocean/list_testcases.py
@@ -4,11 +4,25 @@ import os, fnmatch
 import argparse
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-parser.add_argument("-l", "--list", dest="list", help="If set, script will list available configurations which can be passed into setup_testcases.py.", action="store_true")
+parser.add_argument("-n", "--number", dest="number", help="If set, script will print the flags to use a the N'th configuraiton.")
 
 args = parser.parse_args()
 
-print "Available test cases are:"
+quiet = False
+
+try:
+	print_num = 0
+	if args.number:
+		quiet = True
+		print_num = int(args.number)
+except:
+	args.number = 0
+	print_num = 0
+
+if not quiet:
+	print "Available test cases are:"
+
+case_num = 1
 for core_dir in os.listdir('.'):
 	if os.path.isdir(core_dir) and not core_dir == '.git':
 		for config_dir in os.listdir(core_dir):
@@ -22,4 +36,8 @@ for core_dir in os.listdir('.'):
 							if fnmatch.fnmatch(case_file, '*.xml'):
 								print_case = True
 						if print_case:
-							print "  -o %s -c %s -r %s"%(core_dir, config_dir, res_dir)
+							if not quiet:
+								print "  %d: -o %s -c %s -r %s"%(case_num, core_dir, config_dir, res_dir)
+							if quiet and case_num == print_num:
+								print "-o %s -c %s -r %s"%(core_dir, config_dir, res_dir)
+							case_num = case_num + 1

--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -505,14 +505,30 @@ def generate_run_scripts(config_file, init_path):#{{{
 #}}}
 
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-parser.add_argument("-o", "--core", dest="core", help="Core that contains configurations", metavar="CORE", required=True)
-parser.add_argument("-c", "--configuration", dest="configuration", help="Configuration to setup", metavar="CONFIG", required=True)
-parser.add_argument("-r", "--resolution", dest="resolution", help="Resolution of configuration to setup", metavar="RES", required=True)
+parser.add_argument("-o", "--core", dest="core", help="Core that contains configurations", metavar="CORE")
+parser.add_argument("-c", "--configuration", dest="configuration", help="Configuration to setup", metavar="CONFIG")
+parser.add_argument("-r", "--resolution", dest="resolution", help="Resolution of configuration to setup", metavar="RES")
+parser.add_argument("-n", "--case_number", dest="case_num", help="Case number to setup, as listed from list_testcases.py.", metavar="NUM")
 parser.add_argument("-f", "--config_file", dest="config_file", help="Configuration file for test case setup", metavar="FILE", required=True)
 parser.add_argument("--no_download", dest="no_download", help="If set, script will not auto-download base_mesh files", action="store_true")
 parser.add_argument("--copy_instead_of_symlink", dest="nolink_copy", help="If set, script will replace symlinks with copies of files.", action="store_true")
 
 args = parser.parse_args()
+
+if not args.case_num and ( not args.core and not args.configuration and not args.resolution):
+	print 'Must be run with either the --case_number argument, or the core, configuration, and resolution arguments.'
+	parser.error(' Invalid configuration. Exiting...')
+
+if args.case_num and args.core and args.configuration and args.resoltuion:
+	print 'Can only be configured with either --case_number (-n) or --core (-o), --configuration (-c), and --resolution (-r).'
+	parser.error(' Invalid configuration. Too many options used. Exiting...')
+
+if args.case_num:
+	core_configuration = subprocess.check_output(['./list_testcases.py', '-n', '%d'%(int(args.case_num))])
+	config_options = core_configuration.strip('\n').split(' ')
+	args.core = config_options[1]
+	args.configuration = config_options[3]
+	args.resolution = config_options[5]
 
 config = ConfigParser.SafeConfigParser()
 config.read(args.config_file)


### PR DESCRIPTION
This merge updates the front end testcases scripts to use case numbers
as an alternative to using configuration options.

When using list_testcases, a case number is printed in the left most
column now. All of the scripts can also now use the `-n N` option, where
N is the case number. This will automatically fill in the configuration
options for the specific case number. This way, instead of specifying
`-o ${CORE} -c ${CONFIG} -r ${RES}` one can simply specify
`-n ${CASE_NUM}`.
