### PR TITLE
Change a timer name to get more detailed information

### DIFF
--- a/src/core_cice/shared/mpas_cice_column.F
+++ b/src/core_cice/shared/mpas_cice_column.F
@@ -870,9 +870,9 @@ contains
        ! Update the aggregated state variables
        !-----------------------------------------------------------------
 
-       call mpas_timer_start("Column update state")
+       call mpas_timer_start("Column predyn update state")
        call cice_column_update_state(domain, "thermodynamics", config_dt, config_dt)
-       call mpas_timer_stop("Column update state")
+       call mpas_timer_stop("Column predyn update state")
 
     endif
 


### PR DESCRIPTION
This merge makes a timer name change that was requested by the ACME
performance team, in order to get more detailed timing information when
running within ACME.
