### PR TITLE
Add missing indentation argument in setup_testcase.py

### DIFF
--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -525,7 +525,7 @@ def generate_driver_scripts(config_file, configs):#{{{
 			# Process <step> tags
 			elif child.tag == 'step':
 				script.write('os.chdir(base_path)\n')
-				process_script_step(child, configs, script)
+				process_script_step(child, configs, '', script)
 			# Process <compare_fields> tags
 			elif child.tag == 'validation':
 				script.write('os.chdir(base_path)\n')


### PR DESCRIPTION
The call is missing when the "step" tag is used as a child
within a driver (as opposed to being within a case).
The missing argument is in a call to process_script_step()
