### PR TITLE
Fix incorrect timelevels

### DIFF
--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -561,7 +561,7 @@ module li_time_integration_fe
 
       call mpas_timer_start("halo updates")
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-      call mpas_pool_get_field(geometryPool, 'thickness', thicknessField, timeLevel=2)
+      call mpas_pool_get_field(geometryPool, 'thickness', thicknessField)
       call mpas_dmpar_exch_halo_field(thicknessField)
       call mpas_timer_stop("halo updates")
 

--- a/src/core_landice/shared/mpas_li_setup.F
+++ b/src/core_landice/shared/mpas_li_setup.F
@@ -164,7 +164,6 @@ contains
       integer, pointer :: nVertLevels ! Dimensions
       real (kind=RKIND), dimension(:), pointer :: layerThicknessFractions, layerCenterSigma, layerInterfaceSigma
       real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness1, layerThickness2
       logical, pointer :: config_do_restart
       ! Truly locals
       integer :: k
@@ -178,8 +177,6 @@ contains
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
       call mpas_pool_get_array(meshPool, 'layerInterfaceSigma', layerInterfaceSigma)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness1, timeLevel=1)
-      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness2, timeLevel=2)
 
       ! Check that layerThicknessFractions are valid
       ! TODO - switch to having the user input the sigma levels instead???
@@ -205,12 +202,6 @@ contains
          layerInterfaceSigma(k) = layerInterfaceSigma(k-1) + layerThicknessFractions(k-1)
       end do
       layerInterfaceSigma(nVertLevels+1) = 1.0_RKIND
-
-      ! Also, initialize the layerThickness field
-      do k = 1, nVertLevels
-         layerThickness1(k,:) = thickness(:) * layerThicknessFractions(k)
-      enddo
-      layerThickness2 = layerThickness1
 
    !--------------------------------------------------------------------
    end subroutine li_setup_vertical_grid


### PR DESCRIPTION
A recent branch reduced the number of time levels for thickness and
layerThickness from 2 to 1.  This commit fixes a couple instances that
were still referencing the second time level and were not caught in the
previous branch.  In the instance in mpas_li_setup.F, the reference to
layerThickness is not actually needed, so I just removed it.

This eliminates a number of harmless but confusing 'error' messages.
