### PR TITLE
Fix issues duplicating fields in mpas_forcing

### DIFF
--- a/src/framework/mpas_attlist.F
+++ b/src/framework/mpas_attlist.F
@@ -491,6 +491,12 @@ contains
 
       allocate(destAttList)
 
+      destAttList % attType = -1
+      destAttList % attName = ''
+      nullify(destAttList % next)
+      nullify(destAttList % attValueIntA)
+      nullify(destAttList % attValueRealA)
+
       srcCursor => srcAttList
       do while ( associated(srcCursor) )
          if ( srcCursor % attType == MPAS_ATT_INT ) then

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -1318,6 +1318,15 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 		fortprintf(fd, "      nullify(%s(%d) %% copyList)\n", pointer_name, time_lev);
 		fortprintf(fd, "      allocate(%s(%d) %% attLists(size(%s(%d) %% constituentNames, dim=1)))\n", pointer_name, time_lev, pointer_name, time_lev);
 
+		fortprintf(fd, "      do index_counter = 1, size(%s(%d) %% constituentNames, dim=1)\n", pointer_name, time_lev);
+		fortprintf(fd, "         allocate(%s(%d) %% attLists(index_counter) %% attList)\n", pointer_name, time_lev);
+		fortprintf(fd, "         %s(%d) %% attLists(index_counter) %% attList %% attName = ''\n", pointer_name, time_lev);
+		fortprintf(fd, "         %s(%d) %% attLists(index_counter) %% attList %% attType = -1\n", pointer_name, time_lev);
+		fortprintf(fd, "         nullify(%s(%d) %% attLists(index_counter) %% attList %% next)\n", pointer_name, time_lev);
+		fortprintf(fd, "         nullify(%s(%d) %% attLists(index_counter) %% attList %% attValueIntA)\n", pointer_name, time_lev);
+		fortprintf(fd, "         nullify(%s(%d) %% attLists(index_counter) %% attList %% attValueRealA)\n", pointer_name, time_lev);
+		fortprintf(fd, "      end do\n");
+
 		for(var_xml = ezxml_child(var_arr_xml, "var"); var_xml; var_xml = var_xml->next){
 			varname = ezxml_attr(var_xml, "name");
 			varname_in_code = ezxml_attr(var_xml, "name_in_code");
@@ -1547,6 +1556,12 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		fortprintf(fd, "      nullify(%s(%d) %% recvList)\n", pointer_name, time_lev);
 		fortprintf(fd, "      nullify(%s(%d) %% copyList)\n", pointer_name, time_lev);
 		fortprintf(fd, "      allocate(%s(%d) %% attLists(1))\n", pointer_name, time_lev);
+		fortprintf(fd, "      allocate(%s(%d) %% attLists(1) %% attList)\n", pointer_name, time_lev);
+		fortprintf(fd, "      %s(%d) %% attLists(1) %% attList %% attName = ''\n", pointer_name, time_lev);
+		fortprintf(fd, "      %s(%d) %% attLists(1) %% attList %% attType = -1\n", pointer_name, time_lev);
+		fortprintf(fd, "      nullify(%s(%d) %% attLists(1) %% attList %% next)\n", pointer_name, time_lev);
+		fortprintf(fd, "      nullify(%s(%d) %% attLists(1) %% attList %% attValueIntA)\n", pointer_name, time_lev);
+		fortprintf(fd, "      nullify(%s(%d) %% attLists(1) %% attList %% attValueRealA)\n", pointer_name, time_lev);
 
 		if ( varunits != NULL ) {
 			string = strdup(varunits);


### PR DESCRIPTION
This merge fixes mpas_forcing to properly deal with attribute lists by
making three changes:
- Only attempt to deallocate real and integer array attributes if they
  are allocated
- Allow duplicated fields to not duplicate attribute lists
- When duplicating fields for input in mpas_forcing, prevent duplicating attribute lists
