### PR TITLE
Update land-ice regression testing

### DIFF
--- a/test_cases/ocean/ocean/regression_suites/land_ice_fluxes.xml
+++ b/test_cases/ocean/ocean/regression_suites/land_ice_fluxes.xml
@@ -17,4 +17,10 @@
 	<test name="sub-ice-shelf 2D - Haney-number constrained, iterative init - Smoke Test" core="ocean" configuration="sub_ice_shelf_2D" resolution="5km" test="Haney_number_iterative_init">
 		<script name="run_test.py"/>
 	</test>
+	<test name="QU 240km - Smoke Test" core="ocean" configuration="global_ocean" resolution="QU_240km" test="with_land_ice">
+		<script name="run_test.py"/>
+	</test>
+	<test name="QU 120km - Smoke Test" core="ocean" configuration="global_ocean" resolution="QU_120km" test="with_land_ice">
+		<script name="run_test.py"/>
+	</test>
 </regression_suite>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_driver.xml
@@ -12,5 +12,8 @@
 		<compare_fields file1="forward/output.nc">
 			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_fields file1="forward/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_forward.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_forward.xml
@@ -14,6 +14,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<stream name="globalStatsOutput">
 			<attribute name="output_interval">0000_00:00:01</attribute>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_driver.xml
@@ -17,5 +17,8 @@
 		<compare_fields file1="forward/output.nc">
 			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_fields file1="forward/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_forward.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_forward.xml
@@ -12,6 +12,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
 		<template file="template_iter_forward.xml" path_base="script_resolution_dir"/>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<stream name="globalStatsOutput">
 			<attribute name="output_interval">0000_00:00:01</attribute>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_driver.xml
@@ -12,5 +12,8 @@
 		<compare_fields file1="forward/output.nc">
 			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_fields file1="forward/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_forward.xml
@@ -14,6 +14,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<stream name="globalStatsOutput">
 			<attribute name="output_interval">0000_00:00:01</attribute>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_driver.xml
@@ -17,5 +17,8 @@
 		<compare_fields file1="forward/output.nc">
 			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_fields file1="forward/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_forward.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_forward.xml
@@ -12,6 +12,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
 		<template file="template_iter_forward.xml" path_base="script_resolution_dir"/>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<stream name="globalStatsOutput">
 			<attribute name="output_interval">0000_00:00:01</attribute>

--- a/test_cases/ocean/ocean/templates/validations/land_ice_flux_comparison.xml
+++ b/test_cases/ocean/ocean/templates/validations/land_ice_flux_comparison.xml
@@ -10,7 +10,6 @@
 			<field name="landIceFreshwaterFlux" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="landIceHeatFlux" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="heatFluxToLandIce" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
-			<field name="effectiveDensityInLandIce" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="landIceBoundaryLayerTemperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="landIceBoundaryLayerSalinity" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
 			<field name="landIceHeatTransferVelocity" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>


### PR DESCRIPTION
Brings the land-ice regression testing up-to-date with
the rest of the testing infrastructure:
- Validation checks and output of land-ice variables have been
  added to the sub_ice_shelf_2D test cases
- The effectiveDensity variable has been removed from the list
  of land_ice variables to be compared (because it is typically
  not present, and therefore fails).
- The QU120 and QU240 with_land_ice test cases have been added to
  the suite
