### PR TITLE
Add a nightly regression suite for the ocean

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/QU_240km/default/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/default/config_driver.xml
@@ -8,4 +8,9 @@
 	<case name="forward">
 		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
 	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/regression_suites/nightly.xml
+++ b/test_cases/ocean/ocean/regression_suites/nightly.xml
@@ -1,0 +1,17 @@
+<regression_suite name="nightly_ocean_test_suite">
+	<test name="Global Ocean 240km - Smoke Test" core="ocean" configuration="global_ocean" resolution="QU_240km" test="default">
+		<script name="run_test.py"/>
+	</test>
+	<test name="ZISO 20km - Smoke Test" core="ocean" configuration="ziso" resolution="20km" test="default">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 10km - Thread Test" core="ocean" configuration="baroclinic_channel" resolution="10km" test="threads_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 10km - Decomp Test" core="ocean" configuration="baroclinic_channel" resolution="10km" test="decomp_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 10km - Restart Test" core="ocean" configuration="baroclinic_channel" resolution="10km" test="restart_test">
+		<script name="run_test.py"/>
+	</test>
+</regression_suite>

--- a/test_cases/ocean/ocean/ziso/20km/default/config_driver.xml
+++ b/test_cases/ocean/ocean/ziso/20km/default/config_driver.xml
@@ -12,7 +12,6 @@
 		<compare_fields file1="forward/output/output.0000-01-01_00.00.00.nc">
 			<field name="temperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="layerThickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
-			<field name="normalVelocity" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 		</compare_fields>
 	</validation>
 </driver_script>


### PR DESCRIPTION
This merge adds a starter nightly regression suite for the ocean core.

Additionally, it ensures the default global ocean and ziso cases have
comparisons, to make sure they are compared against baselines.
