### PR TITLE
Adding the BGC link to the .gitignore file

### DIFF
--- a/src/core_ocean/.gitignore
+++ b/src/core_ocean/.gitignore
@@ -1,6 +1,7 @@
 # Ignore all cvmix code.
 cvmix
 .cvmix_all
+BGC
 .BGC_all
 .*.zip
 


### PR DESCRIPTION
This merge adds the BGC linked directory to the .gitignore file so it
doesn't show up in `git status` as an untracked file anymore.
