### PR TITLE
Add an isActive check when duplicating array fields

### DIFF
--- a/src/framework/duplicate_field_array.inc
+++ b/src/framework/duplicate_field_array.inc
@@ -51,7 +51,11 @@
                dst_cursor % sendList => src_cursor % sendList
                dst_cursor % recvList => src_cursor % recvList
                dst_cursor % copyList => src_cursor % copyList
-               call mpas_allocate_mold(dst_cursor % array, src_cursor % array)   ! Until we get F2008 support for ALLOCATE(A,MOLD=B)
+               if ( dst_cursor % isActive ) then
+                  call mpas_allocate_mold(dst_cursor % array, src_cursor % array)   ! Until we get F2008 support for ALLOCATE(A,MOLD=B)
+               else
+                  nullify(dst_cursor % array)
+               end if
             end if
             if ( dst_cursor % isActive .and. src_cursor % isActive ) then
                dst_cursor % array = src_cursor % array


### PR DESCRIPTION
This merge fixes an issue that caused segfaults when duplicating array
fields on fields that were not active. Previously, if a field was
duplicated (for example when cloning a pool) that was decativated by a
package, the allocation of the destiation array would cause a segfault.

This merge adds a check to ensure the destination array is active
before allocating the array (since the destination array is only active
if the source array is active).

Additionally, this merge properly nullifies the array pointer of
destination fields if it is not allocated.
