### PR TITLE
Remove `make clean` of cvmix and BGC.

### DIFF
--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -47,11 +47,11 @@ post_build:
 
 cvmix_source: get_cvmix.sh
 	(chmod a+x get_cvmix.sh; ./get_cvmix.sh)
-	(cd cvmix; make clean)
+	(cd cvmix)
 
 BGC_source: get_BGC.sh
 	(chmod a+x get_BGC.sh; ./get_BGC.sh)
-	(cd BGC; make clean)
+	(cd BGC)
 
 libcvmix: cvmix_source
 	if [ -d cvmix ]; then \


### PR DESCRIPTION
This merge removes a forced `make clean` for cvmix and BGC, which
forced a rebuild of both libraries each time the model was built.
