### PR TITLE
Allow tracers to run in all modes.

### DIFF
--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -1,4 +1,4 @@
-	<nml_record name="tracer_forcing_activeTracers" mode="init;forward;analysis">
+	<nml_record name="tracer_forcing_activeTracers">
 		<nml_option name="config_use_activeTracers" type="logical" default_value=".true." units="unitless"
 					description="if true, the 'activeTracers' category is enabled for the run"
 					possible_values=".true. or .false."

--- a/src/core_ocean/tracer_groups/Registry_debugTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_debugTracers.xml
@@ -1,4 +1,4 @@
-	<nml_record name="tracer_forcing_debugTracers" mode="forward;analysis">
+	<nml_record name="tracer_forcing_debugTracers">
 		<nml_option name="config_use_debugTracers" type="logical" default_value=".false." units="unitless"
 					description="if true, the 'debugTracers' category is enabled for the run"
 					possible_values=".true. or .false."


### PR DESCRIPTION
Previously, we could not initialize the debug tracer group in init mode because they were not activated in the mode flag.  Now tracer1 may be initialized in init mode.
