### PR TITLE
Fix bugs in Ohlman 00 shortwave

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -111,7 +111,7 @@ contains
 
       call MPAS_pool_get_config(ocnConfigs, 'config_sw_absorption_type', config_sw_absorption_type)
 
-      if (trim(config_sw_absorption_type)=='none') return
+      if (trim(config_sw_absorption_type)=='none')  return
 
       err = 0
       if(useJerlov) then
@@ -155,7 +155,15 @@ contains
                                 config_use_activeTracers_surface_bulk_forcing)
 
       useJerlov=.false.
-      if (.not.config_use_activeTracers_surface_bulk_forcing.or.trim( config_sw_absorption_type ) == 'none') return
+
+      if(.not. config_use_activeTracers_surface_bulk_forcing) then
+         if(trim(config_sw_absorption_type) .ne. 'none') then
+              write(stderrUnit,*) 'ERROR: you have specified bulk_forcing off with shortwave absorption on'
+              write(stderrUnit,*) 'either set config_sw_absorption_type to none or enable activeTracers_surface_bulk_forcing'
+              err = 1
+         endif 
+         return
+      endif
 
       if ( trim( config_sw_absorption_type ) == 'jerlov') then
          useJerlov=.true.

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -152,11 +152,7 @@ contains
 
       call mpas_pool_get_array(swForcingPool,'zenithAngle',zenithAngle)
       call mpas_pool_get_array(swForcingPool,'clearSkyRadiation',clearSkyRadiation)
-      if(.not. associated(chlorophyllA) .or. .not. associated(zenithAngle) .or. .not. associated(clearSkyRadiation)) then
-              write(stderrUnit,*) 'WARNING: A necessary data array is missing for ohlmann scheme.'
-              write(stderrUnit,*) 'check data path or set config_sw_absorption_type = none in namelist.ocean'
-              return
-      endif
+      
       !$omp do schedule(runtime) private(depth, k, cloudRatio)
       do iCell = 1, nCells
         depth = 0.0_RKIND


### PR DESCRIPTION
This PR fixes two issues in the Ohlman 00 shortwave scheme.  First,
if clearSkyRadiation is ever zero, a segFault will occur, due to division
by zero.  A small positive number is added to prevent this.  Second, there is
presently no check for the necessary data arrays prior to computing extinction
coefficients.  If config_sw_absorption_type is set to ohlman00 and no data arrays
are provided, the code will attempt to compute extinction coefficients.  In this
commit a check is added for these arrays, if any are missing, a warning is
printed and the code is not run.

This PR fixes #933.
