### PR TITLE
Add PMP temperature variables for output

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -841,6 +841,12 @@ is the value of that variable from the *previous* time level!
 		<var name="basalTemperature" type="real" dimensions="nCells Time" units="K"
 		     description="lower surface ice temperature"
 		/>
+		<var name="pmpTemperature" type="real" dimensions="nVertLevels nCells Time" units="K"
+		     description="pressure melt temperature"
+		/>
+		<var name="basalPmpTemperature" type="real" dimensions="nCells Time" units="K"
+		     description="lower surface pressure melt temperature"
+		/>
 		<var name="surfaceConductiveFlux" type="real" dimensions="nCells Time" units="W m^{-2}"
 		     description="conductive heat flux at the upper surface (positive downward)"
 		/>

--- a/src/core_landice/mode_forward/mpas_li_diagnostic_vars.F
+++ b/src/core_landice/mode_forward/mpas_li_diagnostic_vars.F
@@ -381,7 +381,7 @@ contains
 !> \brief   Computes diagnostic variables prior to velocity
 !> \author  Matt Hoffman
 !> \date    19 April 2012
-!> \details 
+!> \details
 !> This routine computes the diagnostic variables for land ice
 !> that are needed before velocity is solved.
 !
@@ -390,7 +390,8 @@ contains
 
       use mpas_geometry_utils, only: mpas_cells_to_points_using_baryweights
       use mpas_vector_operations, only: mpas_tangential_vector_1d
-   
+      use li_thermal
+
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -428,6 +429,9 @@ contains
       real (kind=RKIND), dimension(:), pointer :: thickness, upperSurface, &
         lowerSurface, bedTopography, upperSurfaceVertex, slopeEdge, &
         normalSlopeEdge, tangentSlopeEdge, dcEdge, dvEdge
+      real (kind=RKIND), dimension(:), pointer :: layerCenterSigma
+      real (kind=RKIND), dimension(:,:), pointer :: pmpTemperature
+      real (kind=RKIND), dimension(:), pointer :: basalPmpTemperature
       integer, dimension(:), pointer :: cellMask, edgeMask, vertexMask
       integer, dimension(:), pointer :: vertexMaskOld, vertexMaskNew
       integer, dimension(:), pointer :: floatingEdges
@@ -515,6 +519,8 @@ contains
           call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
           call mpas_pool_get_config(liConfigs, 'config_tracer_advection', config_tracer_advection)
 
+          call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
+
           call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
           call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -523,6 +529,8 @@ contains
           call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
 
           call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+          call mpas_pool_get_array(thermalPool, 'pmpTemperature', pmpTemperature)
+          call mpas_pool_get_array(thermalPool, 'basalPmpTemperature', basalPmpTemperature)
 
           ! Lower surface is based on floatation for floating ice.  For grounded ice (and non-ice areas) it is the bed.
           where ( li_mask_is_floating_ice(cellMask) )
@@ -540,6 +548,17 @@ contains
 
           ! Upper surface is the lower surface plus the thickness
           upperSurface(:) = lowerSurface(:) + thickness(:)
+
+
+          ! Calculate diagnostic PMP temperature
+          ! Note: this is only to allow these fields to be output;
+          !       the thermal module performs these calculations internally as needed.
+          ! Note: The PMP temperature calculated here will differ from the PMP values
+          !       used in the thermal module, because the thermal solver occurs before
+          !       advection occurs, and this calculation occurs after.
+          call li_compute_pressure_melting_point_fields(nCells, thickness, layerCenterSigma, &
+                pmpTemperature, basalPmpTemperature)
+
 
           ! Calculate SIA-related variables, if needed
           !   This first block for calculating normalSlopeEdge is also needed for the DCFL calculation that could occur with any velocity solver

--- a/src/core_landice/mode_forward/mpas_li_thermal.F
+++ b/src/core_landice/mode_forward/mpas_li_thermal.F
@@ -50,7 +50,9 @@ module li_thermal
    public :: li_thermal_init, li_thermal_solver, &
              li_init_linear_temperature_in_column,  &
              li_heat_dissipation_sia, li_basal_friction_sia,  &
-             li_temperature_to_enthalpy, li_enthalpy_to_temperature
+             li_temperature_to_enthalpy, li_enthalpy_to_temperature, &
+             li_compute_pressure_melting_point_fields
+
 
    !--------------------------------------------------------------------
    !
@@ -2761,7 +2763,7 @@ module li_thermal
          layerCenterSigma,  &
          thickness,         &
          pmpTemperature)
-      
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -2771,7 +2773,7 @@ module li_thermal
 
       real (kind=RKIND), intent(in) ::  &
            thickness             !< Input: ice thickness
- 
+
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
@@ -2781,7 +2783,7 @@ module li_thermal
 
       ! Compute the pressure melting point temperature in the column
 
-      pmpTemperature(:) = - iceMeltingPointPressureDependence * rhoi * gravity * thickness * layerCenterSigma(:) 
+      pmpTemperature(:) = - iceMeltingPointPressureDependence * rhoi * gravity * thickness * layerCenterSigma(:)
 
     end subroutine pressure_melting_point_column
 
@@ -2793,21 +2795,21 @@ module li_thermal
 !> \author William Lipscomb
 !> \date   October 2015
 !> \details
-!>  This routine computes the pressure melting point temperature at a 
+!>  This routine computes the pressure melting point temperature at a
 !>  given depth in an ice column.
 !-----------------------------------------------------------------------
 
     subroutine pressure_melting_point(&
          depth,           &
          pmpTemperature)
-      
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), intent(in) ::  &
            depth                !< Input: depth in column
- 
+
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
@@ -2820,6 +2822,66 @@ module li_thermal
       pmpTemperature = - iceMeltingPointPressureDependence * rhoi * gravity * depth
 
     end subroutine pressure_melting_point
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  !  routine li_compute_pressure_melting_point_fields
+!
+!> \brief MPAS compute pressure melting point temperature for entire domain
+!> \author Matthew Hoffman
+!> \date   February 2016
+!> \details
+!>  This routine computes the pressure melting point temperature for the
+!>  entire interior ice domain and the basal boundary.
+!>  It makes use of existing routines for PMP calculations.
+!>  This is created for diagnostic output purposes, and is not used by the
+!>  thermal solver.
+!-----------------------------------------------------------------------
+
+    subroutine li_compute_pressure_melting_point_fields(&
+         nCells,                 &
+         thickness,              &
+         layerCenterSigma,       &
+         pmpTemperature,         &
+         basalPmpTemperature)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      integer, intent(in) :: nCells !< Input: number of cells
+
+      real (kind=RKIND), dimension(:), intent(in) ::  &
+           thickness                !< Input: thickness field
+
+      real (kind=RKIND), dimension(:), intent(in) ::  &
+           layerCenterSigma         !< Input: layer sigma levels
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+           pmpTemperature          !< Output: pressure melting point temperature (K) for interior ice
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+           basalPmpTemperature     !< Output: pressure melting point temperature (K) at ice-bed interface
+
+      ! Local variables
+      integer :: iCell
+
+      do iCell = 1, nCells
+         ! Calculate internal ice PMP
+         call pressure_melting_point_column(layerCenterSigma, thickness(iCell), pmpTemperature(:,iCell))
+         ! Calculate basal PMP
+         call pressure_melting_point(thickness(iCell), basalPmpTemperature(iCell))
+      enddo
+
+      ! Convert from Celsius to Kelvin
+      pmpTemperature = pmpTemperature + kelvin_to_celsius
+      basalPmpTemperature = basalPmpTemperature + kelvin_to_celsius
+
+    end subroutine li_compute_pressure_melting_point_fields
+
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !


### PR DESCRIPTION
This adds pmpTemperature and basalPmpTemperature as diagnostic output
variables.  They are not used internally by the thermal code, but they
are useful for calculating melted areas in post-processing.
