### PR TITLE
Fix bug in assigning names to var_array constituents when packages are used

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1219,7 +1219,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 			fortprintf(fd, "      if (associated(newSubPool)) then\n");
 			fortprintf(fd, "         call mpas_pool_get_dimension(newSubPool, 'index_%s', const_index)\n", varname_in_code);
 			fortprintf(fd, "      end if\n");
-			fortprintf(fd, "      if (index_counter > 0) then\n", spacing);
+			fortprintf(fd, "      if (const_index > 0) then\n", spacing);
 			fortprintf(fd, "         %s(%d) %% constituentNames(const_index) = '%s'\n", pointer_name, time_lev, varname);
 			fortprintf(fd, "      end if\n", spacing);
 		}


### PR DESCRIPTION
This merge fixes a bug in the registry that caused incorrect code to be generated
for determining whether to set the names of constituents in var_arrays when packages 
are used on individual constituents.
