### PR TITLE
Change namelist template read to read-only

### DIFF
--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -76,7 +76,7 @@ def generate_namelist_files(config_file, case_path, configs):#{{{
 
 def ingest_namelist(namelist_file, namelist_dict):#{{{
 	# Read the template file
-	namelistfile = open(namelist_file, 'r+')
+	namelistfile = open(namelist_file, 'r')
 	lines = namelistfile.readlines()
 
 	record_name = 'NONE!!!'


### PR DESCRIPTION
Previously, the namelist template was opened in append mode, but it is
only needed in read-only mode. This allows namelists that are only user
readable but not user writable to be used by the testing infrastructure.
