### PR TITLE
Add PR and Issue templates to help unify information

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+The title above should be a 1 line short summary of the issue.
+
+Enter a description of the issue.
+This should include what the symptoms are, and steps to reproduce.
+
+Additionally please enter this information if applicable:
+ - Compiler and version
+ - MPI implementation and version
+ - NetCDF version
+ - Parallel NetCDF version
+ - Parallel IO version
+ - Output of `uname -a`
+ - The make line used to build the executable
+ - The line used to run the executable
+ - Test case used

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).
+
+Enter a description of this PR. This should include why this PR was created, and what it does.
+
+Testing and relations to other Pull Requests should be added as subsequent comments.
+
+See the below examples for more information.
+https://github.com/MPAS-Dev/MPAS/pull/930
+https://github.com/MPAS-Dev/MPAS/pull/931
+


### PR DESCRIPTION
This merge adds github templates for pull requests and issues which
will help ensure information provided across PRs and issues is uniform
and/or full.
