### PR TITLE
Ensure Okubo Weiss timers exist on all procs

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -1132,12 +1132,12 @@ contains
       call mpas_timer_stop("sort/reduce")
 
       ! only output if IO node
+      call mpas_timer_start("output")
       if (dminfo % my_proc_id == IO_NODE) then
          ! Output aggregated
-         call mpas_timer_start("output")
          call ocn_output_eddy_stats(listIdx, aggregated, use_lat_lon_coords,xtime)
-         call mpas_timer_stop("output")
       end if
+      call mpas_timer_stop("output")
 
    end subroutine ocn_aggregate_eddy_stats!}}}
 


### PR DESCRIPTION
This merge updates the Okubo Weiss analysis member to ensure all timers
are started / stopped on all processors. If they are not, the code
hangs when trying to synchronize all of the timers at the end of the
run.

This issue can be seen in the 20km ZISO test case using it's default
configuration.
