### PR TITLE
Remove a previous temporary fix on boundary layer depth

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -478,12 +478,8 @@ contains
              endif  ! if (config_use_cvmix_fixed_boundary_layer) then
 
              ! apply minimum limit to OBL
-             ! DWJ 03/02/2016 : change default to 10m to help with coupled simulations.
-             !if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(1,iCell)/2.0_RKIND) then
-             !   cvmix_variables % BoundaryLayerDepth = layerThickness(1,iCell)/2.0_RKIND
-
-             if(cvmix_variables % BoundaryLayerDepth .lt. 10.0_RKIND) then
-                cvmix_variables % BoundaryLayerDepth = 10.0_RKIND
+             if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(1,iCell)/2.0_RKIND) then
+                cvmix_variables % BoundaryLayerDepth = layerThickness(1,iCell)/2.0_RKIND
                 cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
                           zw_iface = cvmix_variables%zw_iface(1:nVertLevels+1),&
                           zt_cntr = cvmix_variables%zt_cntr(1:nVertLevels),    &


### PR DESCRIPTION
This merge removes a previous fix to force the minimum boundary layer
depth to be 10m everywhere.

It is no longer needed, as now the boundary layer depth minimum is set
to 10m where sea ice has a fractional coverage of at least 0.15.
