### PR TITLE
Output of cell-centered time filtered velocities for time filter AM

### DIFF
--- a/src/core_ocean/analysis_members/Registry_time_filters.xml
+++ b/src/core_ocean/analysis_members/Registry_time_filters.xml
@@ -31,6 +31,10 @@
 					description="Cutoff time scale $\tau$ for high and low pass filtering (default is 90 days)."
 					possible_values="Any time stamp in 'DD_hh:mm:ss' format. Items can be removed from the left if they are unused."
 		/>
+		<nml_option name="config_AM_timeFilters_compute_cell_centered_values" type="logical" default_value=".true." units="unitless"
+					description="Logical flag determining if cell centered values should be computed."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<packages>
 		<package name="timeFiltersAMPKG" description="This package includes variables required for the timeFilters analysis member."/>
@@ -45,6 +49,24 @@
 		<var name="normalVelocityFilterTest" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
 			 description="normalVelocityTest (for testing purposes)."
 		/>
+		<var name="velocityZonalLowPass" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Low-pass time filtered component of horizontal velocity in the eastward direction"
+		/>
+		<var name="velocityMeridionalLowPass" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Low-pass time filtered component of horizontal velocity in the northward direction"
+		/>
+		<var name="velocityXLowPass" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Low-pass time filtered component of horizontal velocity in the x-direction (cartesian)"
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="velocityYLowPass" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Low-pass time filtered component of horizontal velocity in the x-direction (cartesian)"
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="velocityZLowPass" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Low-pass time filtered component of horizontal velocity in the x-direction (cartesian)"
+			 packages="forwardMode;analysisMode"
+		/>
 	</var_struct>
 	<streams>
 		<stream name="timeFiltersOutput" type="output"
@@ -57,9 +79,8 @@
 				clobber_mode="truncate"
 				runtime_format="single_file">
 			<var name="xtime"/>
-			<var name="normalVelocityLowPass"/>
-			<var name="normalVelocityHighPass"/>
-			<var name="normalVelocityFilterTest"/>
+			<var name="velocityZonalLowPass"/>
+			<var name="velocityMeridionalLowPass"/>
 		</stream>
 		<stream name="timeFiltersRestart" type="input;output"
 				mode="forward;analysis"

--- a/src/core_ocean/analysis_members/mpas_ocn_time_filters.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_time_filters.F
@@ -26,6 +26,7 @@ module ocn_time_filters
    use mpas_dmpar
    use mpas_timekeeping
    use mpas_stream_manager
+   use mpas_vector_reconstruction
 
    use ocn_constants
    use ocn_diagnostics_routines
@@ -246,12 +247,16 @@ contains
       type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: timeFiltersAM
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalVelocityLowPass, normalVelocityHighPass, normalVelocityTest
+      type (field2DReal), pointer :: normalVelocityLowPassField
+      real (kind=RKIND), dimension(:,:), pointer :: velocityZonalLowPass, velocityMeridionalLowPass, &
+                                                    velocityXLowPass, velocityYLowPass, velocityZLowPass
       integer, pointer :: nVertLevels, nEdgesSolve
       integer :: k, iEdge
       integer, dimension(:), pointer :: maxLevelEdgeBot
 
       type (MPAS_timeInterval_type) :: timeStepESMF
       character(len=StrKIND), pointer :: config_dt
+      logical, pointer :: computeCC
       real (kind=RKIND) :: dt, tau
 #ifdef TIME_FILTERS_DEBUG
       integer :: iBlock
@@ -320,6 +325,33 @@ contains
 
          block => block % next
       end do
+
+      ! do IO communications if this is an output time step
+      call mpas_pool_get_config(domain % configs, 'config_AM_timeFilters_compute_cell_centered_values', computeCC)
+      if (mpas_stream_mgr_ringing_alarms(domain % streamManager, streamID='timeFiltersOutput', direction=MPAS_STREAM_OUTPUT, ierr=err) &
+        .and. computeCC) then
+        block => domain % blocklist
+        do while (associated(block))
+           call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+           call mpas_pool_get_subpool(block % structs, 'timeFiltersAM', timeFiltersAMPool)
+           ! make sure all processors have correct normalVelocityLowPass data
+           call mpas_pool_get_field(timeFiltersAMPool, 'normalVelocityLowPass', normalVelocityLowPassField)
+           call mpas_dmpar_exch_halo_field(normalVelocityLowPassField)
+           ! get variables for computations
+           call mpas_pool_get_array(timeFiltersAMPool, 'normalVelocityLowPass', normalVelocityLowPass)
+           call mpas_pool_get_array(timeFiltersAMPool, 'velocityZonalLowPass', velocityZonalLowPass)
+           call mpas_pool_get_array(timeFiltersAMPool, 'velocityMeridionalLowPass', velocityMeridionalLowPass)
+           call mpas_pool_get_array(timeFiltersAMPool, 'velocityXLowPass', velocityXLowPass)
+           call mpas_pool_get_array(timeFiltersAMPool, 'velocityYLowPass', velocityYLowPass)
+           call mpas_pool_get_array(timeFiltersAMPool, 'velocityZLowPass', velocityZLowPass)
+          ! must perform reconstruction for cell centered values
+           call mpas_reconstruct(meshPool, normalVelocityLowPass,  &
+                            velocityXLowPass, velocityYLowPass, velocityZLowPass,   &
+                            velocityZonalLowPass, velocityMeridionalLowPass, &
+                            includeHalos = .false.)
+          block => block % next
+        end do
+      end if
 
 #ifdef TIME_FILTERS_DEBUG
         write(stderrUnit,*) 'finished computing time filters'


### PR DESCRIPTION
New option to reconstruct cell-centered low-pass filtered velocities for output.

This is a straightforward way to do a "gut check" that the time filter is sufficiently configured and
performing the correct operation on the flow.
