### PR TITLE
Put iterative init script in subdirectory

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=5</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=15</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=15</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>
 	</step>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>
 </config>

--- a/test_cases/ocean/ocean/isomip/10km/expt1.01/config_driver.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt1.01/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="     Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=5</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/isomip/10km/expt1.01/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt1.01/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/plot_cart_ssh_landIcePressure.py" dest="plot_cart_ssh_landIcePressure.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>

--- a/test_cases/ocean/ocean/isomip/10km/expt2.01/config_driver.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt2.01/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="     Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=5</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/isomip/10km/expt2.01/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt2.01/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/plot_cart_ssh_landIcePressure.py" dest="plot_cart_ssh_landIcePressure.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>

--- a/test_cases/ocean/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
+++ b/test_cases/ocean/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
@@ -49,7 +49,7 @@ for iterIndex in range(args.first_iteration,args.iteration_count):
 
     if args.plot_globalStats:
         print "   * Plotting stats"
-        subprocess.check_call(['../plot_globalStats.py', '--out_dir=statsPlots','--iteration=%i'%iterIndex, 'kineticEnergyCellMax',
+        subprocess.check_call(['../scripts/plot_globalStats.py', '--out_dir=statsPlots','--iteration=%i'%iterIndex, 'kineticEnergyCellMax',
                                'kineticEnergyCellAvg', 'layerThicknessMin'], stdout=dev_null, stderr=dev_null, env=os.environ.copy())
         print "   - Complete"
 

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="     Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=20</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/plot_cart_ssh_landIcePressure.py" dest="plot_cart_ssh_landIcePressure.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_driver.xml
@@ -5,7 +5,7 @@
 	<case name="init_step2">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="     Complete"/>
 	</case>
-	<step executable="./iterate_init.py">
+	<step executable="./scripts/iterate_init.py">
  		<argument flag="">--iteration_count=20</argument>
  		<argument flag="">--plot_globalStats</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_link_run_iter.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_link_run_iter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="">
+<config case="scripts">
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/plot_cart_ssh_landIcePressure.py" dest="plot_cart_ssh_landIcePressure.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>


### PR DESCRIPTION
Scripts for iterative init have been put in a 'scripts' subdirectory
within each case.  This prevents an issue where empty cases were
leading to base directories being deleted (along with their
xml files) when no work_dir was specified.
