### PR TITLE
Fix bug that allowed an output-only stream to be unintentionally read

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -2795,7 +2795,7 @@ module mpas_stream_manager
 
                 ! Verify that the stream is an input stream
                 if (stream_cursor % direction == MPAS_STREAM_INPUT .or. &
-                    stream_cursor % direction /= MPAS_STREAM_INPUT_OUTPUT) then
+                    stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
 
                     !
                     ! What should be the meaning of actualWhen if we read multiple streams in this call?


### PR DESCRIPTION
This merge corrects logic in the MPAS_stream_mgr_read( ) routine 
so that only "input" or "input,output" streams are read.

The logic in MPAS_stream_mgr_read( ) that was intended to read all
"input" or "input,output" streams when a streamID was not provided as
an optional argument incorrectly checked whether the stream being
considered was _not_ an "input,output" stream.
