### PR TITLE
Mixed layer depth AM fix

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -260,8 +260,8 @@ contains
                     if(.not. found_temp_mld .and. abs(tracers(index_temperature,k+1,iCell) - temp_ref_lev) .ge. tempThresh) then
                         dVp1 = abs(tracers(index_temperature,k+1,iCell) - temp_ref_lev)
                         dV   = abs(tracers(index_temperature,k  ,iCell) - temp_ref_lev)
-                        dVm1 = abs(tracers(index_temperature,k-1,iCell) - temp_ref_lev)
-                        localVals(1:3)=zMid(k-1:k+1,iCell)
+                    
+                        localVals(2:3)=zMid(k:k+1,iCell)
                         call interp_bw_levels(localVals(2),localVals(3), dV, dVp1, tempThresh,     &
                                    interp_local, mldTemp)!,dVm1, localVals(1))
                         mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)
@@ -301,8 +301,7 @@ contains
                     if(.not. found_den_mld .and. abs(potentialDensity(k+1,iCell) - den_ref_lev) .ge. denThresh) then
                         dVp1 = abs(potentialDensity(k+1,iCell) - den_ref_lev)
                         dV   = abs(potentialDensity(k  ,iCell) - den_ref_lev)
-                        dVm1 = abs(potentialDensity(k-1,iCell) - den_ref_lev)
-                        localVals(1:3)=zMid(k-1:k+1,iCell)
+                        localVals(2:3)=zMid(k:k+1,iCell)
                         call interp_bw_levels(localVals(2),localVals(3), dV, dVp1, denThresh,     &
                                    interp_local, mldTemp)!, dVm1, localVals(1))
                         mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)


### PR DESCRIPTION
This commit fixes an issue in the mixed layer depth AM that occurs for
shallow mixed layers in the presence of thick model layers (e.g. in the
60 layer setup).  In this case, the interpolation code was referencing a
non-existent layer (layer 0).  The offending lines have been removed.  This will limit the interpolation type for mixed layers diagnosed between model levels to linear or quadratic.  The spline interpolation will not be able to match the derivative at the upper of the two model levels.
