### PR TITLE
Compute zMid over nCells in global_ocean test case

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -430,7 +430,7 @@ contains
           call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
           call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
-          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
           call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -448,7 +448,7 @@ contains
                refBottomDepth,refBottomDepth(nVertLevels), &
                nVertLevels,nVertLevels,iErr)
 
-          do iCell = 1, nCellsSolve 
+          do iCell = 1, nCells 
              call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
 
              ! Compute LayerThickness and zMid

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -682,6 +682,8 @@ contains
       do iEdge = 1,nEdges
         c1 = cellsOnEdge(1,iEdge)
         c2 = cellsOnEdge(2,iEdge)
+        ! not a valid edge
+        if((c1 > nCells) .or. (c2 > nCells)) cycle
         maxLevelEdge = min(maxLevelCell(c1), maxLevelCell(c2))
         do k = 1,maxLevelEdge-1
           dzVert1 = zMid(k,c1)-zMid(k+1,c1)


### PR DESCRIPTION
Was previously being computed only over nCellsSolve, which caused
problems when computing the Haney number on edges that included
the halo.

Also, this commit will add a sanity check to the comutation of the
Haney number to make sure that both cells on a given edge are
valid ( <= nCells).
