### PR TITLE
Performance improvements for KPP / CVMix

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -329,10 +329,11 @@ contains
       allocate(surfaceAverageIndex(nVertLevels))
       allocate(deltaVelocitySquared(nVertLevels))
 
-      do k = 1, nVertLevelsP1
+      do k = 1, nVertLevels
          Nsqr_iface(k) = 0.0_RKIND
          turbulentScalarVelocityScale(k) = 0.0_RKIND
       end do
+      Nsqr_iface(nVertLevelsP1) = 0.0_RKIND
 
       call mpas_timer_start('cvmix cell loop', .false.)
       !$omp do schedule(runtime) private(k, bulkRichardsonNumberStop, kIndexOBL, bulkRichardsonFlag)
@@ -469,7 +470,7 @@ contains
                        exit
                     end if
                  enddo
-                 topIndex = surfaceAverageIndex(kIndexOBL) - 1
+                 topIndex = max(1, surfaceAverageIndex(kIndexOBL) - 1)
               end do
 
               ! compute the turbulent scales in order to compute the bulk Richardson number


### PR DESCRIPTION
This merge makes an assortment of changes to the MPAS-O interface for CVMix, specifically when using KPP for vertical mixing. It removes several k loops that were nested within other k loops, and changes some interfaces into CVMix .

Additionally, it causes CVMix to only perform calculations over active portions of the ocean domain, and refactors some loops to help vectorization in some compilers.
