### PR TITLE
Change abort calls to global_abort

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -290,7 +290,7 @@ contains
          if (nDefinedDataFields > nLayerVolWeightedAvgFields) then
              write (stderrUnit,*) 'Abort: nDefinedDataFields > nLayerVolWeightedAvgFields'
              write (stderrUnit,*) '     :  increase size of ocn_layer_volume_weighted_averages scratch space'
-             call mpas_dmpar_abort(dminfo)
+             call mpas_dmpar_global_abort('Abort: nDefinedDataFields > nLayerVolWeightedAvgFields')
          endif
 
          ! get pointers to data that will be analyzed

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -310,7 +310,7 @@ contains
          if (nDefinedDataFields > nSfcAreaWeightedAvgFields) then
              write (stderrUnit,*) 'Abort: nDefinedDataFields > nSfcAreaWeightedAvgFields'
              write (stderrUnit,*) '     :  increase size of ocn_surface_area_weighted_averages scratch space'
-             call mpas_dmpar_abort(dminfo)
+             call mpas_dmpar_global_abort('Abort: nDefinedDataFields > nSfcAreaWeightedAvgFields')
          endif
 
          ! get pointers to data that will be analyzed

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -135,7 +135,7 @@ module ocn_time_integration
 
         if (nanCheck /= nanCheck) then
            write(stderrUnit,*) 'Abort: NaN detected'
-           call mpas_dmpar_abort(dminfo)
+           call mpas_dmpar_global_abort('Abort: NaN detected')
         endif
 
         block => block % next

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -138,7 +138,7 @@ contains
          write (stderrUnit,*) 'Abort: In equation_of_state_jm', &
              ' k_displaced must be between 1 and nVertLevels for ', &
              'displacement_type = absolute'
-         call mpas_dmpar_abort(dminfo)
+         call mpas_dmpar_global_abort('Abort: In equation_of_state_jm')
       endif
 
       ! if surfaceDisplaced, then compute density at all levels based on surface values

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -480,7 +480,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
                   write (stderrUnit,'(a,10f10.2)') ' refBottomDepth(maxLevelCell(iCell)), ' &
                                                    // 'refBottomDepthTopOfCell(maxLevelCell(iCell)): ', &
                                 refBottomDepth(maxLevelCell(iCell)), refBottomDepthTopOfCell(maxLevelCell(iCell))
-                  call mpas_dmpar_abort(dminfo)
+                  call mpas_dmpar_global_abort('Abort: bottomDepth and maxLevelCell do not match')
                endif
 
             enddo


### PR DESCRIPTION
This merge changes mpas_dmpar_abort calls to mpas_dmpar_global_abort.
This helps fix issues when running inside of ACME when the model fails.
