### PR TITLE
Bug fixes to test_ocean_state

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -146,7 +146,7 @@ module ocn_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      integer, dimension(:), pointer   :: maxLevelCell
+      integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:), pointer :: indexToCellID
       integer, pointer :: indexTemperature
       integer, pointer :: indexSalinity
@@ -218,7 +218,7 @@ module ocn_time_integration
               if(kineticEnergyCell(k,iCell).gt.4.0_RKIND) then
                  workValue = kineticEnergyCell(k,iCell)
                  workGlobalID(1) = k
-                 workGlobalID(2) = iCell
+                 workGlobalID(2) = indexToCellID(iCell)
                  workLat = latCell(iCell)
                  workLon = lonCell(iCell)
                  write(errorUnit, 10) 'KE= ', workValue, 'cell= ', workGlobalID(2), &
@@ -234,7 +234,7 @@ module ocn_time_integration
               if(activeTracers(indexTemperature,k,iCell).lt.-1.9_RKIND) then
                  workValue = activeTracers(indexTemperature,k,iCell)
                  workGlobalID(1) = k
-                 workGlobalID(2) = iCell
+                 workGlobalID(2) = indexToCellID(iCell)
                  workLat = latCell(iCell)
                  workLon = lonCell(iCell)
                  write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
@@ -249,7 +249,7 @@ module ocn_time_integration
               if(activeTracers(indexTemperature,k,iCell).gt.33.0_RKIND) then
                  workValue = activeTracers(indexTemperature,k,iCell)
                  workGlobalID(1) = k
-                 workGlobalID(2) = iCell
+                 workGlobalID(2) = indexToCellID(iCell)
                  workLat = latCell(iCell)
                  workLon = lonCell(iCell)
                  write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
@@ -264,7 +264,7 @@ module ocn_time_integration
               if(activeTracers(indexSalinity,k,iCell).lt.0.0_RKIND) then
                  workValue = activeTracers(indexSalinity,k,iCell)
                  workGlobalID(1) = k
-                 workGlobalID(2) = iCell
+                 workGlobalID(2) = indexToCellID(iCell)
                  workLat = latCell(iCell)
                  workLon = lonCell(iCell)
                  write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &
@@ -279,7 +279,7 @@ module ocn_time_integration
               if(layerThickness(k,iCell).lt.1.0e-2_RKIND) then
                  workValue = layerThickness(k,iCell)
                  workGlobalID(1) = k
-                 workGlobalID(2) = iCell
+                 workGlobalID(2) = indexToCellID(iCell)
                  workLat = latCell(iCell)
                  workLon = lonCell(iCell)
                  write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &


### PR DESCRIPTION
Added a mpas_release_unit call because of the potential for a unit number leak
Added "MPAS-Ocean: " before the mpas_dmpar_global_abort call for consistency with other messages
