### PR TITLE
Remove references to defunct flag config_fixed_jerlov_weights

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -124,11 +124,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth
       real (kind=RKIND), dimension(:), allocatable :: weights
 
-      logical, pointer :: config_fixed_jerlov_weights
-
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_fixed_jerlov_weights', config_fixed_jerlov_weights)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)


### PR DESCRIPTION
The option config_fixed_jerlov_weights is no longer needed, but instances remained in the code.  This removes those.
