### PR TITLE
Accumulate timer info when comparing timers

### DIFF
--- a/test_cases/ocean/utility_scripts/compare_timers.py
+++ b/test_cases/ocean/utility_scripts/compare_timers.py
@@ -36,22 +36,14 @@ def find_timer_value(timer_name, directory):#{{{
 					if len(new_block_arr) >= timer_line_size:
 						if sub_timer_name.find(new_block_arr[name_index]) >= 0:
 							try:
-								timer = float(new_block_arr[total_index])
+								timer = timer + float(new_block_arr[total_index])
 								timer_found = True
-								break
 							except ValueError:
-								timer_found = False
+								timer = timer
 						del new_block
 					del new_block_arr
 
-			if timer_found:
-				break
-							
 	return timer_found, timer
-#	if timer_found:
-#		return timer
-#	else:
-#		return False
 #}}}
 
 # Define and process input arguments


### PR DESCRIPTION
This merge updates the compare_timers.py script to accumulate timer
information rather than only printing timer information for the first
instance of a timer.

This is useful if the timer output contains multiple instances of the
same timer name.
