### PR TITLE
Fix an out of bounds error with rSurfaceLayer

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -736,7 +736,7 @@ contains
             tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
                                               * layerThickness(k,iCell)
           enddo
-          k=int(rSurfaceLayer)+1
+          k=min( int(rSurfaceLayer)+1, maxLevelCell(iCell) )
           tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
                                             * activeTracers(:,k,iCell) * layerThickness(k,iCell)
           tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) / surfaceLayerDepth


### PR DESCRIPTION
This merge fixes an issue caused when rSurfaceLayer = nVertLevels. In
this case, k is set to be int(rSurfaceLayer)+1, which is an out of
bounds access and causes a seg fault.

This causes the max of k to be maxLevelCell(iCell) so as to prevent out
of bounds accesses, or accessing garbage from cells below active ocean
cells.
