### PR TITLE
Compute land-ice fluxes at startup

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -37,6 +37,9 @@ module ocn_init_routines
    use ocn_gm
    use ocn_constants
 
+   use ocn_surface_land_ice_fluxes
+   use ocn_forcing
+
    private
 
    !--------------------------------------------------------------------
@@ -666,6 +669,17 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       end if
 
       call mpas_pool_initialize_time_levels(statePool)
+
+      ! compute land-ice fluxes for potential output at startup
+      call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err1, 1)
+      err = ior(err, err1)
+      call mpas_timer_start("land_ice_build_arrays", .false.)
+      call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+                                                    forcingPool, scratchPool, err1)
+      call mpas_timer_stop("land_ice_build_arrays")
+      err = ior(err, err1)
+
+
 
    end subroutine ocn_init_routines_block!}}}
 


### PR DESCRIPTION
This merge adds computation of land-ice fluxes at model init.  Otherwise, when land-ice fluxes (e.g. landIceFreshwaterFlux) are written to output files either before the first simulation step or after a restart, the output is all zeros.  
