### PR TITLE
Fix incorrect symlink in 960km test

### DIFF
--- a/test_cases/ocean/test/basic_spherical/960km/default/config_test.xml
+++ b/test_cases/ocean/test/basic_spherical/960km/default/config_test.xml
@@ -9,7 +9,7 @@
 	<add_executable source="metis" dest="metis"/>
 
 	<add_link source_path="utility_scripts" source="make_graph_file.py" dest="make_graph_file.py"/>
-	<add_link source_path="mesh_database" source="mesh.QU.642.151008.nc" dest="base_mesh.nc"/>
+	<add_link source_path="mesh_database" source="mesh.QU.960km.151026.nc" dest="base_mesh.nc"/>
 
 	<namelist name="namelist.test" mode="forward"/>
 


### PR DESCRIPTION
This merge updates the 960km basic spherical test to create a link to
the correct mesh file for the test case.
