### PR TITLE
Fix issue with halo exchanges of integer fields when running with RKIND=4

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -7900,7 +7900,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   !$omp do schedule(runtime) private(iBuffer)
                   do iExch = 1, exchListPtr % nList
                      iBuffer = exchListPtr % destList(iExch) + bufferOffset
-                     commListPtr % rbuffer(iBuffer) = real(fieldCursor % array(exchListPtr % srcList(iExch)), kind=RKIND)
+                     commListPtr % rbuffer(iBuffer) = transfer(fieldCursor % array(exchListPtr % srcList(iExch)), &
+                                                               commListPtr % rbuffer(1))
                   end do
                   !$omp end do
                   nAdded = nAdded + exchListPtr % nList
@@ -7963,7 +7964,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   do iExch = 1, exchListPtr % nList
                      do j = 1, fieldCursor % dimSizes(1)
                         iBuffer = (exchListPtr % destList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
-                        commListPtr % rbuffer(iBuffer) = real(fieldCursor % array(j, exchListPtr % srcList(iExch)), kind=RKIND)
+                        commListPtr % rbuffer(iBuffer) = transfer(fieldCursor % array(j, exchListPtr % srcList(iExch)), &
+                                                                  commListPtr % rbuffer(1))
                      end do
                   end do
                   !$omp end do
@@ -8029,7 +8031,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                         do k = 1, fieldCursor % dimSizes(1)
                            iBuffer = (exchListPtr % destList(iExch) - 1) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2) &
                                    + (j - 1) * fieldCursor % dimSizes(1) + k + bufferOffset
-                           commListPtr % rbuffer(iBuffer) = real(fieldCursor % array(k, j, exchListPtr % srcList(iExch)), kind=RKIND)
+                           commListPtr % rbuffer(iBuffer) = transfer(fieldCursor % array(k, j, exchListPtr % srcList(iExch)), &
+                                                                     commListPtr % rbuffer(1))
                         end do
                      end do
                   end do
@@ -8892,7 +8895,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   !$omp do schedule(runtime) private(iBuffer)
                   do iExch = 1, exchListPtr % nList
                      iBuffer = exchListPtr % srcList(iExch) + bufferOffset
-                     fieldCursor % array(exchListPtr % destList(iExch)) = int(commListPtr % rbuffer(iBuffer))
+                     fieldCursor % array(exchListPtr % destList(iExch)) = transfer(commListPtr % rbuffer(iBuffer), &
+                                                                                   fieldCursor % array(1))
                   end do
                   !$omp end do
                   nAdded = max(nAdded, maxval(exchListPtr % srcList))
@@ -8963,7 +8967,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   do iExch = 1, exchListPtr % nList
                      do j = 1, fieldCursor % dimSizes(1)
                         iBuffer = (exchListPtr % srcList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
-                        fieldCursor % array(j, exchListPtr % destList(iExch)) = int(commListPtr % rbuffer(iBuffer))
+                        fieldCursor % array(j, exchListPtr % destList(iExch)) = transfer(commListPtr % rbuffer(iBuffer), &
+                                                                                         fieldCursor % array(1,1))
                      end do
                   end do
                   !$omp end do
@@ -9037,7 +9042,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                         do k = 1, fieldCursor % dimSizes(1)
                            iBuffer = (exchListPtr % srcList(iExch) - 1) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2) &
                                    + (j - 1) * fieldCursor % dimSizes(1) + k + bufferOffset
-                           fieldCursor % array(k, j, exchListPtr % destList(iExch)) = int(commListPtr % rbuffer(iBuffer))
+                           fieldCursor % array(k, j, exchListPtr % destList(iExch)) = transfer(commListPtr % rbuffer(iBuffer), &
+                                                                                               fieldCursor % array(1,1,1))
                         end do
                      end do
                   end do


### PR DESCRIPTION
This merge corrects an issue in the new group halo exchange routines for integers when running in single precision.

The mpas_dmpar_exch_group_unpack_buffer_fieldNd_integer and mpas_dmpar_exch_group_pack_buffer_fieldNd_integer routines previously packed integer fields into a default real-kind (RKIND) buffer when performing halo exchanges for integer fields. However, this packing and unpacking was done using type conversions. This leads to incorrect results for integers that cannot be exactly represented when converted to a 32-bit real (potentially affecting integers greater than 2^24, or 16777216, in magnitude).

Instead of type conversion, we now use the Fortran TRANSFER intrinsic to type cast integers to and from reals, since the halo exchange code in no way depends on the values stored in the exchange buffers.
