### PR TITLE
Introduce general, log-time interval division

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1513,9 +1513,8 @@ module mpas_timekeeping
       type (MPAS_TimeInterval_type), intent(out) :: rem
 
       integer :: m, more
-      character (len=StrKIND) :: datestring
       type (MPAS_Time_type) :: target_time
-      type (MPAS_Time_type) :: updated_time, mid_time
+      type (MPAS_Time_type) :: updated_time
 
       type (MPAS_TimeInterval_type) :: temp, mid_int
       type (MPAS_TimeInterval_type) :: zero
@@ -1527,7 +1526,7 @@ module mpas_timekeeping
       ! Avoid division by zero
       !
       if (den == zero) then
-         write(stderrUnit,*) 'Error: Attempting to divide by zero.\n'
+         write(stderrUnit,*) 'Error: Attempting to divide by zero.'
          n = 0
          rem = zero
          return
@@ -1579,22 +1578,21 @@ module mpas_timekeeping
       more = 0
       rem = target_time - updated_time
       do while (rem > den)
-         m  = m / 2
+         m = m / 2
          temp = den * m
          if (updated_time + temp <= target_time) then
             more = more + m
             updated_time = updated_time + temp
             rem = target_time - updated_time
          end if
-         if(m==1) exit
+         if (m==1) exit
       end do
 
       ! Final number of intervals is n + more
       n = n + more
 
-      return
-
    end subroutine mpas_interval_division
+
 
    logical function eq_t_t(t1, t2)
 


### PR DESCRIPTION
This merge introduces a generalized interval division routine to the mpas_timekeeping module. 

The old mpas_interval_division routine previously called a log-time routine when both the numerator and denominator in the division contained only days and seconds, and a slower routine when either the numerator or the denominator contained months or years.

The new mpas_interval_division routine handles any intervals in log-time, without the need to call separate routines for different cases.
