### PR TITLE
Add writeTime as an optional parameter when writing stream

### DIFF
--- a/src/core_test/mpas_test_core_streams.F
+++ b/src/core_test/mpas_test_core_streams.F
@@ -130,6 +130,18 @@ module test_core_streams
          return
       end if
 
+      call MPAS_stream_mgr_create_stream(domain % streamManager, 'R8_time_stream', MPAS_STREAM_OUTPUT, 'r8_data.$Y-$M-$D-$d_$h.$m.$s.nc', &
+                                         filenameInterval="0001-00-00_00:00:00", &
+                                         realPrecision=MPAS_IO_DOUBLE_PRECISION, &
+                                         clobberMode=MPAS_STREAM_CLOBBER_TRUNCATE, &
+                                         ierr=local_ierr)
+      if (local_ierr /= MPAS_STREAM_MGR_NOERR) then
+         ierr = 1
+         write(stderrUnit,*) 'Error creating ''R8_stream''.'
+         return
+      end if
+
+
       call MPAS_stream_mgr_add_field(domain % streamManager, 'R4_stream', 'xtime', ierr=local_ierr)
       call MPAS_stream_mgr_add_field(domain % streamManager, 'R4_stream', 'cellPersistReal5D', ierr=local_ierr)
       call MPAS_stream_mgr_add_field(domain % streamManager, 'R4_stream', 'cellPersistReal4D', ierr=local_ierr)
@@ -140,8 +152,12 @@ module test_core_streams
 
       call MPAS_stream_mgr_add_stream_fields(domain % streamManager, 'R8_stream', 'R4_stream', ierr=local_ierr)
 
+      call MPAS_stream_mgr_add_stream_fields(domain % streamManager, 'R8_time_stream', 'R4_stream', ierr=local_ierr)
+
       call MPAS_stream_mgr_write(domain % streamManager, 'R4_stream', forceWriteNow=.true., ierr=local_ierr)
       call MPAS_stream_mgr_write(domain % streamManager, 'R8_stream', forceWriteNow=.true., ierr=local_ierr)
+      call MPAS_stream_mgr_write(domain % streamManager, 'R8_time_stream', forceWriteNow=.true., ierr=local_ierr)
+      call MPAS_stream_mgr_write(domain % streamManager, 'R8_time_stream', forceWriteNow=.true., writeTime="9999-01-01_00:00:00", ierr=local_ierr)
 
 
       !

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -2310,10 +2310,13 @@ module mpas_stream_manager
     !>  The "forceWriteNow" argument optionally specifies that all streams -- or 
     !>  the stream specified by the "streamID" argument -- should be written by 
     !>  the call regardless of whether any alarms associated with the stream(s) 
-    !>  are ringing.
+    !>  are ringing. The "writeTime" argument optionally specifies a time stamp
+    !>  to be used for expanding a filename template, when it is not passed in,
+    !>  the current time of the streamManager's clock is used to expand filename
+    !>  templates.
     !
     !-----------------------------------------------------------------------
-    subroutine MPAS_stream_mgr_write(manager, streamID, timeLevel, mgLevel, forceWriteNow, ierr) !{{{
+    subroutine MPAS_stream_mgr_write(manager, streamID, timeLevel, mgLevel, forceWriteNow, writeTime, ierr) !{{{
 
         implicit none
 
@@ -2322,6 +2325,7 @@ module mpas_stream_manager
         integer, intent(in), optional :: timeLevel
         integer, intent(in), optional :: mgLevel
         logical, intent(in), optional :: forceWriteNow
+        character (len=*), intent(in), optional :: writeTime
         integer, intent(out), optional :: ierr
 
         type (MPAS_stream_list_type), pointer :: stream_cursor
@@ -2329,6 +2333,7 @@ module mpas_stream_manager
         integer :: local_mgLevel
         logical :: local_forceWrite
         integer :: local_ierr
+        type (MPAS_Time_type) :: local_writeTime
         integer :: temp_ierr
         integer :: threadNum
 
@@ -2361,6 +2366,13 @@ module mpas_stream_manager
         end if
 
 
+        if ( present(writeTime) ) then
+            call mpas_set_time(local_writeTime, dateTimeString=writeTime, ierr=ierr)
+        else
+            local_writeTime = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
+        end if
+
+
         if ( threadNum == 0 ) then
            !
            ! If a stream is specified, we process just that stream; otherwise,
@@ -2379,7 +2391,7 @@ module mpas_stream_manager
                        return 
                    end if
 
-                   call write_stream(manager, stream_cursor, local_timeLevel, local_mgLevel, local_forceWrite, local_ierr)
+                   call write_stream(manager, stream_cursor, local_timeLevel, local_mgLevel, local_forceWrite, local_writeTime, local_ierr)
                else
                    STREAM_ERROR_WRITE('Stream '//trim(streamID)//' does not exist in call to MPAS_stream_mgr_write().')
                    if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
@@ -2395,7 +2407,7 @@ module mpas_stream_manager
                    if (stream_cursor % direction == MPAS_STREAM_OUTPUT .or. &
                        stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
 
-                       call write_stream(manager, stream_cursor, local_timeLevel, local_mgLevel, local_forceWrite, temp_ierr)
+                       call write_stream(manager, stream_cursor, local_timeLevel, local_mgLevel, local_forceWrite, local_writeTime, temp_ierr)
                        if (temp_ierr /= MPAS_STREAM_MGR_NOERR) then
                            local_ierr = temp_ierr
                        end if
@@ -2421,7 +2433,7 @@ module mpas_stream_manager
     !>  Private subroutine to handle the details of actually writing a stream.
     !
     !-----------------------------------------------------------------------
-    subroutine write_stream(manager, stream, timeLevel, mgLevel, forceWritenow, ierr) !{{{
+    subroutine write_stream(manager, stream, timeLevel, mgLevel, forceWritenow, writeTime, ierr) !{{{
 
         implicit none
 
@@ -2430,10 +2442,11 @@ module mpas_stream_manager
         integer, intent(in) :: timeLevel
         integer, intent(in) :: mgLevel
         logical, intent(in) :: forceWriteNow
+        type (MPAS_Time_type), intent(in) :: writeTime
         integer, intent(out) :: ierr
 
         type (MPAS_stream_list_type), pointer :: alarm_cursor
-        type (MPAS_Time_type) :: now_time, ref_time
+        type (MPAS_Time_type) :: ref_time
         type (MPAS_TimeInterval_type) :: temp_interval
         type (MPAS_TimeInterval_type) :: filename_interval
         character (len=StrKIND) :: now_string, time_string
@@ -2513,9 +2526,8 @@ module mpas_stream_manager
            !
            if (.not. stream % valid) then
                if ( stream % filename_interval /= 'none' ) then
-                   now_time = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
                    call mpas_set_timeInterval(filename_interval, timeString=stream % filename_interval)
-                   call mpas_build_stream_filename(stream % referenceTime, now_time, filename_interval, stream % filename_template, stream % filename, ierr=local_ierr)
+                   call mpas_build_stream_filename(stream % referenceTime, writeTime, filename_interval, stream % filename_template, stream % filename, ierr=local_ierr)
                else
                    call mpas_get_time(stream % referenceTime, dateTimeString=time_string)
                    call mpas_expand_string(time_string, stream % filename_template, stream % filename)
@@ -2559,8 +2571,7 @@ module mpas_stream_manager
                ! File exists on disk, prior to creating stream. Need to seek the record to ensure we're writing to the correct place.
                if ( recordSeek ) then
                    STREAM_DEBUG_WRITE(' -- File exists on disk: ' COMMA trim(stream % filename))
-                   now_time = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
-                   call mpas_get_time(now_time, dateTimeString=now_string)
+                   call mpas_get_time(writeTime, dateTimeString=now_string)
     
                    ! Look for exact record (in the case of overwriting)
                    ! This also gets the number of records in the file.
@@ -2586,10 +2597,9 @@ module mpas_stream_manager
                stream % valid = .true.
            else
                if ( stream % filename_interval /= 'none' ) then
-                   now_time = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
                    call mpas_set_timeInterval(filename_interval, timeString=stream % filename_interval)
     
-                   call mpas_build_stream_filename(stream % referenceTime, now_time, filename_interval, stream % filename_template, temp_filename, ierr=local_ierr)
+                   call mpas_build_stream_filename(stream % referenceTime, writeTime, filename_interval, stream % filename_template, temp_filename, ierr=local_ierr)
                else
                    call mpas_get_time(stream % referenceTime, dateTimeString=time_string)
                    call mpas_expand_string(time_string, stream % filename_template, temp_filename)
@@ -2646,8 +2656,7 @@ module mpas_stream_manager
                    ! File exists on disk, prior to creating stream. Need to seek the record to ensure we're writing to the correct place.
                    if ( recordSeek ) then
                        STREAM_DEBUG_WRITE(' -- File exists on disk: ' COMMA trim(stream % filename))
-                       now_time = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
-                       call mpas_get_time(now_time, dateTimeString=now_string)
+                       call mpas_get_time(writeTime, dateTimeString=now_string)
            
                        ! Look for exact record (in the case of overwriting)
                        ! This also gets the number of records in the file.
@@ -2672,8 +2681,7 @@ module mpas_stream_manager
                else
                    stream % nRecords = stream % nRecords + 1
                    if ( stream % clobber_mode == MPAS_STREAM_CLOBBER_OVERWRITE .or. stream % clobber_mode == MPAS_STREAM_CLOBBER_APPEND ) then
-                       now_time = mpas_get_clock_time(manager % streamClock, MPAS_NOW, ierr=local_ierr)
-                       call mpas_get_time(now_time, dateTimeString=now_string)
+                       call mpas_get_time(writeTime, dateTimeString=now_string)
            
                        ! Look for exact record (in the case of overwriting)
                        ! This also gets the number of records in the file.


### PR DESCRIPTION
This merge adds a character string 'writeTime' as an optional paramter
to the mpas_stream_mgr_write routine, which can define the time you want
the data to be written at. This is useful to help manipulate the
filename of the data, if you want it at a different time stamp than the
current time of the clock.

If the writeTime is not passed in, it defaults to the current time of
the clock associated with the stream manager.

A test is also added to the test core to help exercise this
functionality.
