### PR TITLE
Add pressureAdjustedSSH as a diagnostic field

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2385,6 +2385,9 @@
 			description="A mask indicating where layer interface and thickness smoothing is to be performed during Haney number constrained initializaiton."
 			 packages="initMode"
 		/>
+		<var name="pressureAdjustedSSH" type="real" dimensions="nCells Time" units="m"
+			 description="sea surface height adjusted by sea surface pressure"
+		/>
 	</var_struct>
 	<var_struct name="shortwave" time_levs="1">
 		<!-- **********************************************************************

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -113,7 +113,8 @@ contains
       real (kind=RKIND), dimension(:), allocatable:: pTop, div_hu,div_huTransport,div_huGMBolus
 
       real (kind=RKIND), dimension(:), pointer :: &
-        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh, seaSurfacePressure, frazilSurfacePressure
+        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh, seaSurfacePressure, frazilSurfacePressure, &
+        pressureAdjustedSSH
       real (kind=RKIND), dimension(:,:), pointer :: &
         weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
@@ -195,6 +196,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
       call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
 
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', kiteAreasOnVertex)
@@ -799,13 +801,18 @@ contains
                                          diagnosticsPool, timeLevel)
       call mpas_timer_stop("land_ice_diagnostic_fields")
 
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaSurfacePressure(iCell) / ( gravity * rho_sw ) )
+      end do
+      !$omp end do
+
       !$omp do schedule(runtime) private(cell1, cell2)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
 
-         gradSSH(1, iEdge) = edgeMask(1, iEdge) * ( (ssh(cell2) + seaSurfacePressure(cell2)) - (ssh(cell1) &
-                           + seaSurfacePressure(cell1)) ) / (gravity * rho_sw ) / dcEdge(iEdge)
+         gradSSH(1, iEdge) = edgeMask(1, iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
       end do
       !$omp end do
 


### PR DESCRIPTION
This merge adds a diagnostic field pressureAdjustedSSH, which is the
model sea surface height adjusted based on the surface pressure
depression.

It also updates the computation of the SSH gradient to use this
pressureAdjustedSSH field rather than adjusting the SSH inline.
