### PR TITLE
Change computation of Bulk Richardson Number

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -454,8 +454,8 @@ contains
 
                bulkRichardsonNumberShear(kIndexOBL,iCell) = max(deltaVelocitySquared, 1.0e-15_RKIND)
 
-               bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity * (density(kIndexOBL,iCell) - &
-                                 sum(density(1:kav,iCell))/real(kav, kind=RKIND)) / rho_sw
+               bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity * (potentialDensity(kIndexOBL,iCell) - &
+                                 sum(potentialDensity(1:kav,iCell))/real(kav, kind=RKIND)) / rho_sw
 
               enddo ! do kIndexOBL
 !             call mpas_timer_stop('Bulk Richardson kIndexOBL loop')


### PR DESCRIPTION
This merge makes a very small change in the computation of the bulk
Richardson number used to calculate the boundary layer depth in KPP.
Previously, the in-situ density was used to determine the density
difference between a large, boundary layer eddy and the local density.
As these eddies may traverse a large distance, it makes sense to use
the potentialDensity instead, as this is conserved for adiabatic
displacements.
