### PR TITLE
Fix bit reproducibility due to CVMix change

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1303,6 +1303,7 @@
 
 			<stream name="mesh"/>
 			<var_struct name="tracers"/>
+			<var_struct name="tracersSurfaceFlux"/>
 			<var name="normalVelocity"/>
 			<var name="layerThickness"/>
 			<var name="highFreqThickness"/>


### PR DESCRIPTION
This addresses a bit reproducibility fail that resulted from the non
local flux changes introduced in a previous PR (#902)

Tested using the QU240km restart test and it passed.
