### PR TITLE
Add a definition of rho_water when built in coupled mode

### DIFF
--- a/src/core_landice/shared/mpas_li_constants.F
+++ b/src/core_landice/shared/mpas_li_constants.F
@@ -26,7 +26,8 @@ module li_constants
    use shr_const_mod, only: &
           cp_ice => SHR_CONST_CPICE,&
           latent_heat_ice => SHR_CONST_LATICE,&
-          triple_point => SHR_CONST_TKTRIP
+          triple_point => SHR_CONST_TKTRIP,&
+          rho_water => SHR_CONST_RHOFW
    implicit none
    save
 


### PR DESCRIPTION
Previously, when built in coupled mode, rho_water was not defined which
causes mpas_li_thermal to fail building.

This merge adds a definition of this to point to SHR_CONST_RHOFW which
is the shared definition of the density of fresh water.
