### PR TITLE
Adding seaSurfacePressure to the restart stream

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -106,6 +106,10 @@
 					possible_values="Any positive integer value greater than 0."
 					mode="forward;analysis;init"
 		/>
+		<nml_option name="config_restart_forcing_fields" type="logical" default_value=".true." units="unitless"
+					description="Controls whether forcing related fields are part of the restart stream or not."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="decomposition" mode="forward;analysis;init">
 		<nml_option name="config_num_halos" type="integer" default_value="3" units="unitless"
@@ -981,6 +985,7 @@
 		<package name="analysisMode" description="This package controls variables that are intended to be used within the analysis run mode of the ocean model."/>
 		<package name="initMode" description="This package controls variables that are intended to be used within the init run mode of the ocean model."/>
 		<package name="cullCells" description="This package controls variables that provide information on what cells should be culled."/>
+		<package name="restartForcingFields" destiption="This package controls whether forcing related fields are included in the restart stream or not."/>
 	</packages>
 
 	<streams>
@@ -1215,6 +1220,7 @@
 			<var name="vertCoordMovementWeights"/>
 			<var name="xtime"/>
 			<var name="boundaryLayerDepth"/>
+			<var name="seaSurfacePressure" packages="restartForcingFields"/>
 			<var_array name="tracersSurfaceValue"/>
 			<var_array name="surfaceVelocity"/>
 			<var_array name="SSHGradient"/>

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -116,6 +116,7 @@ module ocn_core_interface
       logical, pointer :: thicknessBulkPKGActive
       logical, pointer :: frazilIceActive
       logical, pointer :: inSituEOSActive
+      logical, pointer :: restartForcingFieldsActive
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -135,6 +136,8 @@ module ocn_core_interface
       logical, pointer :: config_use_tracerGroup_exponential_decay
       logical, pointer :: config_use_tracerGroup_idealAge_forcing
       logical, pointer :: config_use_tracerGroup_ttd_forcing
+
+      logical, pointer :: config_restart_forcing_fields
 
       logical, pointer :: config_use_freq_filtered_thickness
       logical, pointer :: config_use_frazil_ice_formation
@@ -241,6 +244,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_pressure_gradient_type', config_pressure_gradient_type)
       if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
          inSituEOSActive = .true.
+      end if
+
+      !
+      ! test for restart of forcing fields
+      !
+      call mpas_pool_get_package(packagePool, 'restartForcingFieldsActive', restartForcingFieldsActive)
+      call mpas_pool_get_config(configPool, 'config_restart_forcing_fields', config_restart_forcing_fields)
+      if ( config_restart_forcing_fields ) then
+         restartForcingFieldsActive = .true.
       end if
 
       !


### PR DESCRIPTION
This merge fixes an issue when trying to restart the ocean model in a
coupled mode. Previously seaSurfacePressure was not part of the restart
stream, but on restart the coupler may not provide a seaSurfacePressure,
in which case the model is unable to restart exactly.

Additionally, to allow whether seaSurfacePressure is read from the
restart stream or not, a namelist option is added named
'config_restart_forcing_fields'. When this is set to `.false.`
seaSurfacePressure will not be read from a restart stream even if it
exists in the file.
