### PR TITLE
Add missing use mpas_dmpar

### DIFF
--- a/src/core_cice/shared/mpas_cice_velocity_solver_constitutive_relation.F
+++ b/src/core_cice/shared/mpas_cice_velocity_solver_constitutive_relation.F
@@ -14,6 +14,7 @@ module cice_velocity_solver_constitutive_relation
 
   use mpas_derived_types
   use mpas_pool_routines
+  use mpas_dmpar
 
   implicit none
 


### PR DESCRIPTION
This merge adds a missing `use mpas_dmpar` to
mpas_cice_velocity_solver_constitutive_relation.F
