### PR TITLE
Fix XML syntax errors in various registry files

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -315,16 +315,16 @@
 		<var name="numTimesReset" type ="integer" dimensions="nParticles Time" units="unitless"
 			 description="flag to specify how many times the particle was reset" default_value="0"
 		/>
-		<var name="vertexReconstMethod" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="vertexReconstMethod" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="type of vertex reconstruction method, with possible_values='RBFlinear(1)' as ENUMs"
 		/>
-		<var name="timeIntegration" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="timeIntegration" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="type of temporal interpolation with possible_values='EE(1), RK2(2), RK4(4)' as ENUMs"
 		/>
-		<var name="horizontalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="horizontalTreatment" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="select type of horizontal treatment to be used, with possible_values='wachspress' as ENUMs"
 		/>
-		<var name="verticalTreatment" type="integer" dimensions="nParticles Time", units="unitless"
+		<var name="verticalTreatment" type="integer" dimensions="nParticles Time" units="unitless"
 			 description="select type of vertical treatment to be used, with possible_values='indexLevel','fixedZLevel','passiveFloat','buoyancySurface','argoFloat' (ENUM)"
 		/>
 		<var name="indexLevel" type="integer" dimensions="nParticles Time" units="unitless"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats.xml
@@ -69,7 +69,7 @@
 					default_value="repeat_interval"
 					units="unitless"
 					description="A list of time durations in d_h:m:s describing how long to accumulate statistics. It has to match the number of tokens in reference_times."
-					possible_values="A list of time durations in d_h:m:s or 'repeat_interval's, separated by ;. Each must be greater than or equal to compute_interval * 2 and less than or requal to repeat_interval. duration_intervals < repeat_intervals allow for repeated statistics within the repeat_interval (i.e., for climatologies)"
+					possible_values="A list of time durations in d_h:m:s or 'repeat_interval's, separated by ;. Each must be greater than or equal to compute_interval * 2 and less than or requal to repeat_interval. duration_intervals less than repeat_intervals allow for repeated statistics within the repeat_interval (i.e., for climatologies)"
 		/>
 		<nml_option name="config_AM_timeSeriesStats_repeat_intervals"
 					type="character"

--- a/src/core_ocean/tracer_groups/Registry_ecosys.xml
+++ b/src/core_ocean/tracer_groups/Registry_ecosys.xml
@@ -414,7 +414,7 @@
 
 	        <var_struct name="ecosysSeaIceCoupling" time_levs="1" packages="ecosysTracersPKG">
                         <var name="oceanSurfacePhytoC" type="real" dimensions="R3 nCells Time" units="mmolC m^{-3}"
-                                 description="Ocean Surface phytoplankton carbon concentration: (1,2,3)=>(diat,sp,phaeo)"
+                                 description="Ocean Surface phytoplankton carbon concentration: (1,2,3) corresponds to (diat,sp,phaeo)"
                         />
                         <var name="oceanSurfaceDIC" type="real" dimensions="nCells Time" units="mmolC m^{-3}"
                                  description="Ocean Surface DIC concentration"
@@ -438,7 +438,7 @@
                                  description="Ocean Surface dissolved bioavailable Fe concentration"
                         />
                         <var name="iceFluxPhytoC" type="real" dimensions="R3 nCells Time" units="mmolC m^{-2} s"
-                                 description="Surface phytoplankton carbon flux from sea ice: (1,2,3)=>(diat,sp,phaeo)"
+                                 description="Surface phytoplankton carbon flux from sea ice: (1,2,3) corresponds to (diat,sp,phaeo)"
                         />
                         <var name="iceFluxDIC" type="real" dimensions="nCells Time" units="mmolC m^{-2} s"
                                  description="Surface DIC flux from sea ice"


### PR DESCRIPTION
This merge fixes a few XML syntax errors in three registry files. These
syntax errors cause some XML parsers (such as python's element tree) to
fail when parsing the XML file.
