### PR TITLE
Add QU_240km restart_test

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/.gitignore
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/.gitignore
@@ -1,0 +1,5 @@
+run_test.py
+init_step1
+init_step2
+full_run
+restart_run

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_driver.xml
@@ -1,0 +1,19 @@
+<driver_script name="run_test.py">
+	<case name="init_step1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message="  - Complete"/>
+	</case>
+	<case name="init_step2">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="  - Complete"/>
+	</case>
+	<case name="full_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running full_run" post_message="  - Complete"/>
+	</case>
+	<case name="restart_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running restart_run" post_message="  - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="full_run/output.nc" file2="restart_run/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_full_run.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_full_run.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="full_run">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init1.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<config case="init_step1">
+
+	<get_file hash="ph1dyjmvcc" dest_path="mesh_database" file_name="mesh.QU.10242.151022.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<get_file dest_path="mesh_database" file_name="graph.QU.10242.151022.info">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
+
+	<add_link source_path="mesh_database" source="mesh.QU.10242.151022.nc" dest="base_mesh.nc"/>
+	<add_link source_path="mesh_database" source="graph.QU.10242.151022.info" dest="graph.info"/>
+	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
+	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
+	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_init1.xml" path_base="script_configuration_dir"/>
+		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_init1.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+
+		<step executable="./MpasCellCuller.x">
+			<argument flag="">ocean.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<config case="init_step2">
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<add_link source="../init_step1/culled_mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source="../init_step1/temperature.nc" dest="temperature.nc"/>
+	<add_link source="../init_step1/salinity.nc" dest="salinity.nc"/>
+	<add_link source="../init_step1/wind_stress.nc" dest="wind_stress.nc"/>
+	<add_link source="../init_step1/topography.nc" dest="topography.nc"/>
+	<add_link source="../init_step1/swData.nc" dest="swData.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
+		<option name="config_use_debugTracers">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_restart_run.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_restart_run.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<config case="restart_run">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_do_restart">.true.</option>
+		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
+		<option name="config_start_time">'0000-01-01_04:00:00'</option>
+		<option name="config_run_duration">'04:00:00'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
+		<stream name="output">
+			<attribute name="output_interval">0000_04:00:00</attribute>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/restart_setup_template.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/restart_setup_template.xml
@@ -1,0 +1,17 @@
+<template>
+	<namelist>
+		<option name="config_start_time">0000-01-01_00:00:00</option>
+		<option name="config_run_duration">'0000_08:00:00'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+	</namelist>
+	<streams>
+		<stream name="output">
+			<attribute name="output_interval">0000-00-00_08:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="filename_template">../restarts/rst.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="filename_interval">output_interval</attribute>
+			<attribute name="output_interval">0000-00-00_00:00:01</attribute>
+		</stream>
+	</streams>
+</template>

--- a/test_cases/ocean/ocean/regression_suites/nightly.xml
+++ b/test_cases/ocean/ocean/regression_suites/nightly.xml
@@ -1,5 +1,5 @@
 <regression_suite name="nightly_ocean_test_suite">
-	<test name="Global Ocean 240km - Smoke Test" core="ocean" configuration="global_ocean" resolution="QU_240km" test="default">
+	<test name="Global Ocean 240km - Restart Test" core="ocean" configuration="global_ocean" resolution="QU_240km" test="restart_test">
 		<script name="run_test.py"/>
 	</test>
 	<test name="ZISO 20km - Smoke Test" core="ocean" configuration="ziso" resolution="20km" test="default">


### PR DESCRIPTION
This merge adds a restart test for the QU_240km global ocean domain, to
help test restarts in realistic configurations.
