### PR TITLE
LIGHT MPI array temporary error bug fix

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -309,7 +309,7 @@ contains
 
       call mpas_pool_get_config(ocnConfigs, 'config_AM_lagrPartTrack_filter_number', filterNum)
 
-      allocate(ioProcRecvList(size(g_ioProcNeighs), domain % dminfo % nprocs))
+      allocate(ioProcRecvList(domain % dminfo % nprocs, size(g_ioProcNeighs)))
       allocate(ioProcSendList(domain % dminfo % nprocs))
       ioProcRecvList = .False.
       ioProcSendList = .False.

--- a/src/core_ocean/analysis_members/mpas_ocn_particle_list.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_particle_list.F
@@ -617,12 +617,12 @@ end subroutine mpas_particle_list_destroy_particle_list !}}}
       ! for each ioProc, send logical array information
       do i = 1, nioProcNeighs
 #ifdef _MPI
-        call MPI_ISend(ioProcRecvList(i,:), nProcs, MPI_LOGICAL, ioProcNeighs(i), domain % dminfo % my_proc_id, &
+        call MPI_ISend(ioProcRecvList(:,i), nProcs, MPI_LOGICAL, ioProcNeighs(i), domain % dminfo % my_proc_id, &
           domain % dminfo % comm, sendRequestID(i), mpi_ierr)
 #endif
 #ifdef MPAS_DEBUG
         write(stderrUnit,*) 'ioProcNeigh= ', ioProcNeighs(i)
-        write(stderrUnit,*) 'send data = ', ioProcRecvList(i,:)
+        write(stderrUnit,*) 'send data = ', ioProcRecvList(:,i)
 #endif
       end do
 
@@ -3953,7 +3953,7 @@ end subroutine allocate_list_particlelists !}}}
      ! which is dependent upon current, on-processor particles
      if (ioProc /= domain % dminfo % my_proc_id) then
        arrayIndex = find_index(gioProcNeighs, ioProc)
-       ioProcRecvList(arrayIndex, currentProc+1) = .True.
+       ioProcRecvList(currentProc+1, arrayIndex) = .True.
      else
        ! consider the case where a particle on A has an ioProc of A and is sent to B (need to have B in A's halo).
        ioProcSendList(currentProc+1) = .True.


### PR DESCRIPTION
This fixes an issue where there was corruption of array temporaries
during MPI_ISend statements due to Fortran vs C-array ordering.
Essentially, array temporaries were being formed for the send data.
This did not present an issue on small processor counts and certain
architectures but caused problems that appeared during usage on
Edison with the 30-10km Idealized Southern Ocean.
