### PR TITLE
Updates ZISO test cases for automated testing

### DIFF
--- a/test_cases/ocean/ocean/ziso/10km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/10km/default/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/mesh.nc" dest="mesh.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
-	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151113.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging"/>
+	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
 	</get_file>
 
-	<add_link source_path="initial_condition_database" source="make_particle_resets.151113.py" dest="make_particle_resets.py"/>
+	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 	<add_executable source="metis" dest="metis"/>
@@ -45,6 +45,7 @@
 			<argument flag="">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
+			<argument flag="">11</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>

--- a/test_cases/ocean/ocean/ziso/10km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/10km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="gom47qx4qu" file_name="doubly_periodic_10km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging" />
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/test_cases/ocean/ocean/ziso/2.5km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/2.5km/default/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/mesh.nc" dest="mesh.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
-	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151113.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging"/>
+	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
 	</get_file>
 
-	<add_link source_path="initial_condition_database" source="make_particle_resets.151113.py" dest="make_particle_resets.py"/>
+	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 	<add_executable source="metis" dest="metis"/>
@@ -45,6 +45,7 @@
 			<argument flag="">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
+			<argument flag="">11</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>

--- a/test_cases/ocean/ocean/ziso/2.5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/2.5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="sp3d6v0wir" file_name="doubly_periodic_2.5km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging" />
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_2.5km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/test_cases/ocean/ocean/ziso/20km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/20km/default/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/mesh.nc" dest="mesh.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
-	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151113.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging"/>
+	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
 	</get_file>
 
-	<add_link source_path="initial_condition_database" source="make_particle_resets.151113.py" dest="make_particle_resets.py"/>
+	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 	<add_executable source="metis" dest="metis"/>
@@ -45,6 +45,7 @@
 			<argument flag="">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
+			<argument flag="">11</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>

--- a/test_cases/ocean/ocean/ziso/20km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/20km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="yu8hv6txi0" file_name="doubly_periodic_20km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging" />
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/test_cases/ocean/ocean/ziso/5km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/5km/default/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/mesh.nc" dest="mesh.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
-	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151113.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging"/>
+	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
 	</get_file>
 
-	<add_link source_path="initial_condition_database" source="make_particle_resets.151113.py" dest="make_particle_resets.py"/>
+	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 	<add_executable source="metis" dest="metis"/>
@@ -45,6 +45,7 @@
 			<argument flag="">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
+			<argument flag="">11</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>

--- a/test_cases/ocean/ocean/ziso/5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="qfp5x0blpj" file_name="doubly_periodic_5km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mpas_ocean/test_cases/staging" />
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>


### PR DESCRIPTION
This merge updates the particle setup script to allow the number of buoyancy surfaces to be an input argument. This allows lighter weight particle test cases to be created using this script.
