### PR TITLE
Fixes config_sw_absorption_type none issue

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -161,7 +161,7 @@ contains
               write(stderrUnit,*) 'ERROR: you have specified bulk_forcing off with shortwave absorption on'
               write(stderrUnit,*) 'either set config_sw_absorption_type to none or enable activeTracers_surface_bulk_forcing'
               err = 1
-         endif 
+         endif
          return
       endif
 


### PR DESCRIPTION
This addresses an error (#965) that arises when bulk forcing is true and shortwave
absorption is set to none.  A missing else if check has been added.
