### PR TITLE
Adds two single column model test cases

### DIFF
--- a/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_driver.xml
+++ b/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run_test.py">
+	<case name="init_step">
+		<step executable="./run.py"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py"/>
+	</case>
+</driver_script>

--- a/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_forward.xml
+++ b/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_forward.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init_step/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step/graph.info" dest="graph.info"/>
+	<add_link source="../init_step/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:10:00'</option>
+		<option name="config_run_duration">'0001_00:00:00'</option>
+		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
+		<option name="config_time_integrator">'split_explicit'</option>
+
+		<option name="config_use_mom_del4">.true.</option>
+		<option name="config_mom_del4">2.0e14</option>
+		<option name="config_use_cvmix">.true.</option>
+		<option name="config_use_cvmix_background">.true.</option>
+		<option name="config_use_cvmix_convection">.true.</option>
+		<option name="config_use_cvmix_shear">.true.</option>
+		<option name="config_use_cvmix_kpp">.true.</option>
+		<option name="config_cvmix_shear_mixing_scheme">'KPP'</option>
+		<option name="config_cvmix_kpp_interpolationOMLType">'cubic'</option>
+		<option name="config_cvmix_kpp_matching">'MatchBoth'</option>
+		<option name="config_cvmix_kpp_criticalBulkRichardsonNumber">0.25</option>
+		<option name="config_cvmix_kpp_surface_layer_extent">0.1</option>
+		
+		<option name="config_eos_type">'linear'</option>
+		<option name="config_bottom_drag_coeff">1.0e-3</option>
+		<option name="config_use_bulk_wind_stress">.true.</option>
+		<option name="config_use_activeTracers_surface_restoring">.false.</option>
+		<option name="config_use_activeTracers_interior_restoring">.false.</option>
+		<option name="config_use_bulk_thickness_flux">.false.</option>
+		<option name="config_use_activeTracers">.true.</option>
+		<option name="config_use_debugTracers">.false.</option>
+		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
+
+		<template file="mixed_layer_depths.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output/output.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="output_interval">0001_00:00:00</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="refZMid" type="var"/>
+				<member name="refLayerThickness" type="var"/>
+				<member name="zMid" type="var"/>
+				<member name="zTop" type="var"/>
+				<member name="kineticEnergyCell" type="var"/>
+				<member name="relativeVorticityCell" type="var"/>
+			</add_contents>
+		</stream>
+		<template file="KPP_testing.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="mixed_layer_depths.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<step executable="mpirun">
+			<argument flag="-n">8</argument>
+			<argument flag="">./ocean_model</argument>
+			<argument flag="-n">namelist.ocean</argument>
+			<argument flag="-s">streams.ocean</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_init.xml
+++ b/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_init.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<config case="init_step">
+
+	<get_file hash="7q1krpgdiu" dest_path="mesh_database" file_name="doubly_periodic_1920km_7680x7680km.151124.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
+
+	<add_link source_path="mesh_database" source="doubly_periodic_1920km_7680x7680km.151124.nc" dest="base_mesh.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'cvmix_WSwSBF'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+
+		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
+		<option name="config_use_activeTracers_surface_restoring">.true.</option>
+		<option name="config_use_activeTracers_interior_restoring">.true.</option>
+		<option name="config_use_bulk_wind_stress">.true.</option>
+		<option name="config_use_bulk_thickness_flux">.true.</option>
+		<option name="config_cvmix_WSwSBF_vert_levels">100</option>
+		<option name="config_cvmix_WSwSBF_surface_temperature">20.0</option>
+		<option name="config_cvmix_WSwSBF_surface_salinity">35.0</option>
+		<option name="config_cvmix_WSwSBF_surface_restoring_temperature">15.0</option>
+		<option name="config_cvmix_WSwSBF_surface_restoring_salinity">36.0</option>
+		<option name="config_cvmix_WSwSBF_surface_temperature_piston_velocity">4E-6</option>
+		<option name="config_cvmix_WSwSBF_surface_salinity_piston_velocity">4E-6</option>
+		<option name="config_cvmix_WSwSBF_sensible_heat_flux">-25.0</option>
+		<option name="config_cvmix_WSwSBF_latent_heat_flux">-50.0</option>
+		<option name="config_cvmix_WSwSBF_shortwave_heat_flux">200.0</option>
+		<option name="config_cvmix_WSwSBF_rain_flux">0.0</option>
+		<option name="config_cvmix_WSwSBF_evaporation_flux">6.5E-4</option>
+		<option name="config_cvmix_WSwSBF_interior_temperature_restoring_rate">1.0e-6</option>
+		<option name="config_cvmix_WSwSBF_interior_salinity_restoring_rate">1.0e-6</option>
+		<option name="config_cvmix_WSwSBF_temperature_gradient">0.01</option>
+		<option name="config_cvmix_WSwSBF_salinity_gradient">0.0</option>
+		<option name="config_cvmix_WSwSBF_vertical_grid">'100layerACMEv1'</option>
+		<option name="config_cvmix_WSwSBF_bottom_depth">400.0</option>
+		<option name="config_cvmix_WSwSBF_max_windstress">0.1</option>
+		<option name="config_cvmix_WSwSBF_coriolis_parameter">1E-4</option>
+		<option name="config_cvmix_WSwSBF_temperature_gradient_mixed_layer">0.0</option>
+		<option name="config_cvmix_WSwSBF_salinity_gradient_mixed_layer">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_depth_temperature">25.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_depth_salinity">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_temperature_change">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_salinity_change">1.0</option>
+
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="seaSurfacePressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+		<stream name="forcing_data_init">
+        	<attribute name="type">output</attribute>
+            <attribute name="filename_template">init_mode_forcing_data.nc</attribute>
+	        <attribute name="clobber_mode">truncate</attribute>
+	        <attribute name="output_interval">0000-00-00_00:00:01</attribute>
+			<add_contents>
+				<member name="tracersSurfaceRestoringFields" type="var_struct"/>
+                <member name="tracersInteriorRestoringFields" type="var_struct"/>
+                <member name="tracersExponentialDecayFields" type="var_struct"/>
+                <member name="tracersIdealAgeFields" type="var_struct"/>
+                <member name="tracersTTDFields" type="var_struct"/>
+                <member name="windStressZonal" type="var"/>
+                <member name="windStressMeridional" type="var"/>
+                <member name="landIceFraction" type="var"/>
+                <member name="landIceSurfaceTemperature" type="var"/>
+                <member name="latentHeatFlux" type="var"/>
+                <member name="sensibleHeatFlux" type="var"/>
+                <member name="shortWaveHeatFlux" type="var"/>
+                <member name="evaporationFlux" type="var"/>
+                <member name="rainFlux" type="var"/>
+			</add_contents>
+		</stream>
+ 
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./MpasMeshConverter.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		
+		<step executable="mpirun">
+			<argument flag="-n">1</argument>
+			<argument flag="">./ocean_model</argument>
+			<argument flag="-n">namelist.ocean</argument>
+			<argument flag="-s">streams.ocean</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_driver.xml
+++ b/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run_test.py">
+	<case name="init_step">
+		<step executable="./run.py"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py"/>
+	</case>
+</driver_script>

--- a/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_forward.xml
+++ b/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_forward.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init_step/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step/graph.info" dest="graph.info"/>
+	<add_link source="../init_step/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:10:00'</option>
+		<option name="config_run_duration">'0001_00:00:00'</option>
+		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
+		<option name="config_time_integrator">'split_explicit'</option>
+
+		<option name="config_use_mom_del4">.true.</option>
+		<option name="config_mom_del4">2.0e14</option>
+		<option name="config_use_cvmix">.true.</option>
+		<option name="config_use_cvmix_background">.true.</option>
+		<option name="config_use_cvmix_convection">.true.</option>
+		<option name="config_use_cvmix_shear">.true.</option>
+		<option name="config_use_cvmix_kpp">.true.</option>
+		<option name="config_cvmix_shear_mixing_scheme">'KPP'</option>
+		<option name="config_cvmix_kpp_interpolationOMLType">'cubic'</option>
+		<option name="config_cvmix_kpp_matching">'MatchBoth'</option>
+		<option name="config_cvmix_kpp_criticalBulkRichardsonNumber">0.25</option>
+		<option name="config_cvmix_kpp_surface_layer_extent">0.1</option>
+		
+		<option name="config_eos_type">'linear'</option>
+		<option name="config_bottom_drag_coeff">1.0e-3</option>
+		<option name="config_use_bulk_wind_stress">.true.</option>
+		<option name="config_use_activeTracers_surface_restoring">.false.</option>
+		<option name="config_use_activeTracers_interior_restoring">.false.</option>
+		<option name="config_use_bulk_thickness_flux">.false.</option>
+		<option name="config_use_activeTracers">.true.</option>
+		<option name="config_use_debugTracers">.false.</option>
+		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
+
+		<template file="mixed_layer_depths.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output/output.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="output_interval">0001_00:00:00</attribute>
+			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="refZMid" type="var"/>
+				<member name="refLayerThickness" type="var"/>
+				<member name="zMid" type="var"/>
+				<member name="zTop" type="var"/>
+				<member name="kineticEnergyCell" type="var"/>
+				<member name="relativeVorticityCell" type="var"/>
+			</add_contents>
+		</stream>
+		<template file="KPP_testing.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="mixed_layer_depths.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<step executable="mpirun">
+			<argument flag="-n">8</argument>
+			<argument flag="">./ocean_model</argument>
+			<argument flag="-n">namelist.ocean</argument>
+			<argument flag="-s">streams.ocean</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_init.xml
+++ b/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_init.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<config case="init_step">
+
+	<get_file hash="rku96q0z66" dest_path="mesh_database" file_name="mesh.QU.1920km.151026.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
+
+	<add_link source_path="mesh_database" source="mesh.QU.1920km.151026.nc" dest="base_mesh.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'cvmix_WSwSBF'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+		<option name="config_expand_sphere">.true.</option>
+
+		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
+		<option name="config_use_activeTracers_surface_restoring">.true.</option>
+		<option name="config_use_activeTracers_interior_restoring">.true.</option>
+		<option name="config_use_bulk_wind_stress">.true.</option>
+		<option name="config_use_bulk_thickness_flux">.true.</option>
+		<option name="config_cvmix_WSwSBF_vert_levels">100</option>
+		<option name="config_cvmix_WSwSBF_surface_temperature">20.0</option>
+		<option name="config_cvmix_WSwSBF_surface_salinity">35.0</option>
+		<option name="config_cvmix_WSwSBF_surface_restoring_temperature">15.0</option>
+		<option name="config_cvmix_WSwSBF_surface_restoring_salinity">36.0</option>
+		<option name="config_cvmix_WSwSBF_surface_temperature_piston_velocity">4E-6</option>
+		<option name="config_cvmix_WSwSBF_surface_salinity_piston_velocity">4E-6</option>
+		<option name="config_cvmix_WSwSBF_sensible_heat_flux">-25.0</option>
+		<option name="config_cvmix_WSwSBF_latent_heat_flux">-50.0</option>
+		<option name="config_cvmix_WSwSBF_shortwave_heat_flux">200.0</option>
+		<option name="config_cvmix_WSwSBF_rain_flux">0.0</option>
+		<option name="config_cvmix_WSwSBF_evaporation_flux">6.5E-4</option>
+		<option name="config_cvmix_WSwSBF_interior_temperature_restoring_rate">1.0e-6</option>
+		<option name="config_cvmix_WSwSBF_interior_salinity_restoring_rate">1.0e-6</option>
+		<option name="config_cvmix_WSwSBF_temperature_gradient">0.01</option>
+		<option name="config_cvmix_WSwSBF_salinity_gradient">0.0</option>
+		<option name="config_cvmix_WSwSBF_vertical_grid">'100layerACMEv1'</option>
+		<option name="config_cvmix_WSwSBF_bottom_depth">400.0</option>
+		<option name="config_cvmix_WSwSBF_max_windstress">0.1</option>
+		<option name="config_cvmix_WSwSBF_coriolis_parameter">1E-4</option>
+		<option name="config_cvmix_WSwSBF_temperature_gradient_mixed_layer">0.0</option>
+		<option name="config_cvmix_WSwSBF_salinity_gradient_mixed_layer">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_depth_temperature">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_depth_salinity">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_temperature_change">0.0</option>
+		<option name="config_cvmix_WSwSBF_mixed_layer_salinity_change">0.0</option>
+
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="seaSurfacePressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+  		<stream name="forcing_data_init">
+        	<attribute name="type">output</attribute>
+            <attribute name="filename_template">init_mode_forcing_data.nc</attribute>
+	        <attribute name="clobber_mode">truncate</attribute>
+	        <attribute name="output_interval">0000-00-00_00:00:01</attribute>
+			<add_contents>
+				<member name="tracersSurfaceRestoringFields" type="var_struct"/>
+                <member name="tracersInteriorRestoringFields" type="var_struct"/>
+                <member name="tracersExponentialDecayFields" type="var_struct"/>
+                <member name="tracersIdealAgeFields" type="var_struct"/>
+                <member name="tracersTTDFields" type="var_struct"/>
+                <member name="windStressZonal" type="var"/>
+                <member name="windStressMeridional" type="var"/>
+                <member name="landIceFraction" type="var"/>
+                <member name="landIceSurfaceTemperature" type="var"/>
+                <member name="latentHeatFlux" type="var"/>
+                <member name="sensibleHeatFlux" type="var"/>
+                <member name="shortWaveHeatFlux" type="var"/>
+                <member name="evaporationFlux" type="var"/>
+                <member name="rainFlux" type="var"/>
+			</add_contents>
+		</stream>
+ 
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./MpasMeshConverter.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		
+		<step executable="mpirun">
+			<argument flag="-n">1</argument>
+			<argument flag="">./ocean_model</argument>
+			<argument flag="-n">namelist.ocean</argument>
+			<argument flag="-s">streams.ocean</argument>
+		</step>
+	</run_script>
+</config>


### PR DESCRIPTION
This merge adds two versions of the single column CVMIX setup.  The
first is on a planar periodic grid (16 cells).  The second is on a
sphere (no bottom topography or continents).  This case uses the
QU1920km mesh.
