### PR TITLE
Adding a summary of OpenMP threads for the ocean core

### DIFF
--- a/src/core_ocean/driver/mpas_ocn_core.F
+++ b/src/core_ocean/driver/mpas_ocn_core.F
@@ -28,6 +28,7 @@ module ocn_core
    use mpas_dmpar
    use mpas_timer
    use mpas_io_units
+   use mpas_threading
 
    use ocn_forward_mode
    use ocn_analysis_mode
@@ -60,10 +61,19 @@ module ocn_core
       integer :: ierr
 
       character (len=StrKIND), pointer :: config_ocean_run_mode
+      integer :: numThreads
 
       ierr = 0
 
       call mpas_pool_get_config(domain % configs, 'config_ocean_run_mode', config_ocean_run_mode)
+
+      numThreads = mpas_threading_get_max_threads()
+
+      write(stderrUnit, *) ''
+      write(stderrUnit, *) ' **********************************************************************************'
+      write(stderrUnit, *) ' MPI Task ', domain % dminfo % my_proc_id, ' has access to ', numThreads, ' threads'
+      write(stderrUnit, *) ' **********************************************************************************'
+      write(stderrUnit, *) ''
 
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          ierr = ocn_forward_mode_init(domain, startTimeStamp)


### PR DESCRIPTION
This merge adds writing of the number of OpenMP threads available to an
MPI task within the log.*.err file.

Note: The thread number is the number available to an MPI task, but the
MPI task may not use them. For example, if there is no parallel region,
no additionaly OpenMP threads will be used.
