### PR TITLE
Fixes an indexing error in surface_bulk_forcing

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -360,6 +360,8 @@ contains
       integer, pointer :: index_temperature_flux, index_salinity_flux
       integer, pointer :: nCells
 
+      type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
+
       real (kind=RKIND), dimension(:), pointer :: latentHeatFlux, sensibleHeatFlux, longWaveHeatFluxUp, longWaveHeatFluxDown, seaIceHeatFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
@@ -370,8 +372,10 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-      call mpas_pool_get_dimension(forcingPool, 'index_temperatureSurfaceFlux', index_temperature_flux)
-      call mpas_pool_get_dimension(forcingPool, 'index_salinitySurfaceFlux', index_salinity_flux)
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
+
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', index_temperature_flux)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', index_salinity_flux)
 
       call mpas_pool_get_array(forcingPool, 'latentHeatFlux', latentHeatFlux)
       call mpas_pool_get_array(forcingPool, 'sensibleHeatFlux', sensibleHeatFlux)


### PR DESCRIPTION
in surface_bulk_forcing index_tracerssurfaceFlux and index_salinitysurfaceFlux were not being found, causing an error.  Adding a call to retrieve the tracersSurfaceFluxPool and then retrieving these indices fixed the issue.  Whenever bulk_forcing was enabled for tracers, the model would crash.  With this fix, it runs fine.
