### PR TITLE
Change QU_120km/default from 60 to 100 layers.

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init1.xml
@@ -5,11 +5,11 @@
 		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
 	</get_file>
 
-	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
+	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
 		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
 	</get_file>
 
-	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
+	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
 		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
 	</get_file>
 
@@ -31,15 +31,14 @@
 
 	<add_link source_path="mesh_database" source="mesh.QU.120km.151026.nc" dest="base_mesh.nc"/>
 	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
-	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
-	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="PTemp.Jan_p3.filled.mpas100levs.160127.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc" dest="salinity.nc"/>
 	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
 	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init1.xml" path_base="script_core_dir" path="global_ocean"/>
-		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
@@ -52,9 +51,9 @@
 			<argument flag="-f">base_mesh.nc</argument>
 		</step>
 		<step executable="./metis">
-			<argument flag="graph.info">2</argument>
+			<argument flag="graph.info">4</argument>
 		</step>
-		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
 		</step>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init2.xml
@@ -14,7 +14,6 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
@@ -23,11 +22,11 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">2</argument>
+			<argument flag="graph.info">4</argument>
 		</step>
 		<step executable="./metis">
-			<argument flag="graph.info">2</argument>
+			<argument flag="graph.info">4</argument>
 		</step>
-		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/template_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/template_forward.xml
@@ -1,7 +1,7 @@
 <template>
 	<namelist>
-		<option name="config_dt">'00:48:00'</option>
-		<option name="config_run_duration">'0000_02:24:00'</option>
+		<option name="config_dt">'00:45:00'</option>
+		<option name="config_run_duration">'0000_01:30:00'</option>
 		<option name="config_mom_del4">2.6e13</option>
 	</namelist>
 </template>


### PR DESCRIPTION
The standard vertical resolution is now 100 layers, but all QU test cases currently use 60.  This is a first in a series of PRs to change all global cases to 100 layers.

In addition, I changed this case from 2 to 4 processors for speed, and from dt=48 to dt=45 minutes, for more friendly intervals.

This commit is non bit-for-bit for the QU_120km/default.
