### PR TITLE
Update dependencies in LI Makefiles

### DIFF
--- a/src/core_landice/mode_forward/Makefile
+++ b/src/core_landice/mode_forward/Makefile
@@ -40,8 +40,7 @@ mpas_li_time_integration.o: mpas_li_time_integration_fe.o \
 	                    mpas_li_setup.o \
 			    mpas_li_constants.o
 
-mpas_li_time_integration_fe.o: mpas_li_velocity.o \
-                               mpas_li_advection.o \
+mpas_li_time_integration_fe.o: mpas_li_advection.o \
 	                       mpas_li_calving.o \
                                mpas_li_thermal.o \
                                mpas_li_diagnostic_vars.o \
@@ -49,7 +48,9 @@ mpas_li_time_integration_fe.o: mpas_li_velocity.o \
 
 mpas_li_advection.o: mpas_li_thermal.o \
 	             mpas_li_diagnostic_vars.o \
-                     mpas_li_setup.o
+                     mpas_li_setup.o \
+		     mpas_li_mask.o \
+		     mpas_li_constants.o
 
 mpas_li_calving.o: mpas_li_mask.o \
 	           mpas_li_thermal.o \
@@ -62,18 +63,21 @@ mpas_li_thermal.o: mpas_li_mask.o \
 
 mpas_li_diagnostic_vars.o: mpas_li_mask.o \
                            mpas_li_velocity.o \
-                           mpas_li_constants.o
+                           mpas_li_constants.o \
+			   mpas_li_thermal.o
 
 mpas_li_velocity.o: mpas_li_sia.o \
                     mpas_li_setup.o \
                     mpas_li_velocity_simple.o \
-                    mpas_li_velocity_external.o
+                    mpas_li_velocity_external.o \
+		    mpas_li_mask.o
 
 mpas_li_sia.o: mpas_li_mask.o \
                mpas_li_setup.o
 
 mpas_li_velocity_simple.o: mpas_li_mask.o \
-                           mpas_li_setup.o
+                           mpas_li_setup.o \
+			   mpas_li_constants.o
 
 mpas_li_statistics.o: mpas_li_mask.o \
 	              mpas_li_diagnostic_vars.o \
@@ -84,7 +88,9 @@ mpas_li_mask.o: mpas_li_setup.o
 
 mpas_li_constants.o:
 
-mpas_li_velocity_external.o:
+mpas_li_velocity_external.o: mpas_li_setup.o \
+	                     mpas_li_mask.o \
+	                     Interface_velocity_solver.o
 
 Interface_velocity_solver.o:
 


### PR DESCRIPTION
There were a few missing dependencies that were inexplicably causing
some .f90 to not be generated when using gen_f90 (in ACME on LANL IC, anyway).
This merge makes sure all LI modules have the correct dependencies
in the Makefiles.  This resolves the problem in ACME on LANL IC.
