### PR TITLE
In with_land_ice test cases, add link missing link to critical_passages.nc

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_init_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_init_iter.xml
@@ -2,6 +2,7 @@
 <config case="init_iter">
 	<add_link source="../init_step1/culled_mesh_final.nc" dest="mesh.nc"/>
 	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source="../init_step1/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
 
 	<add_link source="../init_step2/temperature.nc" dest="temperature.nc"/>
 	<add_link source="../init_step2/salinity.nc" dest="salinity.nc"/>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_init_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_init_iter.xml
@@ -2,6 +2,7 @@
 <config case="init_iter">
 	<add_link source="../init_step1/culled_mesh_final.nc" dest="mesh.nc"/>
 	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source="../init_step1/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
 
 	<add_link source="../init_step2/temperature.nc" dest="temperature.nc"/>
 	<add_link source="../init_step2/salinity.nc" dest="salinity.nc"/>


### PR DESCRIPTION
This merge adds a link to the NetCDF file containing the location
and depth of critical passages in the init_iter step of both
global_ocean test cases with land ice.
