### PR TITLE
Move ocean state checker to the debug diagnostics AM

### DIFF
--- a/src/core_ocean/analysis_members/Registry_debug_diagnostics.xml
+++ b/src/core_ocean/analysis_members/Registry_debug_diagnostics.xml
@@ -19,6 +19,10 @@
 			description="Logical flag determining if an analysis member write occurs on start-up."
 			possible_values=".true. or .false."
 		/>
+		<nml_option name="config_AM_debugDiagnostics_check_state" type="logical" default_value=".false." units="unitless"
+			description="Logical flag determining if state checking happens when the debug diagnostics AM is called."
+			possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<packages>
 		<package name="debugDiagnosticsAMPKG" description="This package includes variables required for the debugDiagnostics analysis member."/>

--- a/src/core_ocean/analysis_members/mpas_ocn_debug_diagnostics.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_debug_diagnostics.F
@@ -172,7 +172,12 @@ contains
       real (kind=RKIND), dimension(:), pointer :: rx1MaxCell
       real (kind=RKIND), dimension(:,:), pointer :: zMid
 
+      logical, pointer :: config_AM_debugDiagnostics_check_state
+
       err = 0
+
+      call mpas_pool_get_config(domain % configs, 'config_AM_debugDiagnostics_check_state', &
+                                config_AM_debugDiagnostics_check_state)
 
       localMaxRx1 = 0.0_RKIND
 
@@ -184,6 +189,10 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          !call mpas_pool_get_subpool(block % structs, 'debugDiagnosticsAM', debugDiagnosticsAMPool)
+
+         if ( config_AM_debugDiagnostics_check_state ) then
+            call ocn_test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)
+         end if
 
          ! Here are some example variables which may be needed for your analysis member
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -334,6 +343,168 @@ contains
       err = 0
 
    end subroutine ocn_finalize_debug_diagnostics!}}}
+
+   subroutine ocn_test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)!{{{
+
+      type (dm_info) :: dminfo
+      type (mpas_pool_type), pointer :: statePool, meshPool, diagnosticsPool, tracersPool
+      character (len=StrKIND), pointer :: xtime
+      real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: indexToCellID
+      integer, pointer :: indexTemperature
+      integer, pointer :: indexSalinity
+      integer, pointer :: nCellsSolve
+      real (kind=RKIND) :: nanCheck, workValue, workLat, workLon
+      integer :: workGlobalID(2), errorUnit, mpiRank, iCell, k
+      logical :: errorFlag
+      character(len=StrKIND) :: charMPIRank, charFilename
+
+      !get all pointers that might be needed
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+      call mpas_pool_get_array(meshPool, 'latCell', latCell)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 2)
+      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 2)
+
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 2)
+
+      !assume that no abnormal values exist
+      errorFlag = .false.
+
+      !now step through tests to see if abnormal values do exist
+      !if so, reset errorFlag to be true
+
+      ! test for abnormal values
+      do iCell=1,nCellsSolve
+         do k=1,maxLevelCell(iCell)
+            if(kineticEnergyCell(k,iCell).gt.4.0_RKIND) errorFlag=.true.
+            if(activeTracers(indexTemperature,k,iCell).lt.-1.9_RKIND) errorFlag=.true.
+            if(activeTracers(indexTemperature,k,iCell).gt.33.0_RKIND) errorFlag=.true.
+            if(activeTracers(indexSalinity,k,iCell).lt.0.0_RKIND) errorFlag=.true.
+            if(layerThickness(k,iCell).lt.1.0e-2_RKIND) errorFlag=.true.
+         enddo
+      enddo
+
+      !if an errorFlag exists, then
+      !  1) open a file
+      !  2) step through tests again and write the file
+      !  3) close file
+
+      if(errorFlag) then
+
+        !find an open unit
+        call mpas_new_unit(errorUnit)
+        mpiRank = dminfo % my_proc_id
+        charFilename = 'mpas_ocean_state_test_'
+        if(                       mpiRank.le.     9) write(charMPIRank,'(I1)') mpiRank
+        if(mpiRank.gt.    9 .and. mpiRank.le.    99) write(charMPIRank,'(I2)') mpiRank
+        if(mpiRank.gt.   99 .and. mpiRank.le.   999) write(charMPIRank,'(I3)') mpiRank
+        if(mpiRank.gt.  999 .and. mpiRank.le.  9999) write(charMPIRank,'(I4)') mpiRank
+        if(mpiRank.gt. 9999 .and. mpiRank.le. 99999) write(charMPIRank,'(I5)') mpiRank
+        if(mpiRank.gt.99999 .and. mpiRank.le.999999) write(charMPIRank,'(I6)') mpiRank
+        charFilename = trim(charFilename) // trim(charMPIRank)
+        open(unit=errorUnit, file=charFilename, form='formatted', status='unknown', position='append')
+
+        !write time
+        write(errorUnit,'(a80)') trim(xtime)
+
+        !test to see if cell kinetic energy is greater than 4.0 m2/s2
+        do iCell=1,nCellsSolve
+           do k=1,maxLevelCell(iCell)
+              if(kineticEnergyCell(k,iCell).gt.4.0_RKIND) then
+                 workValue = kineticEnergyCell(k,iCell)
+                 workGlobalID(1) = k
+                 workGlobalID(2) = indexToCellID(iCell)
+                 workLat = latCell(iCell)
+                 workLon = lonCell(iCell)
+                 write(errorUnit, 10) 'KE= ', workValue, 'cell= ', workGlobalID(2), &
+                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
+                 10 format(a4,e10.3, 3x,a6,i8, 3x,a3,i4, 3x,a6,f6.2, 3x,a6,f6.2)
+              endif
+           enddo
+        enddo
+
+        !test to see if cell temperature is less than -1.9C
+        do iCell=1,nCellsSolve
+           do k=1,maxLevelCell(iCell)
+              if(activeTracers(indexTemperature,k,iCell).lt.-1.9_RKIND) then
+                 workValue = activeTracers(indexTemperature,k,iCell)
+                 workGlobalID(1) = k
+                 workGlobalID(2) = indexToCellID(iCell)
+                 workLat = latCell(iCell)
+                 workLon = lonCell(iCell)
+                 write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
+                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
+              endif
+           enddo
+        enddo
+
+        !test to see if cell temperature is greater than 33.0
+        do iCell=1,nCellsSolve
+           do k=1,maxLevelCell(iCell)
+              if(activeTracers(indexTemperature,k,iCell).gt.33.0_RKIND) then
+                 workValue = activeTracers(indexTemperature,k,iCell)
+                 workGlobalID(1) = k
+                 workGlobalID(2) = indexToCellID(iCell)
+                 workLat = latCell(iCell)
+                 workLon = lonCell(iCell)
+                 write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
+                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
+              endif
+           enddo
+        enddo
+
+        !test to see if cell salinity is less than 0
+        do iCell=1,nCellsSolve
+           do k=1,maxLevelCell(iCell)
+              if(activeTracers(indexSalinity,k,iCell).lt.0.0_RKIND) then
+                 workValue = activeTracers(indexSalinity,k,iCell)
+                 workGlobalID(1) = k
+                 workGlobalID(2) = indexToCellID(iCell)
+                 workLat = latCell(iCell)
+                 workLon = lonCell(iCell)
+                 write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &
+                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
+              endif
+           enddo
+        enddo
+
+        !test to see if cell thickness is less than 1.0e-2
+        do iCell=1,nCellsSolve
+           do k=1,maxLevelCell(iCell)
+              if(layerThickness(k,iCell).lt.1.0e-2_RKIND) then
+                 workValue = layerThickness(k,iCell)
+                 workGlobalID(1) = k
+                 workGlobalID(2) = indexToCellID(iCell)
+                 workLat = latCell(iCell)
+                 workLon = lonCell(iCell)
+                 write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &
+                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
+              endif
+           enddo
+        enddo
+
+        write(errorUnit,*) ''
+
+        !close unit
+        close(errorUnit)
+        call mpas_release_unit(errorUnit)
+
+      endif ! if(errorFlag)
+
+   end subroutine ocn_test_ocean_state!}}}
 
 end module ocn_debug_diagnostics
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -102,6 +102,8 @@ module ocn_time_integration
       real (kind=RKIND), pointer :: daysSinceStartOfSim
       character (len=StrKIND), pointer :: simulationStartTime
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
+      real (kind=RKIND) :: nanCheck
+      real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
 
 
       if (rk4On) then
@@ -128,184 +130,17 @@ module ocn_time_integration
         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
 
-        ! test ocean state for abnormal values and NaNs in the velocity field
-        call test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)
+        !now test for NaNs in the ocean velocity field and abort if true
+        call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 2)
+        call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+        nanCheck = sum(normalVelocity)
+        if (nanCheck /= nanCheck) then
+           write(stderrUnit,*) 'Ocean Abort: NaN detected'
+           call mpas_dmpar_global_abort('MPAS-ocean: time_integration: NaN detected')
+        endif
 
         block => block % next
      end do
-
-   contains
-
-   subroutine test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)
-
-      type (dm_info) :: dminfo
-      type (mpas_pool_type), pointer :: statePool, meshPool, diagnosticsPool, tracersPool
-      character (len=StrKIND), pointer :: xtime
-      real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      integer, dimension(:), pointer :: maxLevelCell
-      integer, dimension(:), pointer :: indexToCellID
-      integer, pointer :: indexTemperature
-      integer, pointer :: indexSalinity
-      integer, pointer :: nCellsSolve
-      real (kind=RKIND) :: nanCheck, workValue, workLat, workLon
-      integer :: workGlobalID(2), errorUnit, mpiRank, iCell, k
-      logical :: errorFlag
-      character(len=StrKIND) :: charMPIRank, charFilename
-
-      !get all pointers that might be needed
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
-      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-      call mpas_pool_get_array(meshPool, 'latCell', latCell)
-      call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 2)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 2)
-
-      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 2)
-
-      !assume that no abnormal values exist
-      errorFlag = .false.
-
-      !now step through tests to see if abnormal values do exist
-      !if so, reset errorFlag to be true
-
-      ! test for abnormal values
-      do iCell=1,nCellsSolve
-         do k=1,maxLevelCell(iCell)
-            if(kineticEnergyCell(k,iCell).gt.4.0_RKIND) errorFlag=.true.
-            if(activeTracers(indexTemperature,k,iCell).lt.-1.9_RKIND) errorFlag=.true.
-            if(activeTracers(indexTemperature,k,iCell).gt.33.0_RKIND) errorFlag=.true.
-            if(activeTracers(indexSalinity,k,iCell).lt.0.0_RKIND) errorFlag=.true.
-            if(layerThickness(k,iCell).lt.1.0e-2_RKIND) errorFlag=.true.
-         enddo
-      enddo
-
-      !if an errorFlag exists, then
-      !  1) open a file
-      !  2) step through tests again and write the file
-      !  3) close file
-
-      if(errorFlag) then
-
-        !find an open unit
-        call mpas_new_unit(errorUnit)
-        mpiRank = dminfo % my_proc_id
-        charFilename = 'mpas_ocean_state_test_'
-        if(                       mpiRank.le.     9) write(charMPIRank,'(I1)') mpiRank
-        if(mpiRank.gt.    9 .and. mpiRank.le.    99) write(charMPIRank,'(I2)') mpiRank
-        if(mpiRank.gt.   99 .and. mpiRank.le.   999) write(charMPIRank,'(I3)') mpiRank
-        if(mpiRank.gt.  999 .and. mpiRank.le.  9999) write(charMPIRank,'(I4)') mpiRank
-        if(mpiRank.gt. 9999 .and. mpiRank.le. 99999) write(charMPIRank,'(I5)') mpiRank
-        if(mpiRank.gt.99999 .and. mpiRank.le.999999) write(charMPIRank,'(I6)') mpiRank
-        charFilename = trim(charFilename) // trim(charMPIRank)
-        open(unit=errorUnit, file=charFilename, form='formatted', status='unknown', position='append')
-
-        !write time
-        write(errorUnit,'(a80)') trim(xtime)
-
-        !test to see if cell kinetic energy is greater than 4.0 m2/s2
-        do iCell=1,nCellsSolve
-           do k=1,maxLevelCell(iCell)
-              if(kineticEnergyCell(k,iCell).gt.4.0_RKIND) then
-                 workValue = kineticEnergyCell(k,iCell)
-                 workGlobalID(1) = k
-                 workGlobalID(2) = indexToCellID(iCell)
-                 workLat = latCell(iCell)
-                 workLon = lonCell(iCell)
-                 write(errorUnit, 10) 'KE= ', workValue, 'cell= ', workGlobalID(2), &
-                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
-                 10 format(a4,e10.3, 3x,a6,i8, 3x,a3,i4, 3x,a6,f6.2, 3x,a6,f6.2)
-              endif
-           enddo
-        enddo
-
-        !test to see if cell temperature is less than -1.9C
-        do iCell=1,nCellsSolve
-           do k=1,maxLevelCell(iCell)
-              if(activeTracers(indexTemperature,k,iCell).lt.-1.9_RKIND) then
-                 workValue = activeTracers(indexTemperature,k,iCell)
-                 workGlobalID(1) = k
-                 workGlobalID(2) = indexToCellID(iCell)
-                 workLat = latCell(iCell)
-                 workLon = lonCell(iCell)
-                 write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
-                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
-              endif
-           enddo
-        enddo
-
-        !test to see if cell temperature is greater than 33.0
-        do iCell=1,nCellsSolve
-           do k=1,maxLevelCell(iCell)
-              if(activeTracers(indexTemperature,k,iCell).gt.33.0_RKIND) then
-                 workValue = activeTracers(indexTemperature,k,iCell)
-                 workGlobalID(1) = k
-                 workGlobalID(2) = indexToCellID(iCell)
-                 workLat = latCell(iCell)
-                 workLon = lonCell(iCell)
-                 write(errorUnit, 10) 'T= ', workValue, 'cell= ', workGlobalID(2), &
-                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
-              endif
-           enddo
-        enddo
-
-        !test to see if cell salinity is less than 0
-        do iCell=1,nCellsSolve
-           do k=1,maxLevelCell(iCell)
-              if(activeTracers(indexSalinity,k,iCell).lt.0.0_RKIND) then
-                 workValue = activeTracers(indexSalinity,k,iCell)
-                 workGlobalID(1) = k
-                 workGlobalID(2) = indexToCellID(iCell)
-                 workLat = latCell(iCell)
-                 workLon = lonCell(iCell)
-                 write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &
-                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
-              endif
-           enddo
-        enddo
-
-        !test to see if cell thickness is less than 1.0e-2
-        do iCell=1,nCellsSolve
-           do k=1,maxLevelCell(iCell)
-              if(layerThickness(k,iCell).lt.1.0e-2_RKIND) then
-                 workValue = layerThickness(k,iCell)
-                 workGlobalID(1) = k
-                 workGlobalID(2) = indexToCellID(iCell)
-                 workLat = latCell(iCell)
-                 workLon = lonCell(iCell)
-                 write(errorUnit, 10) 'S= ', workValue, 'cell= ', workGlobalID(2), &
-                    'k= ',workGlobalID(1), 'lat = ', workLat, 'lon= ', workLon
-              endif
-           enddo
-        enddo
-
-        write(errorUnit,*) ''
-
-        !close unit
-        close(errorUnit)
-        call mpas_release_unit(errorUnit)
-
-      endif ! if(errorFlag)
-
-      !now test for NaNs in the ocean velocity field and abort if true
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 2)
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-      nanCheck = sum(normalVelocity)
-      if (nanCheck /= nanCheck) then
-         write(stderrUnit,*) 'Ocean Abort: NaN detected'
-         call mpas_dmpar_global_abort('MPAS-ocean: test_ocean_state: NaN detected')
-      endif
-
-   end subroutine test_ocean_state
 
    end subroutine ocn_timestep!}}}
 


### PR DESCRIPTION
This merge moves the ocean state checker from the time integration
module to the debug diagnostics AM. This allows the state checker to be
disabled for a run, or for someone to control how frequently it will be
called.
