### PR TITLE
Initialize scratch array for split explicit time integrator

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -715,7 +715,7 @@ module ocn_time_integration_split
             ! Allocate subcycled scratch fields before starting subcycle loop
             call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
             call mpas_pool_get_field(scratchPool, 'btrvel_temp', btrvel_tempField)
-            call mpas_allocate_scratch_field(btrvel_tempField, .false., .false.)
+            call mpas_allocate_scratch_field(btrvel_tempField, .false.)
 
             call mpas_threading_barrier()
 


### PR DESCRIPTION
This merge adds back in the initialization of the scratch array within
the split explicit time integrator. This was removed when working on
performance modifications from the communication avoidance project, but
when run within ACME, this array needs to be initialized.
