### PR TITLE
Fix init of analysis members

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -249,9 +249,6 @@ module ocn_forward_mode
       call ocn_sea_ice_init(nVertLevels, err_tmp)
       ierr = ior(ierr, err_tmp)
 
-      call ocn_analysis_init(domain, err_tmp)
-      ierr = ior(ierr, err_tmp)
-
       if(ierr.eq.1) then
           call mpas_dmpar_global_abort('ERROR: An error was encountered while initializing the MPAS-Ocean forward mode')
       endif


### PR DESCRIPTION
This merge removes one of the init steps when setting up the forward
mode in the ocean. Previously there were two, and some analysis members
caused the model to die when setting them up.
