### PR TITLE
Turn defaults in registry to off, and cleanup registry

### DIFF
--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -23,23 +23,10 @@ core_input_gen:
 	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.forward mode=forward )
 	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.analysis mode=analysis )
 	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init mode=init )
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.baroclinic_channel mode=init configuration=baroclinic_channel)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.lock_exchange mode=init configuration=lock_exchange)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.internal_waves mode=init configuration=internal_waves)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.overflow mode=init configuration=overflow)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.cvmix_convection_unit_test mode=init configuration=cvmix_convection_unit_test)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.cvmix_shear_unit_test mode=init configuration=cvmix_shear_unit_test)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.soma mode=init configuration=soma)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.iso mode=init configuration=iso)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.ziso mode=init configuration=ziso)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.global_ocean mode=init configuration=global_ocean)
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.periodic_planar mode=init configuration=periodic_planar)
 	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean stream_list.ocean. mutable )
 	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.forward stream_list.ocean.forward. mutable mode=forward )
 	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.analysis stream_list.ocean.analysis. mutable mode=analysis )
 	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.init stream_list.ocean.init. mutable mode=init )
-	#(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init.TEMPLATE mode=init configuration=TEMPLATE)
-	#(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.init.TEMPLATE stream_list.ocean.init.TEMPLATE. mutable mode=init configuration=TEMPLATE )
 
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
@@ -78,6 +65,9 @@ analysis_members: libcvmix shared
 clean:
 	if [ -d cvmix ]; then \
 		(cd cvmix; make clean) \
+	fi
+	if [ -d inc ]; then \
+		($(RM) -r inc) \
 	fi
 	(cd mode_forward; $(MAKE) clean)
 	(cd mode_analysis; $(MAKE) clean)

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -141,34 +141,22 @@
 		<nml_option name="config_init_configuration" type="character" default_value="none" units="unitless"
 					description="Name of configuration to create."
 					possible_values="Any configuration name"
-					baroclinic_channel_value="baroclinic_channel"
-					cvmix_convection_unit_test_value="cvmix_convection_unit_test"
-					cvmix_shear_unit_test_value="cvmix_shear_unit_test"
-					cvmix_WSwSBF_value="cvmix_WSwSBF"
-					global_ocean_value="global_ocean"
-					internal_waves_value="internal_waves"
-					lock_exchange_value="lock_exchange"
-					overflow_value="overflow"
-					soma_value="soma"
-					iso_value="iso"
-					ziso_value="ziso"
-					periodic_planar_value="periodic_planar"
 		/>
-		<nml_option name="config_expand_sphere" type="logical" default_value="false" units="unitless"
+		<nml_option name="config_expand_sphere" type="logical" default_value=".false." units="unitless"
 					description="Logical flag that controls if a spherical mesh is expanded to an earth sized sphere or not."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_realistic_coriolis_parameter" type="logical" default_value="false" units="unitless"
+		<nml_option name="config_realistic_coriolis_parameter" type="logical" default_value=".false." units="unitless"
 					description="Logical flag that controls if a spherical mesh will get realistic coriolis parameters or not."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_write_cull_cell_mask" type="logical" default_value="true" units="unitless"
+		<nml_option name="config_write_cull_cell_mask" type="logical" default_value=".true." units="unitless"
 					description="Logicial flag that controls if the cullCell field is written to output."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_vertical_grid" type="character" default_value="uniform" units="unitless"
 					description="Name of vertical grid to use in configuration generation"
-					possible_values="'uniform', ..."
+					possible_values="'uniform', '60layerPHC', '42layerWOCE', '100layerACMEv1', '1dCVTgenerator', ..."
 		/>
 	</nml_record>
 	<nml_record name="CVTgenerator" mode="init">
@@ -280,7 +268,7 @@
 		/>
 	</nml_record>
 	<nml_record name="hmix_del2" mode="forward">
-		<nml_option name="config_use_mom_del2" type="logical" default_value=".true." units="unitless"
+		<nml_option name="config_use_mom_del2" type="logical" default_value=".false." units="unitless"
 					description="If true, Laplacian horizontal mixing is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
@@ -310,10 +298,10 @@
 					description="Coefficient for horizontal biharmonic operator on momentum."
 					possible_values="any positive real"
 		/>
-                <nml_option name="config_mom_del4_div_factor" type="real" default_value="1.0" units="non-dimensional"
-                                        description="The divergence portion of the del4 operator is scaled by this factor."
-                                        possible_values="any positive real"
-                />
+		<nml_option name="config_mom_del4_div_factor" type="real" default_value="1.0" units="non-dimensional"
+					description="The divergence portion of the del4 operator is scaled by this factor."
+					possible_values="any positive real"
+		/>
 		<nml_option name="config_tracer_del4" type="real" default_value="0.0" units="m^4 s^{-1}"
 					description="Coefficient for horizontal biharmonic operator on tracers."
 					possible_values="any positive real"
@@ -400,7 +388,7 @@
 		/>
 	</nml_record>
 	<nml_record name="vmix_const" mode="forward">
-		<nml_option name="config_use_const_visc" type="logical" default_value=".true." units="unitless"
+		<nml_option name="config_use_const_visc" type="logical" default_value=".false." units="unitless"
 					description="If true, constant vertical viscosity is included in the momentum equation"
 					possible_values=".true. or .false."
 		/>
@@ -482,7 +470,7 @@
 					description="Prandtl number to be used within the CVMix parameterization suite"
 					possible_values="Any non-negative real value."
 		/>
-		<nml_option name="config_use_cvmix_background" type="logical" default_value=".true." units="NA"
+		<nml_option name="config_use_cvmix_background" type="logical" default_value=".false." units="NA"
 					description="If true, background diffusivity and viscosity is computed using CVMix"
 					possible_values="True or False"
 		/>
@@ -506,7 +494,7 @@
 					description="Convective vertical viscosity applied to horizontal velocity components"
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_cvmix_convective_basedOnBVF" type="logical" default_value=".true." units="NA"
+		<nml_option name="config_cvmix_convective_basedOnBVF" type="logical" default_value=".false." units="NA"
 					description="If true, convection is triggered based on value of config_cvmix_convective_triggerBVF"
 					possible_values="True or False"
 		/>

--- a/src/core_ocean/mode_init/Registry_baroclinic_channel.xml
+++ b/src/core_ocean/mode_init/Registry_baroclinic_channel.xml
@@ -3,7 +3,7 @@
 					description="Number of vertical levels in baroclinic channel test case. Typical value is 20."
 					possible_values="Any positive integer number greater than 0."
 		/>
-		<nml_option name="config_baroclinic_channel_use_distances" type="logical" default_value="false" units="unitless"
+		<nml_option name="config_baroclinic_channel_use_distances" type="logical" default_value=".false." units="unitless"
 					description="Logical flag that determines if locations of features are defined by distances of fractions. False means fractions."
 					possible_values=".true. or .false."
 		/>

--- a/src/core_ocean/mode_init/Registry_iso.xml
+++ b/src/core_ocean/mode_init/Registry_iso.xml
@@ -15,7 +15,7 @@
 				description="Latitude of the top of the main channel south wall wall in the ISO domain."
 				possible_values="Any real number."
 	/>
-        <nml_option name="config_iso_ridge_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_ridge_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag that controls if a ridge is used or not."
 				possible_values=".true. or .false."
 	/>
@@ -31,7 +31,7 @@
 				description="Width of the ridge at the zonal middle of the ISO domain."
 				possible_values="Any positive real number."
 	/>
-        <nml_option name="config_iso_plateau_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_plateau_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag that controls if a plateau is used or not."
 				possible_values=".true. or .false."
 	/>
@@ -55,7 +55,7 @@
 				description="Width of the sloping region of the plateau in the ISO domain."
 				possible_values="Any positive real number."
 	/>
-        <nml_option name="config_iso_shelf_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_shelf_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag that controls if a shelf is used or not."
 				possible_values=".true. or .false."
 	/>
@@ -67,7 +67,7 @@
 				description="Width of the shelf in the ISO."
 				possible_values="Any positive real number."
 	/>
-        <nml_option name="config_iso_cont_slope_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_cont_slope_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag that controls if a continental slope is used or not."
 				possible_values=".true. or .false."
 	/>
@@ -75,7 +75,7 @@
 				description="Maximum slope of the continental slope in the ISO."
 				possible_values="Any positive real number."
 	/>
-       <nml_option name="config_iso_embayment_flag" type="logical" default_value="true" units="unitless"
+       <nml_option name="config_iso_embayment_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag that controls if an embayment is used or not."
 				possible_values=".true. or .false."
 	/>
@@ -95,7 +95,7 @@
 				description="Depth of the embayment in the ISO."
 				possible_values="Any positive real number."
 	/>
-        <nml_option name="config_iso_depression_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_depression_flag" type="logical" default_value=".true." units="unitless"
 				description="Logical flag to add a depresseion between embayment and main channel."
 				possible_values=".true. or .false."
 	/>
@@ -267,7 +267,7 @@
 				description="Sponge layer restoring time scale, used to calculate interior restoring rate."
 				possible_values="Any real number."
          />
-        <nml_option name="config_iso_temperature_restore_region1_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_temperature_restore_region1_flag" type="logical" default_value=".true." units="unitless"
                                 description="Logical flag controlling use of temperature restoring in region 1."
 				possible_values=".true. or .false."
 	/>
@@ -283,7 +283,7 @@
 				description="Meridional length scale of the restoring region 1"
 				possible_values="Any real number."
 	/>
-        <nml_option name="config_iso_temperature_restore_region2_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_temperature_restore_region2_flag" type="logical" default_value=".true." units="unitless"
                                 description="Logical flag controlling use of temperature restoring in region 2."
 				possible_values=".true. or .false."
 	/>
@@ -299,7 +299,7 @@
 				description="Meridional length scale of the restoring region 2"
 				possible_values="Any real number."
 	/>
-        <nml_option name="config_iso_temperature_restore_region3_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_temperature_restore_region3_flag" type="logical" default_value=".true." units="unitless"
                                description="Logical flag controlling use of temperature restoring in region 3."
 				possible_values=".true. or .false."
 	/>
@@ -315,7 +315,7 @@
 				description="Meridional length scale of the restoring region 3"
 				possible_values="Any real number."
 	/>
-        <nml_option name="config_iso_temperature_restore_region4_flag" type="logical" default_value="true" units="unitless"
+        <nml_option name="config_iso_temperature_restore_region4_flag" type="logical" default_value=".true." units="unitless"
                                description="Logical flag controlling use of temperature restoring in region 4."
 				possible_values=".true. or .false."
 	/>

--- a/src/core_ocean/mode_init/Registry_ziso.xml
+++ b/src/core_ocean/mode_init/Registry_ziso.xml
@@ -1,4 +1,4 @@
-<nml_record name="ziso" in_defaults="true" mode="init" configuration="ziso">
+<nml_record name="ziso" mode="init" configuration="ziso">
   <nml_option name="config_ziso_vert_levels" type="integer" default_value="100" units="unitless"
     description="Number of vertical levels in ziso. Typical value is 100."
     possible_values="Any positive integer number greater than 0."


### PR DESCRIPTION
This merge disables all physics options within the ocean model by
default. This means you need to turn on the specific features you want
in a run now.

Additionally, this merge performs some cleanup. Including removing
unneeded attributes, and cleaning up white space within Registry files.
Additionally, it removes the src/core_ocean/inc directory when a `make
clean` is issued.
