### PR TITLE
Change template for globalStats

### DIFF
--- a/test_cases/ocean/ocean/templates/analysis_members/global_stats.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/global_stats.xml
@@ -1,10 +1,10 @@
 <template>
 	<namelist>
 		<option name="config_AM_globalStats_enable">.true.</option>
-		<option name="config_AM_globalStats_compute_interval">'dt'</option>
+		<option name="config_AM_globalStats_compute_interval">'output_interval'</option>
 		<option name="config_AM_globalStats_compute_on_startup">.true.</option>
 		<option name="config_AM_globalStats_write_on_startup">.true.</option>
-		<option name="config_AM_globalStats_text_file">.true.</option>
+		<option name="config_AM_globalStats_text_file">.false.</option>
 		<option name="config_AM_globalStats_directory">'analysis_members'</option>
 		<option name="config_AM_globalStats_output_stream">'globalStatsOutput'</option>
 	</namelist>


### PR DESCRIPTION
Turns off writing global stats to text files by in the default template used by some test cases.  The default interval for computing stats is the output interval, not every time step. These are also the default values for these entries in default_input/namelist.ocean.forward
