### PR TITLE
Change EC 60to30 default to also run as a performance test

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_driver.xml
@@ -12,5 +12,8 @@
 		<compare_fields file1="forward/output.nc">
 			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_timers rundir1="forward">
+			<timer name="time integration"/>
+		</compare_timers>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_forward.xml
@@ -9,7 +9,9 @@
 	<namelist name="namelist.ocean" mode="forward">
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_pio_num_iotasks">8</option>
+		<option name="config_pio_stride">16</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
@@ -20,17 +22,18 @@
 			<attribute name="filename_template">init.nc</attribute>
 		</stream>
 		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">0000_00:01:30</attribute>
+		</stream>
 		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
 	</streams>
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">128</argument>
 		</step>
 
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_init2.xml
@@ -42,8 +42,8 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">128</argument>
 		</step>
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_forward.xml
@@ -40,9 +40,9 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">128</argument>
 		</step>
 
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_init2.xml
@@ -42,8 +42,8 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">128</argument>
 		</step>
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_spin_up1.xml
@@ -39,9 +39,9 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">128</argument>
 		</step>
 
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/template_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/template_forward.xml
@@ -1,8 +1,8 @@
 <template>
 	<namelist>
-		<option name="config_dt">'00:20:00'</option>
+		<option name="config_dt">'00:30:00'</option>
 		<option name="config_btr_dt">'00:01:00'</option>
-		<option name="config_run_duration">'0000_01:00:00'</option>
+		<option name="config_run_duration">'0000_01:30:00'</option>
 		<option name="config_mom_del4">4.0e11</option>
 		<option name="config_hmix_scaleWithMesh">.true.</option>
 		<option name="config_use_standardGM">.true.</option>


### PR DESCRIPTION
- Change to 128 cores, with 8 i/o cores
- take 3 time steps
- output only at end
- turn off analysis members
- compare 'time integration' timer
