### PR TITLE
Update driver baseline comparisons and remove file checks from driver scripts

### DIFF
--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -678,19 +678,21 @@ def process_compare_fields_step(compare_tag, configs, script):#{{{
 		sys.exit(1)
 	
 	baseline_root = configs.get('script_paths', 'baseline_dir')
-	baseline_root = '%s/%s'%(baseline_root, configs.get('script_paths', 'test_dir'))
+
+	if not baseline_root == 'NONE':
+		baseline_root = '%s/%s'%(baseline_root, configs.get('script_paths', 'test_dir'))
 	
 	for child in compare_tag:
 		# Process field comparisions
 		if child.tag == 'field':
 			if not (missing_file1 or missing_file2):
-				process_field_definition(child, configs, script, file1, file2)
+				process_field_definition(child, configs, script, file1, file2, False)
 
-			if not missing_file1:
-				process_field_definition(child, configs, script, file1, '%s/%s'%(baseline_root, file1))
+			if not missing_file1 and not baseline_root == 'NONE':
+				process_field_definition(child, configs, script, file1, '%s/%s'%(baseline_root, file1), True)
 
-			if not missing_file2:
-				process_field_definition(child, configs, script, file2, '%s/%s'%(baseline_root, file2))
+			if not missing_file2 and not baseline_root == 'NONE':
+				process_field_definition(child, configs, script, file2, '%s/%s'%(baseline_root, file2), True)
 		# Process field comparision template
 		elif child.tag == 'template':
 			apply_compare_fields_template(child, compare_tag, configs, script)
@@ -717,7 +719,8 @@ def apply_compare_fields_template(template_tag, compare_tag, configs, script):#{
 
 	# Build the path to the baselines
 	baseline_root = configs.get('script_paths', 'baseline_dir')
-	baseline_root = '%s/%s'%(baseline_root, configs.get('script_paths', 'test_dir'))
+	if not baseline_root == 'NONE':
+		baseline_root = '%s/%s'%(baseline_root, configs.get('script_paths', 'test_dir'))
 
 	# Determine template information, like path and filename
 	template_info = get_template_info(template_tag, configs)
@@ -736,13 +739,13 @@ def apply_compare_fields_template(template_tag, compare_tag, configs, script):#{
 					for field in compare_fields:
 						if field.tag == 'field':
 							if not (missing_file1 or missing_file2):
-								process_field_definition(field, configs, script, file1, file2)
+								process_field_definition(field, configs, script, file1, file2, False)
 
-							if not missing_file1:
-								process_field_definition(field, configs, script, file1, '%s/%s'%(baseline_root, file1))
+							if not missing_file1 and not baseline_root == 'NONE':
+								process_field_definition(field, configs, script, file1, '%s/%s'%(baseline_root, file1), True)
 
-							if not missing_file2:
-								process_field_definition(field, configs, script, file2, '%s/%s'%(baseline_root, file2))
+							if not missing_file2 and not baseline_root == 'NONE':
+								process_field_definition(field, configs, script, file2, '%s/%s'%(baseline_root, file2), True)
 						elif field.tag == 'template':
 							apply_compare_fields_template(field, compare_tag, configs, script)
 
@@ -751,7 +754,7 @@ def apply_compare_fields_template(template_tag, compare_tag, configs, script):#{
 	del template_info
 #}}}
 
-def process_field_definition(field_tag, configs, script, file1, file2):#{{{
+def process_field_definition(field_tag, configs, script, file1, file2, baseline_comp):#{{{
 	# Build the path to the comparision script.
 	compare_executable = '%s/compare_fields.py'%(configs.get('script_paths', 'utility_scripts'))
 
@@ -763,24 +766,26 @@ def process_field_definition(field_tag, configs, script, file1, file2):#{{{
 	command = "%s, '-v', '%s'"%(base_command, field_name)
 	
 	# Determine norm thresholds
-	if 'l1_norm' in field_tag.attrib.keys():
-		command = "%s, '--l1', '%s'"%(command, field_tag.attrib['l1_norm'])
-	if 'l2_norm' in field_tag.attrib.keys():
-		command = "%s, '--l2', '%s'"%(command, field_tag.attrib['l2_norm'])
-	if 'linf_norm' in field_tag.attrib.keys():
-		command = "%s, '--linf', '%s'"%(command, field_tag.attrib['linf_norm'])
+	if not baseline_comp:
+		if 'l1_norm' in field_tag.attrib.keys():
+			command = "%s, '--l1', '%s'"%(command, field_tag.attrib['l1_norm'])
+		if 'l2_norm' in field_tag.attrib.keys():
+			command = "%s, '--l2', '%s'"%(command, field_tag.attrib['l2_norm'])
+		if 'linf_norm' in field_tag.attrib.keys():
+			command = "%s, '--linf', '%s'"%(command, field_tag.attrib['linf_norm'])
+	else:
+		command = "%s, '--l1', '0.0', '--l2', '0.0', '--linf', '0.0'"%(command)
 
 	# Ensure the comparision script has the same environment as the calling script.
 	command = '%s], env=os.environ.copy())'%(command)
 
 	# Write the pass/fail logic.
-	script.write('if os.path.exists("%s") and os.path.exists("%s"):\n'%(file1, file2))
-	script.write('\ttry:\n')
-	script.write('\t\t%s\n'%(command))
-	script.write("\t\tprint ' ** PASS Comparison of %s between %s and %s'\n"%(field_name, file1, file2))
-	script.write('\texcept:\n')
-	script.write("\t\tprint ' ** FAIL Comparison of %s between %s and %s'\n"%(field_name, file1, file2))
-	script.write('\t\terror = True\n')
+	script.write('try:\n')
+	script.write('\t%s\n'%(command))
+	script.write("\tprint ' ** PASS Comparison of %s between %s and %s'\n"%(field_name, file1, file2))
+	script.write('except:\n')
+	script.write("\tprint ' ** FAIL Comparison of %s between %s and %s'\n"%(field_name, file1, file2))
+	script.write('\terror = True\n')
 #}}}
 #}}}
 


### PR DESCRIPTION
This merge updates generated driver scripts within the testing infrastructure to remove the check for file existence before calling the compare fields script (this allows the comparison script to determine a failure if the files are missing). Additionally, this sets the default threshold for all norms when comparing to a baseline to be 0.0, since the assumption is that relative to a baseline an identical run produces identical output.

Finally, this merge also turns off buffering of output in driver scripts.
