### PR TITLE
Corrects LIGHT restart location to restarts folder

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -122,7 +122,7 @@
 		<stream name="lagrPartTrackRestart" type="input;output"
 				mode="forward"
 				runtime_format="single_file"
-				filename_template="analysis_members/lagrangianParticleTrackingRestart.$Y-$M-$D_$h.$m.$s.nc"
+				filename_template="restarts/lagrangianParticleTrackingRestart.$Y-$M-$D_$h.$m.$s.nc"
 				filename_interval="output_interval"
 				clobber_mode="truncate"
 				input_interval="initial_only"


### PR DESCRIPTION
This places LIGHT restarts in the "restarts" folder instead of "analysis_members" for the default
restart stream location.
