### PR TITLE
Adds a package option for new sw scheme and swtype None

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -602,9 +602,9 @@
 		/>
 	</nml_record>
 	<nml_record name="shortwaveRadiation" mode="init;forward">
-		<nml_option name="config_sw_absorption_type" type="character" default_value="ohlmann00" units="unitless"
-					description="Name of shortwave absorption type used in simulation. Not recommended to change default"
-					possible_values="'jerlov' or 'ohlmann00' "
+		<nml_option name="config_sw_absorption_type" type="character" default_value="none" units="unitless"
+					description="Name of shortwave absorption type used in simulation. "
+					possible_values="'jerlov' or 'ohlmann00' or 'none'"
 		/>
 		<nml_option name="config_jerlov_water_type" type="integer" default_value="3" units="unitless"
 					description="Integer value defining the water type used in Jerlov short wave absorption."
@@ -970,6 +970,8 @@
 		/>
 	</nml_record>
 	<packages>
+		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
+
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
 		<package name="thicknessFilter" description="This package includes variables required for frequency filtered thickness."/>
 		<package name="windStressBulkPKG" description="This package includes varibles required for bulk wind stress forcing."/>
@@ -1265,6 +1267,7 @@
 				filename_template="shortwaveData.nc"
 				input_interval="none"
 				runtime_format="single_file"
+				packages="variableShortwave"
 				mode="forward">
 				
 			<var name="xtime"/>
@@ -1279,6 +1282,7 @@
 				output_interval="0000-00-00_00:00:01"
 				clobber_mode="truncate"
 				runtime_format="single_file"
+				packages="variableShortwave"
 				mode="init">
 
 			<var name="chlorophyllData"/>
@@ -2265,12 +2269,15 @@
 		     ********************************************************************** -->
 		<var name="chlorophyllData" type="real" dimensions="nCells Time" units="mg m^{-3}"
 			 description="the concentration of chlorophyll data in mg/m^-3"
+			 packages="variableShortwave"	 
 		/>
 		<var name="zenithAngle" type="real" dimensions="nCells Time"  units="none"
-			 description="the cos of the solar zenith angle"
+			description="the cos of the solar zenith angle"
+			packages="variableShortwave"
 		/>
 		<var name="clearSkyRadiation" type="real" dimensions="nCells Time" units="%"
-			 description="the fractional cloudiness (between 0 and 1)"
+			description="the fractional cloudiness (between 0 and 1)"
+			packages="variableShortwave"
 		/>
 	</var_struct>
 	<var_struct name="forcing" time_levs="1">

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -117,6 +117,7 @@ module ocn_core_interface
       logical, pointer :: frazilIceActive
       logical, pointer :: inSituEOSActive
       logical, pointer :: restartForcingFieldsActive
+      logical, pointer :: variableShortwaveActive
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -144,6 +145,8 @@ module ocn_core_interface
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
       character (len=StrKIND), pointer :: config_pressure_gradient_type
+      character (len=StrKIND), pointer :: config_sw_absorption_type
+
       logical, pointer :: config_use_bulk_wind_stress
       logical, pointer :: config_use_bulk_thickness_flux
       character (len=StrKIND), pointer :: config_land_ice_flux_mode
@@ -161,6 +164,7 @@ module ocn_core_interface
       call mpas_pool_get_package(packagePool, 'analysisModeActive', analysisModeActive)
       call mpas_pool_get_package(packagePool, 'initModeActive', initModeActive)
       call mpas_pool_get_config(configPool, 'config_ocean_run_mode', config_ocean_run_mode)
+      
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          forwardModeActive = .true.
       endif
@@ -211,6 +215,17 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_use_bulk_wind_stress', config_use_bulk_wind_stress)
       if ( config_use_bulk_wind_stress ) then
          windStressBulkPKGActive = .true.
+      end if
+
+      !
+      ! Test if chlorophyll, solar zenith angle, and clear sky radiation should
+      ! be used
+      !
+
+      call mpas_pool_get_package(packagePool,'variableShortwaveActive',variableShortwaveActive)
+      call mpas_pool_get_config(configPool,'config_sw_absorption_type',config_sw_absorption_type)
+      if (trim (config_sw_absorption_type) == 'ohlmann00') then
+         variableShortwaveActive = .false.
       end if
 
       !

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -103,11 +103,12 @@ contains
       !
       !-----------------------------------------------------------------
 
-      logical, pointer :: config_use_activeTracers_surface_bulk_forcing
+      character(len=strKIND), pointer :: config_sw_absorption_type
 
-      call MPAS_pool_get_config(ocnConfigs, 'config_use_activeTracers_surface_bulk_forcing', config_use_activeTracers_surface_bulk_forcing)
+      call MPAS_pool_get_config(ocnConfigs, 'config_sw_absorption_type', config_sw_absorption_type)
 
-      if (.not.config_use_activeTracers_surface_bulk_forcing) return
+      write(stderrUnit,*) 'in swTend',config_sw_absorption_type
+      if (trim(config_sw_absorption_type)=='none') return
 
       err = 0
       if(useJerlov) then


### PR DESCRIPTION
this PR adds an option to disable the reading of chlorophyll, solar zenith angle, and
clear sky radiation unless config_sw_absorption_type = 'ohlmann00'.  Previously enabling bulk_forcing for tracers caused an error, outlined in #711 This should fully address that issue

it also adds a config_sw_absorption_type=='none' for use of bulk forcing without shortwave
