### PR TITLE
change default bottom drag setting

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -738,7 +738,7 @@
 		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
-		<nml_option name="config_bottom_drag_coeff" type="real" default_value="1.0e-2" units="unitless"
+		<nml_option name="config_bottom_drag_coeff" type="real" default_value="1.0e-3" units="unitless"
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/config_forward.xml
@@ -23,7 +23,6 @@
 		<option name="config_use_cvmix_shear">.true.</option>
 		<option name="config_use_cvmix_kpp">.true.</option>
 		<option name="config_eos_type">'jm'</option>
-		<option name="config_bottom_drag_coeff">1.0e-3</option>
 		<option name="config_use_bulk_wind_stress">.true.</option>
 		<option name="config_use_activeTracers_surface_restoring">.true.</option>
 		<option name="config_use_debugTracers">.true.</option>


### PR DESCRIPTION
Change default bottom drag to 1.0e-3 to match the standard global ocean setting.
