### PR TITLE
Removes array temporary warning message in LIGHT

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -1364,6 +1364,7 @@ contains
       integer  :: nVertices, iCell, i, im1, i0, ip1, iVertex
       integer, pointer :: nCells
       real (kind=RKIND), dimension(:), allocatable :: xv,yv,zv
+      real (kind=RKIND), dimension(3) :: v1, v2, v3
       real (kind=RKIND), pointer :: radiusLocal
       integer, dimension(:,:), pointer :: verticesOnCell
       integer, dimension(:), pointer :: nCellVerticesArray
@@ -1423,9 +1424,16 @@ contains
 
             ! precompute B_i areas
             ! always the same because B_i independent of xp,yp,zp
-            areaBArray(iCell, i) = mpas_triangle_signed_area( (/ xv(im1),yv(im1),zv(im1) /) , &
-              (/ xv(i0),yv(i0),zv(i0) /) , &
-              (/ xv(ip1),yv(ip1),zv(ip1) /) , meshPool)
+            v1(1) = xv(im1)
+            v1(2) = yv(im1)
+            v1(3) = zv(im1)
+            v2(1) = xv(i0)
+            v2(2) = yv(i0)
+            v2(3) = zv(i0)
+            v3(1) = xv(ip1)
+            v3(2) = yv(ip1)
+            v3(3) = zv(ip1)
+            areaBArray(iCell, i) = mpas_triangle_signed_area(v1, v2, v3, meshPool)
           end do
           deallocate(xv, yv, zv)
 


### PR DESCRIPTION
Fixes warning message of type

Image              PC                Routine            Line        Source
ocean_model        0000000001DDDBE6  Unknown               Unknown  Unknown
ocean_model        00000000012963EA  ocn_lagrangian_pa        1426  mpas_ocn_lagrangian_particle_tracking.F
ocean_model        000000000127CDEC  ocn_lagrangian_pa         187  mpas_ocn_lagrangian_particle_tracking.F
ocean_model        00000000010A371A  ocn_analysis_driv         948  mpas_ocn_analysis_driver.F
ocean_model        000000000109C72A  ocn_analysis_driv         405  mpas_ocn_analysis_driver.F
ocean_model        0000000000C21EA7  ocn_forward_mode_         325  mpas_ocn_forward_mode.F
ocean_model        00000000010A982A  ocn_core_mp_ocn_c          79  mpas_ocn_core.F
ocean_model        00000000004051B9  mpas_subdriver_mp         307  mpas_subdriver.F
ocean_model        00000000004012F8  MAIN__                     14  mpas.F
ocean_model        000000000040128E  Unknown               Unknown  Unknown
ocean_model        0000000001EABDB1  Unknown               Unknown  Unknown
ocean_model        0000000000401175  Unknown               Unknown  Unknown
forrtl: warning (406): fort: (1): In call to MPAS_TRIANGLE_SIGNED_AREA, an array temporary was created for argument #1
