### PR TITLE
Fix uninitialized dimension in redi vmix module

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -188,6 +188,8 @@ contains
 
       if(.not.rediDiffOn) return
 
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + vertRediDiff(:, iCell)


### PR DESCRIPTION
This merge correctly initializes the nCells dimension in the redi vmix
module. Previously it was uninitialized, so using gm would cause a
segfault.
