### PR TITLE
Clean up some XML syntax errors

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -315,16 +315,16 @@
 		<var name="numTimesReset" type ="integer" dimensions="nParticles Time" units="unitless"
 			 description="flag to specify how many times the particle was reset" default_value="0"
 		/>
-		<var name="vertexReconstMethod" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="vertexReconstMethod" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="type of vertex reconstruction method, with possible_values='RBFlinear(1)' as ENUMs"
 		/>
-		<var name="timeIntegration" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="timeIntegration" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="type of temporal interpolation with possible_values='EE(1), RK2(2), RK4(4)' as ENUMs"
 		/>
-		<var name="horizontalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="horizontalTreatment" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="select type of horizontal treatment to be used, with possible_values='wachspress' as ENUMs"
 		/>
-		<var name="verticalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="verticalTreatment" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="select type of vertical treatment to be used, with possible_values='indexLevel','fixedZLevel','passiveFloat','buoyancySurface','argoFloat' (ENUM)"
 		/>
 		<var name="indexLevel" type="integer" dimensions="nParticles Time" units="unitless"

--- a/src/core_ocean/mode_init/Registry_periodic_planar.xml
+++ b/src/core_ocean/mode_init/Registry_periodic_planar.xml
@@ -1,4 +1,4 @@
-	<nml_record name="periodic_planar" mode="init" configuration=="periodic_planar">
+	<nml_record name="periodic_planar" mode="init" configuration="periodic_planar">
 		<nml_option name="config_periodic_planar_vert_levels" type="integer" default_value="100" units="unitless"
 					description="Number of vertical levels in periodic_planar. Typical value is 1."
 					possible_values="Any positive integer number greater than 0."

--- a/src/core_ocean/mode_init/Registry_ziso.xml
+++ b/src/core_ocean/mode_init/Registry_ziso.xml
@@ -17,7 +17,7 @@
     />
   <nml_option name="config_ziso_wind_stress_shelf_front_max" type="real" default_value="-0.05" units="N m^{-2}"
     description="Maximum zonal windstress value in the shelf front region, following Stewart et al. 2013"
-    possible_values="Any real number < 0"
+    possible_values="Any real number less than 0"
     />
   <nml_option name="config_ziso_use_slopping_bathymetry" type="logical" default_value="false" units="unitless"
     description="Logical flag that determines if sloping bathymetery is used."


### PR DESCRIPTION
This merge removes some XML syntax errors that prevent certain parses
(like python's ElementTree) from parsing the resulting
Registry_processed.xml file.
