### PR TITLE
Add -n flag when creating symlinks in setup_testcases

### DIFF
--- a/test_cases/ocean/setup_testcase.py
+++ b/test_cases/ocean/setup_testcase.py
@@ -1055,7 +1055,7 @@ def add_links(config_file, configs):#{{{
 			old_cwd = os.getcwd()
 			os.chdir(base_path)
 
-			subprocess.check_call(['ln', '-sf', '%s'%(source_file), '%s'%(dest)], stdout=dev_null, stderr=dev_null, env=os.environ.copy())
+			subprocess.check_call(['ln', '-sfn', '%s'%(source_file), '%s'%(dest)], stdout=dev_null, stderr=dev_null, env=os.environ.copy())
 			os.chdir(old_cwd)
 			del source
 			del dest


### PR DESCRIPTION
Without the -n flag, ln -sf creates a link _within_ the linked
directory, rather than replacing the link to the directory.
