### PR TITLE
Updates CVMix tag in MPAS

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -649,6 +649,10 @@
 					description="The search for boundary layer depth is terminated when bulk Richardson number is greater than config_cvmix_kpp_stop_OBL_search*config_cvmix_kpp_criticalBulkRichardsonNumber"
 					possible_values="Any positive value"
 		/>
+		<nml_option name="config_cvmix_kpp_use_enhanced_diff" type="logical" default_value=".true." units="none"
+					description="Flag for use of enhanced diffusion at boundary layer base as in Large et al (1994)"
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="forcing" mode="init;forward">
 		<nml_option name="config_use_bulk_wind_stress" type="logical" default_value=".false." units="unitless"

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=v0.64-beta
-
+CVMIX_TAG=v0.84-beta
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -670,7 +670,7 @@ contains
       logical, pointer ::  config_use_cvmix_convection
       real (kind=RKIND), pointer :: config_cvmix_convective_diffusion, config_cvmix_convective_viscosity, &
                                     config_cvmix_convective_triggerBVF
-      logical, pointer :: config_cvmix_convective_basedOnBVF
+      logical, pointer :: config_cvmix_convective_basedOnBVF, config_cvmix_kpp_use_enhanced_diff
 
       ! Tidal mixing
       logical, pointer :: config_use_cvmix_tidal_mixing
@@ -720,7 +720,7 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_prandtl_number', config_cvmix_prandtl_number)
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_convective_diffusion', config_cvmix_convective_diffusion)
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_convective_viscosity', config_cvmix_convective_viscosity)
-
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_use_enhanced_diff', config_cvmix_kpp_use_enhanced_diff)
       cvmixOn = config_use_cvmix
       cvmixBackgroundOn = config_use_cvmix_background
       backgroundVisc = config_cvmix_background_viscosity
@@ -836,7 +836,8 @@ contains
                lEkman = config_cvmix_kpp_EkmanOBL, &
                lMonOb = config_cvmix_kpp_MonObOBL, &
                MatchTechnique = config_cvmix_kpp_matching, &
-               surf_layer_ext = config_cvmix_kpp_surface_layer_extent)
+               surf_layer_ext = config_cvmix_kpp_surface_layer_extent, &
+               lenhanced_diff = config_cvmix_kpp_use_enhanced_diff)
       endif
 
 


### PR DESCRIPTION
This PR updates the version of CVMix utilized in MPAS-O.  A glaring bug
was discovered in CVMix that resulted in artificially enhanced diffusivity
in the layer directly below the boundary layer.  The new version of
CVMix fixes this issue.  When this issue has been fixed, artificial noise in
boundary layer depths is found. Utilizing enhanced diffusivity from Large
et al. 1994 (implemented in this new CVMix tag) removes this noise.  A flag
to enable this artificial diffusion has been added to the registry.  It should be
enabled in nearly all runs and is thus the flag is set to true by default

The changes made will be nonBFB with current ocean/develop.
