### PR TITLE
Added a check for open fileunits for mpas get fileunits.

### DIFF
--- a/src/framework/mpas_io_units.F
+++ b/src/framework/mpas_io_units.F
@@ -44,11 +44,18 @@ module mpas_io_units
 
         integer :: i
 
+        logical :: opened
+
         do i = 1, maxUnits
-            if(.not. unitsInUse(i) ) then
-                newUnit = i
-                unitsInUse(newUnit) = .true.
-                return
+            if (.not. unitsInUse(i)) then
+                inquire(i, opened=opened)
+                if (opened) then
+                    unitsInUse(i) = .true.
+                else
+                    newUnit = i
+                    unitsInUse(newUnit) = .true.
+                    return
+                endif
             end if
         end do
 


### PR DESCRIPTION
This merge fixes an issue with mpas_new_unit where the resulting unit number might have already been opened if the call is made within a coupled model. It adds a check to make sure the unit number is not already opened before passing it back to the calling component.
