### PR TITLE
Limit salt fluxes to prevent negative salinities

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1654,6 +1654,11 @@
 			 packages="frazilIce"
 		/>
 
+		<var name="accumulatedFrazilIceSalinity" type="real" dimensions="nCells Time" units="kg m^{-2}"
+			 description="Salinity associated with accumulatedFrazilIceMass. Reset to zero at each coupling interval"
+			 packages="frazilIce"
+		/>
+
 		<!-- FIELDS FOR SPLIT EXPLICIT TIME INTEGRATOR -->
 		<var name="normalBarotropicVelocity" type="real" dimensions="nEdges Time" units="m s^{-1}"
 			 description="barotropic velocity, used in split-explicit time-stepping"

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -339,13 +339,15 @@ contains
       real (kind=RKIND), pointer :: config_frazil_maximum_freezing_temperature
       logical, pointer :: config_frazil_use_surface_pressure
 
-      real (kind=RKIND) :: newFrazilIceThickness
-      real (kind=RKIND) :: sumNewFrazilIceThickness
-      real (kind=RKIND) :: meltedFrazilIceThickness
+      real (kind=RKIND) :: newFrazilIceThickness, newThicknessWeightedSaltContent
+      real (kind=RKIND) :: sumNewFrazilIceThickness, sumNewThicknessWeightedSaltContent
+      real (kind=RKIND) :: meltedFrazilIceThickness, meltedThicknessWeightedSaltContent
       real (kind=RKIND) :: oceanFreezingTemperature
 
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceMassNew
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceMassOld
+      real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceSalinityNew
+      real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceSalinityOld
       real (kind=RKIND), pointer, dimension(:,:)   :: zMid
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
       real (kind=RKIND), pointer, dimension(:,:)   :: density
@@ -382,6 +384,8 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
       call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassNew, 2)
       call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassOld, 1)
+      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityNew, 2)
+      call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityOld, 1)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
       call mpas_pool_get_array(diagnosticsPool, 'density', density)
@@ -438,6 +442,7 @@ contains
 
         ! initialize the sum of new frazil ice created
         sumNewFrazilIceThickness = 0.0_RKIND
+        sumNewThicknessWeightedSaltContent = 0.0_RKIND
 
         ! loop from maximum depth of frazil creation to surface
         do k = kBottomFrazil, 1, -1
@@ -467,14 +472,18 @@ contains
             frazilLayerThicknessTendency(k,iCell) = - newFrazilIceThickness * config_frazil_sea_ice_density / density(k,iCell) / dt
 
             ! salt is extracted with the frazil
-            frazilSalinityTendency(k,iCell) = - newFrazilIceThickness * config_frazil_ice_reference_salinity / dt
+            frazilSalinityTendency(k,iCell) = - newFrazilIceThickness &
+                                            * min( config_frazil_ice_reference_salinity, activeTracers(indexSalinity, k, iCell) ) &
+                                            / dt
 
             ! ocean fluid temperature is warmed due to creation of frazil
             frazilTemperatureTendency(k,iCell) =  + ( newFrazilIceThickness * config_frazil_heat_of_fusion &
                                                * config_frazil_sea_ice_density ) / (config_specific_heat_sea_water * rho_sw) / dt
 
             ! keep track of sum of frazil ice
+            newThicknessWeightedSaltContent = frazilSalinityTendency(k, iCell) * dt
             sumNewFrazilIceThickness = sumNewFrazilIceThickness + newFrazilIceThickness
+            sumNewThicknessWeightedSaltContent = sumNewThicknessWeightedSaltContent + newThicknessWeightedSaltContent
 
           else
 
@@ -493,6 +502,10 @@ contains
               meltedFrazilIceThickness = min(meltedFrazilIceThickness, layerThickness(k,iCell) &
                                        * config_frazil_fractional_thickness_limit)
 
+              ! assign some salt to the melted ice
+              meltedThicknessWeightedSaltContent = meltedFrazilIceThickness &
+                                                 * ( sumNewThicknessWeightedSaltContent / sumNewFrazilIceThickness )
+
               ! compute tendency to thickness, temperature and salinity
 
               ! layer thickness increases due to melting of frazil
@@ -501,7 +514,7 @@ contains
                                                     / density(k,iCell) / dt
 
               ! salt is released into ocean with the melting frazil
-              frazilSalinityTendency(k,iCell) = + meltedFrazilIceThickness * config_frazil_ice_reference_salinity / dt
+              frazilSalinityTendency(k,iCell) = + meltedThicknessWeightedSaltContent/ dt
 
               ! ocean fluid temperature is cooled due to melting of frazil
               frazilTemperatureTendency(k,iCell) = - ( meltedFrazilIceThickness * config_frazil_heat_of_fusion &
@@ -509,6 +522,7 @@ contains
                                                  / dt
 
               ! keep track of new frazil ice
+              sumNewThicknessWeightedSaltContent = sumNewThicknessWeightedSaltContent - meltedThicknessWeightedSaltContent
               sumNewFrazilIceThickness = sumNewFrazilIceThickness - meltedFrazilIceThickness
 
             endif  ! if (sumNewFrazilIceThickness > 0.0_RKIND)
@@ -521,6 +535,7 @@ contains
         ! note: the accumulatedFrazilIceMass (at both time levels) is reset to zero after being sent to the coupler
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
                                            * config_frazil_sea_ice_density
+        accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
 
       enddo   ! do iCell = 1, nCells
       !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -72,7 +72,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_surface_bulk_forcing_tracers(meshPool, groupName, forcingPool, tracerGroup,   &
-      tracersSurfaceFlux, tracersSurfaceFluxRunoff, err)!{{{
+      tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, dt, layerThickness, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -92,6 +92,10 @@ contains
       real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux !< Input/Output: Surface flux for tracer group
       real (kind=RKIND), dimension(:,:), intent(inout) ::   &
          tracersSurfaceFluxRunoff !< Input/Output: Surface flux for tracer group due to river runoff
+      real (kind=RKIND), dimension(:,:), intent(inout) ::   &
+         tracersSurfaceFluxRemoved !< Input/Output: Accumulator for ignored Surface flux for tracer group
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: dt
 
       !-----------------------------------------------------------------
       !
@@ -111,7 +115,7 @@ contains
 
       if ( trim(groupName) == 'activeTracers' ) then
          call ocn_surface_bulk_forcing_active_tracers(meshPool, forcingPool, tracerGroup,  &
-            tracersSurfaceFlux, tracersSurfaceFluxRunoff, err)
+            tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)
       end if
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
@@ -333,7 +337,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_surface_bulk_forcing_active_tracers(meshPool, forcingPool, tracerGroup,  &
-      tracersSurfaceFlux, tracersSurfaceFluxRunoff, err)!{{{
+      tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -350,7 +354,10 @@ contains
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
       real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
       real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFluxRunoff
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFluxRemoved
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: dt
 
       !-----------------------------------------------------------------
       !
@@ -377,6 +384,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
+      real (kind=RKIND) :: requiredSalt, allowedSalt
 
       err = 0
 
@@ -404,7 +412,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
 
       ! Build surface fluxes at cell centers
-      !$omp do schedule(runtime)
+      !$omp do schedule(runtime) private(allowedSalt, requiredSalt)
       do iCell = 1, nCells
         tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
                                                            + (latentHeatFlux(iCell) + sensibleHeatFlux(iCell) &
@@ -412,8 +420,23 @@ contains
                                                            + seaIceHeatFlux(iCell) - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
                                                            * latent_heat_fusion_mks) * hflux_factor
 
-        tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
-                                                        + seaIceSalinityFlux(iCell) * sflux_factor
+        ! Negative seaIceSalinityFlux is an extraction of salt from the ocean
+        ! So, we negate seaIceSalinityFlux when determining how much salt this flux needs.
+        requiredSalt = - seaIceSalinityFlux(iCell) * sflux_factor * dt / layerThickness(1, iCell)
+        allowedSalt = min( 4.0_RKIND, tracerGroup(index_salinity_flux, 1, iCell) )
+
+        if ( allowedSalt < requiredSalt ) then
+           tracersSurfaceFluxRemoved(index_salinity_flux, iCell) = tracersSurfaceFluxRemoved(index_salinity_flux, iCell)  &
+                                                                 + ( 1 - allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                                 * sflux_factor
+
+           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+                                                          + ( allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                          * sflux_factor
+        else
+           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+                                                          + seaIceSalinityFlux(iCell) * sflux_factor
+        end if
       end do
       !$omp end do
       ! assume that snow comes in at 0 C
@@ -428,11 +451,11 @@ contains
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature
-            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
                       + (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
 
-            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
-            tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
+           ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
+           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
                       * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
 
            ! Accumulate fluxes that use the freezing point

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -444,7 +444,7 @@ contains
         normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
         tend_layerThickness, normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed, zMid, relativeSlopeTopOfEdge, &
         relativeSlopeTapering, relativeSlopeTaperingCell, fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
-        nonLocalSurfaceTracerFlux
+        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux
 
       !
       ! three dimensional pointers
@@ -592,6 +592,10 @@ contains
                modifiedGroupName = trim(groupItr % memberName) // "SurfaceFluxRunoff"
                call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFluxRunoff)
 
+               ! Get surface flux removed array to keep track of how much flux is ignored
+               modifiedGroupName = trim(groupItr % memberName) // "SurfaceFluxRemoved"
+               call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFluxRemoved)
+
                !
                ! initialize tracer surface flux and tendency to zero.
                !
@@ -603,11 +607,12 @@ contains
                !$omp end do
 
                if (trim(groupItr % memberName) == 'activeTracers') then
-               !$omp do schedule(runtime)
-               do iCell = 1, nCells
-                 tracerGroupSurfaceFluxRunoff(:, iCell) = 0.0_RKIND
-               end do
-               !$omp end do
+                  !$omp do schedule(runtime)
+                  do iCell = 1, nCells
+                    tracerGroupSurfaceFluxRunoff(:, iCell) = 0.0_RKIND
+                    tracerGroupSurfaceFluxRemoved(:, iCell) = 0.0_RKIND
+                  end do
+                  !$omp end do
                endif
 
                !
@@ -616,7 +621,8 @@ contains
                if (config_use_tracerGroup_surface_bulk_forcing) then
                   call mpas_timer_start("bulk_" // trim(groupItr % memberName))
                   call ocn_surface_bulk_forcing_tracers(meshPool, groupItr % memberName, forcingPool, tracerGroup, &
-                                                        tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff, err)
+                                                        tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff, &
+                                                        tracerGroupSurfaceFluxRemoved, dt, layerThickness, err)
                   call mpas_timer_stop("bulk_" // trim(groupItr % memberName))
                end if
 
@@ -634,7 +640,7 @@ contains
 
                   call mpas_timer_start("ecosys surface flux", .false.)
                   call ocn_tracer_ecosys_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &
-                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)!{{{
+                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                   call mpas_timer_stop("ecosys surface flux")
                endif
 
@@ -653,7 +659,7 @@ contains
 
                   call mpas_timer_start("DMS surface flux", .false.)
                   call ocn_tracer_DMS_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &
-                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)!{{{
+                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                   call mpas_timer_stop("DMS surface flux")
                endif
 

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -83,6 +83,14 @@
 					 description="Flux of salinity through the ocean surface due to river runoff. Positive into ocean."
 				/>
 			</var_array>
+			<var_array name="activeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="activeTracersPKG">
+				<var name="temperatureSurfaceFluxRemoved" array_group="activeRemovedFluxGRP" units="^\circ C m s^{-1}"
+					 description="Flux of temperature that is ignored coming into the ocean. Positive into ocean."
+				/>
+				<var name="salinitySurfaceFluxRemoved" array_group="activeRemovedFluxGRP" units="PSU m s^{-1}"
+					 description="Flux of salinity that is ignroed coming into the ocean. Positive into ocean."
+				/>
+			</var_array>
 			<var_array name="nonLocalSurfaceTracerFlux" type="real" dimensions="nCells Time" packages="activeTracersPKG">
 				<var name="nonLocalTemperatureSurfaceFlux" array_group="activeNonLocalGRP" units="^\circ C m s^{-1}"
 					description="total flux of temperature (including thickness contributions) through ocean surface"


### PR DESCRIPTION
This merge modifies the computation of salt fluxes within the
computation of frazil fluxes and the bulk forcing module. Salt is only
removed if it is present, rather than removing salt regardless of how
much is present.

Surface fluxes are scaled back if the salt flux requires too much salt.

Additionally, arrays are added to keep track of how much salt flux is
ignored, and the actually salt content of frazil as it's formed.
