### PR TITLE
Initialize btr_vel edge on the ghost edge

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -928,7 +928,7 @@ module ocn_time_integration_split
                    btrvel_temp => btrvel_tempField % array
 
                    !$omp do schedule(runtime)
-                   do iEdge = 1, nEdges
+                   do iEdge = 1, nEdges+1
                       btrvel_temp(iEdge) = normalBarotropicVelocitySubcycleNew(iEdge)
                    end do
                    !$omp end do


### PR DESCRIPTION
This merge initializes the temporary barotropic velocity on the ghost
edge for each block to help prevent a floating point exception.
