### PR TITLE
Fix write of restart_timestamp file

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -552,9 +552,11 @@ module ocn_forward_mode
 
          if ( mpas_stream_mgr_ringing_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_OUTPUT, &
                                              ierr=ierr) ) then
-            open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
-            write(22, *) trim(timeStamp)
-            close(22)
+            if ( domain % dminfo % my_proc_id == 0 ) then
+               open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
+               write(22, *) trim(timeStamp)
+               close(22)
+            end if
 
             if(trim(config_sw_absorption_type)=='ohlmann00') call ocn_shortwave_forcing_write_restart(domain)
          end if


### PR DESCRIPTION
This merge updates the write of the restart_timestamp file within the
ocean core. Specifically, it only writes this file after a restart file
has been written, and additionally it only allows the master process to
write out this file to prevent multiple processors from writing the same
file.
