### PR TITLE
Add read/write support for 1D character arrays

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -62,6 +62,7 @@ include 'mpif.h'
    public :: mpas_dmpar_bcast_doubles
    public :: mpas_dmpar_bcast_logical
    public :: mpas_dmpar_bcast_char
+   public :: mpas_dmpar_bcast_chars
    public :: mpas_dmpar_sum_int
    public :: mpas_dmpar_sum_real
    public :: mpas_dmpar_min_int
@@ -594,6 +595,45 @@ include 'mpif.h'
 #endif
 
    end subroutine mpas_dmpar_bcast_char!}}}
+
+!-----------------------------------------------------------------------
+!  routine mpas_dmpar_bcast_chars
+!
+!> \brief MPAS dmpar broadcast character array routine.
+!> \author Doug Jacobsen
+!> \date   01/22/2016
+!> \details
+!>  This routine broadcasts an array of characters to all processors in the communicator.
+!>  An optional argument specifies the source node; else broadcast from IO_NODE.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_dmpar_bcast_chars(dminfo, n, carray, proc)!{{{
+
+      implicit none
+
+      type (dm_info), intent(in) :: dminfo !< Input: Domain information
+      integer, intent(in) :: n !< Input: Number of character strings to broadcast
+      character (len=*), dimension(:), intent(inout) :: carray !< Input/Output: Character to be broadcast
+      integer, intent(in), optional :: proc  !< optional argument indicating which processor to broadcast from
+
+#ifdef _MPI
+      integer :: mpi_ierr, source
+      integer :: threadNum
+
+      threadNum = mpas_threading_get_thread_num()
+
+      if ( threadNum == 0 ) then
+         if (present(proc)) then
+            source = proc
+         else
+            source = IO_NODE
+         endif
+
+         call MPI_Bcast(carray, n * len(carray(1)), MPI_CHARACTER, source, dminfo % comm, mpi_ierr)
+      end if
+#endif
+
+   end subroutine mpas_dmpar_bcast_chars!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_sum_int

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -36,6 +36,7 @@ module mpas_io
       module procedure MPAS_io_get_var_real4d
       module procedure MPAS_io_get_var_real5d
       module procedure MPAS_io_get_var_char0d
+      module procedure MPAS_io_get_var_char1d
    end interface MPAS_io_get_var
 
    interface MPAS_io_put_var
@@ -51,6 +52,7 @@ module mpas_io
       module procedure MPAS_io_put_var_real4d
       module procedure MPAS_io_put_var_real5d
       module procedure MPAS_io_put_var_char0d
+      module procedure MPAS_io_put_var_char1d
    end interface MPAS_io_put_var
 
    interface MPAS_io_get_att
@@ -1314,7 +1316,7 @@ module mpas_io
 
    subroutine MPAS_io_get_var_generic(handle, fieldname, intVal, intArray1d, intArray2d, intArray3d, intArray4d, &
                                                         realVal, realArray1d, realArray2d, realArray3d, realArray4d, realArray5d, &
-                                                        charVal, ierr)
+                                                        charVal, charArray1d, ierr)
 
       implicit none
 
@@ -1332,6 +1334,7 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:,:), intent(out), optional :: realArray4d
       real (kind=RKIND), dimension(:,:,:,:,:), intent(out), optional :: realArray5d
       character (len=*), intent(out), optional :: charVal
+      character (len=*), dimension(:), intent(out), optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
@@ -1356,6 +1359,8 @@ module mpas_io
       real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
       real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
       real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+
+      integer i, j
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -1430,6 +1435,51 @@ module mpas_io
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, tempchar)
             charVal(1:count1(1)) = tempchar(1)(1:count1(1))
+         end if
+      else if (present(charArray1d)) then
+!         write (0,*) '  value is char1'
+         if (field_cursor % fieldhandle % has_unlimited_dim) then
+            ! Can only read one string at a time, since the sizes differ so much (i.e. StrLen != StrKIND)
+            do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
+               start3(1) = 1
+               start3(2) = i
+               start3(3) = handle % frame_number
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize ! Should be StrLen
+               count3(2) = 1
+               count3(3) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, tempchar)
+
+               ! Copy all characters up to the first C null char or the end of
+               ! the string, whichever comes first
+               charArray1d(i)(:) = ' '
+               do j = 1, len(tempchar(1))
+                  if ( tempchar(1)(j:j) /= CHAR(0)) then
+                     charArray1d(i)(j:j) = tempchar(1)(j:j)
+                  else
+                     exit
+                  end if
+               end do
+            end do
+         else
+            ! Can only read one string at a time, since the sizes differ so much (i.e. StrLen != StrKIND)
+            do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
+               start2(1) = 1
+               start2(2) = i
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize ! Should be StrLen
+               count2(2) = 1
+               pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, tempchar)
+
+               ! Copy all characters up to the first C null char or the end of
+               ! the string, whichever comes first
+               charArray1d(i)(:) = ' '
+               do j = 1, len(tempchar(1))
+                  if ( tempchar(1)(j:j) /= CHAR(0)) then
+                     charArray1d(i)(j:j) = tempchar(1)(j:j)
+                  else
+                     exit
+                  end if
+               end do
+            end do
          end if
       else if (present(realArray1d)) then
 !         write (0,*) '  value is real1'
@@ -1975,6 +2025,23 @@ module mpas_io
    end subroutine MPAS_io_get_var_char0d
 
 
+   subroutine MPAS_io_get_var_char1d(handle, fieldname, val, ierr)
+
+      implicit none
+
+      type (MPAS_IO_Handle_type), intent(inout) :: handle
+      character (len=*), intent(in) :: fieldname
+      character (len=*), dimension(:), intent(out) :: val
+      integer, intent(out), optional :: ierr
+
+!     write(stderrUnit,*) 'Called MPAS_io_get_var_char1d()'
+      if (present(ierr)) ierr = MPAS_IO_NOERR
+
+      call MPAS_io_get_var_generic(handle, fieldname, charArray1d=val, ierr=ierr)
+
+   end subroutine MPAS_io_get_var_char1d
+
+
    logical function MPAS_io_would_clobber_records(handle, ierr)
 
       implicit none
@@ -2003,7 +2070,7 @@ module mpas_io
 
    subroutine MPAS_io_put_var_generic(handle, fieldname, intVal, intArray1d, intArray2d, intArray3d, intArray4d, &
                                                         realVal, realArray1d, realArray2d, realArray3d, realArray4d, realArray5d, &
-                                                        charVal, ierr)
+                                                        charVal, charArray1d, ierr)
 
       implicit none
 
@@ -2021,6 +2088,7 @@ module mpas_io
       real (kind=RKIND), dimension(:,:,:,:), intent(in), optional :: realArray4d
       real (kind=RKIND), dimension(:,:,:,:,:), intent(in), optional :: realArray5d
       character (len=*), intent(in), optional :: charVal
+      character (len=*), dimension(:), intent(in), optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
@@ -2044,6 +2112,8 @@ module mpas_io
       real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
       real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
       real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+
+      integer :: i
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -2126,6 +2196,28 @@ module mpas_io
             start1(1) = 1
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, charVal(1:count1(1)))
+         end if
+      else if (present(charArray1d)) then
+         if (field_cursor % fieldhandle % has_unlimited_dim) then
+            ! Write one string at a time because the sizes differ so much (i.e. StrLen != StrKIND)
+            do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
+               start3(1) = 1
+               start3(2) = i
+               start3(3) = handle % frame_number
+               count3(1) = field_cursor % fieldhandle % dims(1) % dimsize ! Should be StrLen
+               count3(2) = 1
+               count3(3) = 1
+               pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, charArray1d(i)(1:count3(1)))
+            end do
+         else
+            ! Write one string at a time because the sizes differ so much (i.e. StrLen != StrKIND)
+            do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
+               start2(1) = 1
+               start2(2) = i
+               count2(1) = field_cursor % fieldhandle % dims(1) % dimsize ! Should be StrLen
+               count2(2) = 1
+               pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, charArray1d(i)(1:count2(1)))
+            end do
          end if
       else if (present(realArray1d)) then
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
@@ -2684,6 +2776,23 @@ module mpas_io
       call MPAS_io_put_var_generic(handle, fieldname, charVal=val, ierr=ierr)
 
    end subroutine MPAS_io_put_var_char0d
+
+
+   subroutine MPAS_io_put_var_char1d(handle, fieldname, val, ierr)
+
+      implicit none
+
+      type (MPAS_IO_Handle_type), intent(inout) :: handle
+      character (len=*), intent(in) :: fieldname
+      character (len=*), dimension(:), intent(in) :: val
+      integer, intent(out), optional :: ierr
+
+!      write(stderrUnit,*) 'Called MPAS_io_put_var_char1d()'
+      if (present(ierr)) ierr = MPAS_IO_NOERR
+
+      call MPAS_io_put_var_generic(handle, fieldname, charArray1d=val, ierr=ierr)
+
+   end subroutine MPAS_io_put_var_char1d
 
 
    subroutine MPAS_io_get_att_int0d(handle, attName, attValue, fieldname, ierr)

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -36,6 +36,7 @@ module mpas_io_streams
       module procedure MPAS_streamAddField_4dReal
       module procedure MPAS_streamAddField_5dReal
       module procedure MPAS_streamAddField_0dChar
+      module procedure MPAS_streamAddField_1dChar
    end interface MPAS_streamAddField
 
    interface MPAS_streamUpdateField
@@ -50,6 +51,7 @@ module mpas_io_streams
       module procedure MPAS_streamUpdateField_4dReal
       module procedure MPAS_streamUpdateField_5dReal
       module procedure MPAS_streamUpdateField_0dChar
+      module procedure MPAS_streamUpdateField_1dChar
    end interface MPAS_streamUpdateField
 
    interface MPAS_readStreamAtt
@@ -1480,6 +1482,99 @@ module mpas_io_streams
    end subroutine MPAS_streamAddField_0dChar
 
 
+   subroutine MPAS_streamAddField_1dChar(stream, field, ierr)
+
+      implicit none
+
+      type (MPAS_Stream_type), intent(inout) :: stream
+      type (field1DChar), intent(in), target :: field
+      integer, intent(out), optional :: ierr
+
+      integer :: io_err
+      integer :: i
+      integer :: idim
+      integer :: totalDimSize, globalDimSize
+      integer :: ndims
+      type (field1dChar), pointer :: field_ptr
+      character (len=StrKIND), dimension(2) :: dimNames
+      character (len=StrKIND), dimension(:), pointer :: dimNamesInq
+      integer, dimension(:), pointer :: dimSizes
+      integer, dimension(:), pointer :: indices
+      type (field_list_type), pointer :: field_list_cursor
+      type (field_list_type), pointer :: new_field_list_node
+
+      if (present(ierr)) ierr = MPAS_STREAM_NOERR
+
+      !
+      ! Sanity checks
+      !
+      if (.not. stream % isInitialized) then
+         if (present(ierr)) ierr = MPAS_STREAM_NOT_INITIALIZED
+         return
+      end if
+
+!write(stderrUnit,*) '... Adding field '//trim(field % fieldName)//' to stream'
+
+      ndims = 2
+
+!write(stderrUnit,*) '... field has ', ndims, ' dimensions'
+
+      ! 
+      ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
+      !    and the total number of outer-indices owned by this task
+      ! 
+      idim = ndims
+      allocate(indices(1))
+      allocate(dimSizes(2))
+      dimSizes(1) = 64
+      dimNames(1) = 'StrLen'
+      dimSizes(2) = field % dimSizes(1)
+      dimNames(2) = field % dimNames(1)
+      globalDimSize = dimSizes(2)
+      totalDimSize = dimSizes(2)
+      
+      if (field % isVarArray) then
+         do i=1,size(field % constituentNames)
+            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_CHAR, dimNames, &
+                                             dimSizes, field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
+                                             indices, ierr=io_err)
+         end do
+      else
+         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_CHAR, dimNames, dimSizes, &
+                                          field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
+      end if
+
+      deallocate(indices)
+      deallocate(dimSizes)
+      if (io_err /= MPAS_STREAM_NOERR) then
+          if (present(ierr)) ierr = MPAS_IO_ERR
+          return
+      end if
+
+      if (field % isVarArray) then
+         do i=1,size(field % constituentNames)
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attList)
+         end do
+      else
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attList)
+      end if
+
+
+      !
+      ! Set field pointer and type in fieldList
+      !
+      new_field_list_node => stream % fieldList
+      do while (associated(new_field_list_node % next))
+         new_field_list_node => new_field_list_node % next
+      end do
+      new_field_list_node % field_type = FIELD_1D_CHAR
+      new_field_list_node % char1dField => field
+
+!write(stderrUnit,*) '... done adding field'
+
+   end subroutine MPAS_streamAddField_1dChar
+
+
    subroutine MPAS_streamAddField_generic(stream, fieldName, fieldType, dimNames, dimSizes, hasTimeDimension, isDecomposed, &
                                           totalDimSize, globalDimSize, indices, precision, ierr)
 
@@ -2207,6 +2302,50 @@ module mpas_io_streams
    end subroutine MPAS_streamUpdateField_0dChar
 
 
+   subroutine MPAS_streamUpdateField_1dChar(stream, field, ierr)
+
+      implicit none
+
+      type (MPAS_Stream_type), intent(inout) :: stream
+      type (field1DChar), intent(in), target :: field
+      integer, intent(out), optional :: ierr
+
+      type (field_list_type), pointer :: field_cursor
+
+
+      if (present(ierr)) ierr = MPAS_STREAM_NOERR
+
+      !
+      ! Sanity checks
+      !
+      if (.not. stream % isInitialized) then
+         if (present(ierr)) ierr = MPAS_STREAM_NOT_INITIALIZED
+         return
+      end if
+
+      STREAM_DEBUG_WRITE( '... Updating 1d char field '//trim(field % fieldName)//' in stream' )
+
+      field_cursor => stream % fieldList
+      do while (associated(field_cursor))
+         if (field_cursor % field_type == FIELD_1D_CHAR) then
+            if (field_cursor % char1dField % fieldname == field % fieldname) then
+               STREAM_DEBUG_WRITE( '... found 1d char named '//trim(field_cursor % char0dField % fieldname) )
+               field_cursor % char1dField => field
+               exit
+            end if
+         end if
+         field_cursor => field_cursor % next
+      end do
+      if (.not. associated(field_cursor)) then
+         STREAM_DEBUG_WRITE( '... 1d char field '//trim(field % fieldname)//' not found in stream' )
+         if (present(ierr)) ierr = MPAS_STREAM_FIELD_NOT_FOUND
+      end if
+
+      STREAM_DEBUG_WRITE( '... done updating field' )
+
+   end subroutine MPAS_streamUpdateField_1dChar
+
+
    subroutine MPAS_readStream(stream, frame, ierr)
 
       implicit none
@@ -2232,6 +2371,7 @@ module mpas_io_streams
       type (field0dChar), pointer :: field_0dchar_ptr
       type (field1dChar), pointer :: field_1dchar_ptr
       type (field_list_type), pointer :: field_cursor
+      character (len=StrKIND), dimension(:), pointer :: char1d_temp
       integer                            :: int0d_temp
       integer, dimension(:),     pointer :: int1d_temp
       integer, dimension(:,:),   pointer :: int2d_temp
@@ -2997,6 +3137,31 @@ module mpas_io_streams
             end do
 
          else if (field_cursor % field_type == FIELD_1D_CHAR) then
+!write(stderrUnit,*) 'Reading in field '//trim(field_cursor % char1dField % fieldName)
+!write(stderrUnit,*) '   > is the field decomposed? ', field_cursor % isDecomposed
+!write(stderrUnit,*) '   > outer dimension size ', field_cursor % totalDimSize
+
+!write(stderrUnit,*) 'MGD calling MPAS_io_get_var now...'
+            allocate(char1d_temp(field_cursor % char1dField % dimSizes(1)))
+            call MPAS_io_get_var(stream % fileHandle, field_cursor % char1dField % fieldName, char1d_temp, io_err)
+            call MPAS_io_err_mesg(io_err, .false.)
+            if (io_err /= MPAS_IO_NOERR) then
+                if (present(ierr)) ierr = MPAS_IO_ERR
+                deallocate(char1d_temp)
+                return
+            end if
+
+!write(stderrUnit,*) 'Distributing and Copying field to other blocks'
+
+            call mpas_dmpar_bcast_chars(field_cursor % char1dField % block % domain % dminfo, &
+                                        field_cursor % char1dField % dimSizes(1), char1d_temp)
+            field_1dchar_ptr => field_cursor % char1dField
+            do while (associated(field_1dchar_ptr))
+               field_1dchar_ptr % array(:)(:) = char1d_temp(:)(:)
+               field_1dchar_ptr => field_1dchar_ptr % next
+            end do
+
+            deallocate(char1d_temp)
          end if
          field_cursor => field_cursor % next
       end do
@@ -3593,6 +3758,18 @@ module mpas_io_streams
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_CHAR) then
+
+!write(stderrUnit,*) 'Writing out field '//trim(field_cursor % char1dField % fieldName)
+!write(stderrUnit,*) '   > is the field decomposed? ', field_cursor % isDecomposed
+!write(stderrUnit,*) '   > outer dimension size ', field_cursor % totalDimSize
+
+!write(stderrUnit,*) 'Copying field from first block'
+!write(stderrUnit,*) 'MGD calling MPAS_io_put_var now...'
+            call MPAS_io_put_var(stream % fileHandle, field_cursor % char1dField % fieldName, field_cursor % char1dField % array, io_err)
+            call MPAS_io_err_mesg(io_err, .false.)
+            if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
+
+
          end if
          field_cursor => field_cursor % next
       end do

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -3675,9 +3675,8 @@ module mpas_stream_manager
                                 call mpas_pool_get_field(allFields, itr % memberName, char0d, timeLevel)
                                 call MPAS_streamAddField(stream % stream, char0d)
                             case (1)
-!                                call mpas_pool_get_field(allFields, itr % memberName, char1d, timeLevel)
-!                                call MPAS_streamAddField(stream % stream, char1d)
-                                 write(stderrUnit,*) 'Error: In build_stream, unsupported type field1DChar.'
+                                 call mpas_pool_get_field(allFields, itr % memberName, char1d, timeLevel)
+                                 call MPAS_streamAddField(stream % stream, char1d)
                         end select
                 end select
 


### PR DESCRIPTION
This merge adds the ability to read and write 1D character arrays to
the MPAS framework. Additionally, it adds a routine for broadcasting a
1D character array into mpas_dmpar.
