### PR TITLE
Remove write of the short wave absorption method

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -107,7 +107,6 @@ contains
 
       call MPAS_pool_get_config(ocnConfigs, 'config_sw_absorption_type', config_sw_absorption_type)
 
-      write(stderrUnit,*) 'in swTend',config_sw_absorption_type
       if (trim(config_sw_absorption_type)=='none') return
 
       err = 0


### PR DESCRIPTION
This merge removes an unneeded write statement that prints the
absorption method for short wave.
