### PR TITLE
ok to have null pointer for surfaceTracerFluxRunoff

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -583,10 +583,8 @@ contains
                call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFlux)
 
                ! Get surface flux due to river runoff array
-               if (trim(groupItr % memberName) == 'activeTracers') then
-                  modifiedGroupName = trim(groupItr % memberName) // "SurfaceFluxRunoff"
-                  call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFluxRunoff)
-               endif
+               modifiedGroupName = trim(groupItr % memberName) // "SurfaceFluxRunoff"
+               call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFluxRunoff)
 
                !
                ! initialize tracer surface flux and tendency to zero.


### PR DESCRIPTION
this was causing an error when nTracers > 2 since surfaceTracerFluxRunoff is not defined for any groups except activeTracers.
