### PR TITLE
Improved terminal error messages

### DIFF
--- a/src/core_landice/analysis_members/mpas_li_analysis_driver.F
+++ b/src/core_landice/analysis_members/mpas_li_analysis_driver.F
@@ -242,7 +242,7 @@ contains
                end do
    
                if ( .not. streamFound ) then
-                  call mpas_dmpar_global_abort('ERROR: Stream ' // trim(config_AM_stream_name) // ' does not exist. Exiting...')
+                  call mpas_dmpar_global_abort('MPAS-landice: ERROR: Stream ' // trim(config_AM_stream_name) // ' does not exist. Exiting...')
                end if
             end if
             

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -292,7 +292,7 @@ module li_calving
                write(stderrUnit,*) 'ERROR: Must have config_calving_thickness > config_dynamic_thickness'
                write(stderrUnit,*) 'config_calving_thickness (m) =', config_calving_thickness
                write(stderrUnit,*) 'config_dynamic_thickness (m) =', config_dynamic_thickness
-!!               call mpas_dmpar_global_abort('Aborting with calving error')
+!!               call mpas_dmpar_global_abort('MPAS-landice: Aborting with calving error')
             endif
 
             ! get scratch fields for calving

--- a/src/core_landice/mode_forward/mpas_li_core.F
+++ b/src/core_landice/mode_forward/mpas_li_core.F
@@ -222,7 +222,7 @@ module li_core
 
       call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
       if (globalErr > 0) then
-          call mpas_dmpar_global_abort("An error has occurred in li_core_init. Aborting...")
+          call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_core_init. Aborting...")
       endif
 
    !--------------------------------------------------------------------
@@ -413,7 +413,7 @@ module li_core
          ! === error check and exit
          call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
          if (globalErr > 0) then
-             call mpas_dmpar_global_abort("An error has occurred in li_core_run. Aborting...")
+             call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_core_run. Aborting...")
          endif
 
       end do
@@ -492,7 +492,7 @@ module li_core
       ! === error check and exit
       call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
       if (globalErr > 0) then
-          call mpas_dmpar_global_abort("An error has occurred in li_core_finalize. Aborting...")
+          call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_core_finalize. Aborting...")
       endif
 
       call mpas_timer_stop("land ice finalize")
@@ -659,7 +659,7 @@ module li_core
       ! === error check and exit
       call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
       if (globalErr > 0) then
-          call mpas_dmpar_global_abort("An error has occurred in li_core_initial_solve. Aborting...")
+          call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_core_initial_solve. Aborting...")
       endif
 
 

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -183,7 +183,7 @@ module li_core_interface
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 
       if (.not. associated(config_do_restart)) then
-         call mpas_dmpar_global_abort('ERROR: config_do_restart is not associated.')
+         call mpas_dmpar_global_abort('MPAS-landice: ERROR: config_do_restart is not associated.')
       else if (config_do_restart) then
          write(stream,'(a)') 'restart'
       else

--- a/src/core_landice/mode_forward/mpas_li_thermal.F
+++ b/src/core_landice/mode_forward/mpas_li_thermal.F
@@ -742,7 +742,7 @@ module li_thermal
 
       if (deltat <= 0.0_RKIND) then
          write(stderrUnit,*) 'ERROR: li_thermal_solver was called with invalid deltat =', deltat
-         call mpas_dmpar_global_abort("An error has occurred in li_thermal. Aborting...")
+         call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_thermal. Aborting...")
       endif
 
       ! block loop
@@ -1228,7 +1228,7 @@ module li_thermal
                   do k = 1, nVertLevels
                      write(stderrUnit,*) k, temperature(k,iCell)
                   enddo
-                  call mpas_dmpar_global_abort("An error has occurred in li_thermal. Aborting...")
+                  call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_thermal. Aborting...")
                endif
 
                if (mintemp < mintempThreshold) then
@@ -1238,7 +1238,7 @@ module li_thermal
                   do k = 1, nVertLevels
                      write(stderrUnit,*) k, temperature(k,iCell)
                   enddo
-                  call mpas_dmpar_global_abort("An error has occurred in li_thermal. Aborting...")
+                  call mpas_dmpar_global_abort("MPAS-landice: An error has occurred in li_thermal. Aborting...")
                endif
           
             enddo   ! iCell


### PR DESCRIPTION
Added "MPAS-landice: " to the start of all mpas_dmpar_global_abort messages for coupled simualtion runs.
