### PR TITLE
Fix norm computations to use abs value

### DIFF
--- a/test_cases/ocean/utility_scripts/compare_fields.py
+++ b/test_cases/ocean/utility_scripts/compare_fields.py
@@ -68,7 +68,7 @@ linf_norm = -(sys.float_info.max)
 
 pass_val = True
 
-print "Comparing field '%s'"%(args.variable)
+print "Beginning variable comparisons for all time levels of field '%s'. Note any time levels reported are 0-based."%(args.variable)
 if ( args.l2_norm or args.l1_norm or args.linf_norm ):
 	print "    Pass thresholds are:"
 	if ( args.l1_norm ):


### PR DESCRIPTION
This merge fixes the compare fields script to use the absolute value of
the difference when computing norms.

Additionally, it removes the normalization in the L2 norm computation.
