### PR TITLE
Fix bed topo field in Interface to actually be bed topo

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -307,7 +307,7 @@ void velocity_solver_init_fo(double const *levelsRatio_F) {
   initialize_velocity = false;
 }
 
-void velocity_solver_solve_fo(double const* lowerSurface_F,
+void velocity_solver_solve_fo(double const* bedTopography_F, double const* lowerSurface_F,
     double const* thickness_F, double const* beta_F, double const* smb_F, double const* temperature_F,
     double* const dirichletVelocityXValue, double* const dirichletVelocitYValue,
     double* u_normal_F, double* xVelocityOnCell, double* yVelocityOnCell, double const* deltat) {
@@ -352,7 +352,7 @@ void velocity_solver_solve_fo(double const* lowerSurface_F,
 
 
 
-    import2DFields(lowerSurface_F, thickness_F, beta_F, smb_F,  minThickness);
+    import2DFields(bedTopography_F, lowerSurface_F, thickness_F, beta_F, smb_F,  minThickness);
 
     std::vector<double> regulThk(thicknessData);
     for (int index = 0; index < nVertices; index++)
@@ -1308,7 +1308,7 @@ void extendMaskByOneLayer(int const* verticesMask_F,
   }
 }
 
-void import2DFields(double const * lowerSurface_F, double const * thickness_F,
+void import2DFields(double const* bedTopography_F, double const * lowerSurface_F, double const * thickness_F,
     double const * beta_F, double const * smb_F, double eps) {
   elevationData.assign(nVertices, 1e10);
   thicknessData.assign(nVertices, 1e10);
@@ -1324,8 +1324,8 @@ void import2DFields(double const * lowerSurface_F, double const * thickness_F,
   for (int index = 0; index < nVertices; index++) {
     int iCell = vertexToFCell[index];
     thicknessData[index] = std::max(thickness_F[iCell] / unit_length, eps);
-    bedTopographyData[index] = lowerSurface_F[iCell] / unit_length;
-    elevationData[index] = bedTopographyData[index] + thicknessData[index];
+    bedTopographyData[index] = bedTopography_F[iCell] / unit_length;
+    elevationData[index] = lowerSurface_F[iCell] / unit_length + thicknessData[index];
     if (beta_F != 0)
       betaData[index] = beta_F[iCell] / unit_length;
     if (smb_F != 0)
@@ -1374,8 +1374,8 @@ void import2DFields(double const * lowerSurface_F, double const * thickness_F,
     int iv = it->first;
     int ic = it->second;
     thicknessData[iv] = std::max(thickness_F[ic] / unit_length, eps);
-    bedTopographyData[iv] = lowerSurface_F[ic] / unit_length;
-    elevationData[iv] = thicknessData[iv] + bedTopographyData[iv];
+    bedTopographyData[iv] = bedTopography_F[ic] / unit_length;
+    elevationData[iv] = thicknessData[iv] + lowerSurface_F[ic] / unit_length;
     if (beta_F != 0)
       betaData[iv] = beta_F[ic] / unit_length;
     if (smb_F != 0)

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -97,7 +97,7 @@ void velocity_solver_solve_l1l2(double const* lowerSurface_F,
     double* u_normal_F = 0,
     double* xVelocityOnCell = 0, double* yVelocityOnCell = 0);
 
-void velocity_solver_solve_fo(double const* lowerSurface_F,
+void velocity_solver_solve_fo(double const* bedTopography_F, double const* lowerSurface_F,
     double const* thickness_F, double const* beta_F, double const* smb_F, double const* temperature_F,
     double* const dirichletVelocityXValue = 0, double* const dirichletVelocitYValue = 0,
     double* u_normal_F = 0,
@@ -232,7 +232,7 @@ double signedTriangleArea(const double* x, const double* y, const double* z);
 
 void createReducedMPI(int nLocalEntities, MPI_Comm& reduced_comm_id);
 
-void import2DFields(double const* lowerSurface_F, double const* thickness_F,
+void import2DFields(double const* bedTopography_F, double const* lowerSurface_F, double const* thickness_F,
     double const* beta_F = 0, double const* smb_F = 0, double eps = 0);
 
 std::vector<int> extendMaskByOneLayer(int const* verticesMask_F);

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -405,7 +405,7 @@ contains
       !-----------------------------------------------------------------
       integer, pointer :: index_temperature
       real (kind=RKIND), dimension(:), pointer :: &
-         thickness, lowerSurface, upperSurface, layerThicknessFractions, betaSolve, sfcMassBal
+         thickness, bedTopography, lowerSurface, upperSurface, layerThicknessFractions, betaSolve, sfcMassBal
       real (kind=RKIND), dimension(:,:), pointer :: &
          normalVelocity, uReconstructX, uReconstructY, uReconstructZ
       real (kind=RKIND), dimension(:,:,:), pointer :: &
@@ -436,6 +436,7 @@ contains
 
       ! Geometry variables
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel = 1)
@@ -514,7 +515,8 @@ contains
       case ('FO') ! ===============================================
 #ifdef USE_EXTERNAL_FIRSTORDER
           call mpas_timer_start("velocity_solver_solve_FO")
-          call velocity_solver_solve_FO(lowerSurface, thickness, betaSolve, sfcMassBal, tracers(index_temperature,:,:), &
+          call velocity_solver_solve_FO(bedTopography, lowerSurface, thickness, &
+                betaSolve, sfcMassBal, tracers(index_temperature,:,:), &
                 uReconstructX, uReconstructY,  &  ! Dirichlet boundary values to apply where dirichletVelocityMask=1
                 normalVelocity, uReconstructX, uReconstructY, deltat)  ! return values
 !	  call velocity_solver_estimate_SS_SMB(normalVelocity, mesh % sfcMassBal % array)  ! this was used only for some ice2sea experiments, and is not a general routine to use


### PR DESCRIPTION
Populate the bedTopographyData vector to be passed to Albany with the
bedTopography field from MPAS.  Before, the bedTopographyData vector
was erroneously populated with the lowerSurface field.
