### PR TITLE
Allow model_run steps to specify executable

### DIFF
--- a/test_cases/ocean/doc/README.config
+++ b/test_cases/ocean/doc/README.config
@@ -238,4 +238,6 @@ what children can be placed below the tag.
             - threads: The number of OpenMP threads to use in the run
             - namelist: The namelist file to use when performing the run
             - streams: The streams file to use when performing the run
+            - executable: (Optional) The name of the executble to use from the
+                          config file. If this is not specified, it defaults to 'model'.
 

--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -903,6 +903,11 @@ def process_model_run_step(model_run_tag, configs, script):#{{{
 	run_config_tree = ET.parse(run_definition_file)
 	run_config_root = run_config_tree.getroot()
 
+	try:
+		executable_name = model_run_tag.attrib['executable']
+	except:
+		executable_name = 'model'
+
 	# Process each part of the run script
 	for child in run_config_root:
 		# Process each <step> tag
@@ -913,7 +918,7 @@ def process_model_run_step(model_run_tag, configs, script):#{{{
 					arg_text = grandchild.text
 
 					if arg_text == 'model':
-						grandchild.text = config.get('executables', 'model')
+						grandchild.text = config.get('executables', executable_name)
 					elif arg_text.find('attr_') >= 0:
 						attr_array = arg_text.split('_')
 						try:


### PR DESCRIPTION
This merge updates the model_run step to allow specification of the
executable, rather than just using the model executable. This allows
cores that have multiple executables run each one.
