### PR TITLE
Fix ezxml Makefile when flags have a colon

### DIFF
--- a/src/external/ezxml/Makefile
+++ b/src/external/ezxml/Makefile
@@ -10,4 +10,5 @@ library: $(OBJS)
 clean:
 	$(RM) *.o *.i
 
-.c.o: $(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+.c.o:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<


### PR DESCRIPTION
This merge fixes an issue with the ezxml Makefile that is caused when
the CFLAGS (or other flags) have an option that contains a colon (e.g.
-qsmp=omp:noopt for xlf / IBM compilers).
