### PR TITLE
Update output_intervals to be synced to the restart stream

### DIFF
--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -126,7 +126,7 @@
 				filename_interval="output_interval"
 				clobber_mode="truncate"
 				input_interval="initial_only"
-				output_interval="0030_00:00:00"
+				output_interval="stream:restart:output_interval"
 				packages="lagrPartTrackAMPKG"
 			immutable="false">
 

--- a/src/core_ocean/analysis_members/Registry_time_series_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats.xml
@@ -152,7 +152,7 @@
 				clobber_mode="truncate"
 				input_interval="initial_only"
 				packages="timeSeriesStatsAMPKG"
-				output_interval="0005_00:00:00"
+				output_interval="stream:restart:output_interval"
 				immutable="false"
 				mode="forward;analysis" />
 


### PR DESCRIPTION
This merge updates analysis member output_intervals on restart streams
to be synchronized with the main restart stream of the model.
