### PR TITLE
Add history output and alternate base_path to testing scripts

### DIFF
--- a/test_cases/ocean/.gitignore
+++ b/test_cases/ocean/.gitignore
@@ -1,0 +1,1 @@
+command_history


### PR DESCRIPTION
This merge updates the testcases scripts to have two new features:
1. The ability (with setup_testcases.py and clean_testcases.py) to specify the base path (through `--base_path`) which controls where the test case directories are created.
2. Writing of a command_history file which summarizes what steps have been used in a particular base path. To allow easier reproduction of specific test cases and behavior.
