### PR TITLE
Add required fields for frazil to restart stream

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1226,6 +1226,8 @@
 			<var_array name="vertNonLocalFlux"/>
 			<var name="effectiveDensityInLandIce"/>
 			<var_struct name="ecosysAuxiliary"/>
+			<var name="accumulatedFrazilIceMass"/>
+			<var name="frazilSurfacePressure"/>
 		</stream>
 
 		<stream name="output" 


### PR DESCRIPTION
This merge adds fields that are required to properly restart frazil
forcing within a coupled model to the restart stream.
