### PR TITLE
Add a timer to netcdf output of global stats AM

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1272,6 +1272,7 @@
 			<var name="normalBarotropicVelocity"/>
 			<var name="vertCoordMovementWeights"/>
 			<var name="xtime"/>
+			<var name="simulationStartTime"/>
 			<var name="boundaryLayerDepth"/>
 			<var name="seaSurfacePressure" packages="restartForcingFields"/>
 			<var_array name="tracersSurfaceValue"/>
@@ -1861,6 +1862,12 @@
 	<var_struct name="diagnostics" time_levs="1">
 		<var name="xtime" type="text" dimensions="Time" units="unitless"
 			 description="model time, with format 'YYYY-MM-DD_HH:MM:SS'"
+		/>
+		<var name="simulationStartTime" type="text" dimensions="" units="unitless" default_value="'no_date_available'"
+			 description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"
+		/>
+		<var name="daysSinceStartOfSim" type="real" dimensions="Time" units="days"
+			 description="Time since simulationStartTime, for plotting"
 		/>
 		<var_array name="tracersSurfaceValue" type="real" dimensions="nCells Time" packages="forwardMode;analysisMode">
 			<var name="temperatureSurfaceValue" array_group="surfaceValues" units="degrees Celsius" name_in_code="temperatureSurfaceValue"

--- a/src/core_ocean/analysis_members/Registry_global_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_global_stats.xml
@@ -32,9 +32,6 @@
 		<package name="globalStatsAMPKG" description="This package includes variables required for the global statistics analysis member."/>
 	</packages>
 	<var_struct name="globalStatsAM" time_levs="1" packages="globalStatsAMPKG">
-		<var name="timeInDays" type="real" dimensions="Time" units="days"
-			 description="Time since config_start_time, for plotting"
-		/>
 		<var_array name="minGlobalStats" type="real" dimensions="Time">
 			<var name="layerThicknessMin" array_group="mins" units="m"
 				 description="Minimum global value of layerThickness in ocean cells."
@@ -424,7 +421,7 @@
 				runtime_format="single_file">
 
 			<var name="xtime"/>
-			<var name="timeInDays"/>
+			<var name="daysSinceStartOfSim"/>
 			<var_array name="minGlobalStats"/>
 			<var_array name="maxGlobalStats"/>
 			<var_array name="sumGlobalStats"/>

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -233,8 +233,8 @@ contains
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot
 
-      character (len=StrKIND), pointer :: xtime
-      type (MPAS_Time_type) :: xtime_time, zero_time
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
+      type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
 
       real (kind=RKIND) :: volumeCellGlobal, volumeEdgeGlobal, CFLNumberGlobal, localCFL, localSum, areaCellGlobal, areaEdgeGlobal, areaTriangleGlobal, time_sec
       real (kind=RKIND), dimension(:), pointer ::  areaCell, dcEdge, dvEdge, areaTriangle, areaEdge
@@ -244,7 +244,7 @@ contains
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
-      real (kind=RKIND), pointer :: timeInDays
+      real (kind=RKIND), pointer :: daysSinceStartOfSim
       real (kind=RKIND), dimension(:), pointer :: minGlobalStats,maxGlobalStats,sumGlobalStats, averages, rms, verticalSumMins, verticalSumMaxes
       real (kind=RKIND), dimension(kMaxVariables) :: sumSquares, reductions, sums, mins, maxes
       real (kind=RKIND), dimension(kMaxVariables) :: sums_tmp, sumSquares_tmp, mins_tmp, maxes_tmp, averages_tmp, verticalSumMins_tmp, verticalSumMaxes_tmp
@@ -263,7 +263,6 @@ contains
 
       ! write out data to Analysis Member output
       call mpas_pool_get_subpool(domain % blocklist % structs, 'globalStatsAM', globalStatsAMPool)
-      call mpas_pool_get_array(globalStatsAMPool, 'timeInDays',timeInDays)
       call mpas_pool_get_array(globalStatsAMPool, 'minGlobalStats', minGlobalStats)
       call mpas_pool_get_array(globalStatsAMPool, 'maxGlobalStats', maxGlobalStats)
       call mpas_pool_get_array(globalStatsAMPool, 'sumGlobalStats', sumGlobalStats)
@@ -325,6 +324,8 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
          call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
          call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime',simulationStartTime)
+         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
 
          allocate(areaEdge(1:nEdgesSolve))
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
@@ -596,12 +597,6 @@ contains
       ! compute the averages (slightly different depending on how the sum was computed)
       variableIndex = 0
 
-      ! compute time since time zero, in days
-      call mpas_set_time(xtime_time, dateTimeString=xtime)
-      call mpas_set_time(zero_time, dateTimeString="0000-01-01_00:00:00")
-      call mpas_get_timeInterval(xtime_time-zero_time,dt=time_sec)
-      timeInDays = time_sec/86400.0_RKIND
-
       ! layerThickness
       variableIndex = variableIndex + 1
       averages(variableIndex) = sums(variableIndex)/(areaCellGlobal*nVertLevels)
@@ -706,19 +701,19 @@ contains
          if (dminfo % my_proc_id == IO_NODE) then
             fileID = getFreeUnit()
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_min.txt',STATUS='UNKNOWN', POSITION='append')
-            write (fileID,'(100es24.14)') timeInDays, mins(1:nVariables)
+            write (fileID,'(100es24.14)') daysSinceStartOfSim, mins(1:nVariables)
             close (fileID)
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_max.txt',STATUS='UNKNOWN', POSITION='append')
-            write (fileID,'(100es24.14)') timeInDays, maxes(1:nVariables)
+            write (fileID,'(100es24.14)') daysSinceStartOfSim, maxes(1:nVariables)
             close (fileID)
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_sum.txt',STATUS='UNKNOWN', POSITION='append')
-            write (fileID,'(100es24.14)') timeInDays, sums(1:nVariables)
+            write (fileID,'(100es24.14)') daysSinceStartOfSim, sums(1:nVariables)
             close (fileID)
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_rms.txt',STATUS='UNKNOWN', POSITION='append')
-            write (fileID,'(100es24.14)') timeInDays, rms(1:nVariables)
+            write (fileID,'(100es24.14)') daysSinceStartOfSim, rms(1:nVariables)
             close (fileID)
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_avg.txt',STATUS='UNKNOWN', POSITION='append')
-            write (fileID,'(100es24.14)') timeInDays, averages(1:nVariables)
+            write (fileID,'(100es24.14)') daysSinceStartOfSim, averages(1:nVariables)
             close (fileID)
             open(fileID,file=trim(config_AM_globalStats_directory)//'/stats_time.txt',STATUS='UNKNOWN', POSITION='append')
             write (fileID,'(a)') trim(xtime)

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -72,7 +72,9 @@ module ocn_analysis_mode
 
       ! remove dt later
       real (kind=RKIND) :: dt
-      character (len=StrKIND), pointer :: xtime
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
+      real (kind=RKIND), pointer :: daysSinceStartOfSim
+      type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_Time_Type) :: startTime
 
       ierr = 0
@@ -123,6 +125,20 @@ module ocn_analysis_mode
          endif
 
          xtime = startTimeStamp
+
+         ! Set simulationStartTime only if that variable is not read from the restart file.
+         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
+         if (trim(simulationStartTime)=="no_date_available") then
+            simulationStartTime = startTimeStamp
+         end if
+
+         ! compute time since start of simulation, in days
+         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
+         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
+         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
+         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
          block => block % next
       end do
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -115,7 +115,9 @@ module ocn_forward_mode
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: diagnosticsPool
 
-      character (len=StrKIND), pointer :: xtime
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
+      real (kind=RKIND), pointer :: daysSinceStartOfSim
+      type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_Time_Type) :: startTime
       type (MPAS_TimeInterval_type) :: timeStep
 
@@ -314,6 +316,20 @@ module ocn_forward_mode
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
          xtime = startTimeStamp
+
+         ! Set simulationStartTime only if that variable is not read from the restart file.
+         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
+         if (trim(simulationStartTime)=="no_date_available") then
+            simulationStartTime = startTimeStamp
+         end if
+
+         ! compute time since start of simulation, in days
+         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
+         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
+         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
+         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
          block => block % next
       end do
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -23,6 +23,7 @@ module ocn_time_integration
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_constants
+   use mpas_timekeeping
    use mpas_dmpar
    use mpas_vector_reconstruction
    use mpas_spline_interpolation
@@ -100,6 +101,9 @@ module ocn_time_integration
       type (mpas_pool_type), pointer :: diagnosticsPool, statePool
 
       character (len=StrKIND), pointer :: xtime
+      real (kind=RKIND), pointer :: daysSinceStartOfSim
+      character (len=StrKIND), pointer :: simulationStartTime
+      type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
 
@@ -118,6 +122,14 @@ module ocn_time_integration
         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
 
         xtime = timeStamp
+
+        ! compute time since start of simulation, in days
+        call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
+        call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
+        call mpas_set_time(xtime_timeType, dateTimeString=xtime)
+        call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
+        call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+        daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
 
         nanCheck = sum(normalVelocity)
 

--- a/src/core_ocean/shared/mpas_ocn_constants.F
+++ b/src/core_ocean/shared/mpas_ocn_constants.F
@@ -64,6 +64,7 @@ module ocn_constants
       T0_Kelvin        ,&! zero point for Celsius
       mpercm           ,&! meters per m
       cmperm           ,&! m per meter
+      days_per_second  ,&! days per second
       salt_to_ppt      ,&! salt (kg/kg) to ppt
       ppt_to_salt      ,&! salt ppt to kg/kg
       mass_to_Sv       ,&! mass flux to Sverdrups
@@ -135,6 +136,7 @@ contains
        !
        !-----------------------------------------------------------------------
 
+       days_per_second = 1._RKIND/86400._RKIND     ! days per second
        salt_to_ppt   = 1000._RKIND        ! salt (kg/kg) to ppt
        ppt_to_salt   = 1.e-3_RKIND        ! salt ppt to kg/kg
        mass_to_Sv    = 1.0e-12_RKIND      ! mass flux to Sverdrups

--- a/test_cases/ocean/ocean/templates/analysis_members/global_stats.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/global_stats.xml
@@ -14,13 +14,14 @@
 			<attribute name="runtime_format">single_file</attribute>
 			<attribute name="name">globalStatsOutput</attribute>
 			<attribute name="filename_interval">01-00-00_00:00:00</attribute>
-			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="clobber_mode">append</attribute>
 			<attribute name="output_interval">0000_01:00:00</attribute>
+			<attribute name="reference_time">0000-01-01_00:00:00</attribute>
 			<attribute name="filename_template">analysis_members/globalStats.$Y-$M-$D_$h.$m.$s.nc</attribute>
 			<attribute name="packages">globalStatsAMPKG</attribute>
 			<attribute name="type">output</attribute>
 			<add_contents>
-				<member name="timeInDays" type="var"/>
+				<member name="daysSinceStartOfSim" type="var"/>
 				<member name="xtime" type="var"/>
 				<member name="minGlobalStats" type="var_array"/>
 				<member name="maxGlobalStats" type="var_array"/>


### PR DESCRIPTION
Add a variable to conveniently plot time in plots of global statistics.  Add a variable to conveniently plot time in plots of global statistics.  The new variable, timeInDays, is a floating point number of days since time "0000-01-01_00:00:00", so that this timer will work across restart files.
