### PR TITLE
Fix masking but in iterate_init.py script

### DIFF
--- a/test_cases/ocean/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
+++ b/test_cases/ocean/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
@@ -72,7 +72,7 @@ for iterIndex in range(args.first_iteration,args.iteration_count):
     nVertLevels = len(initFile.dimensions['nVertLevels'])
     initSSH = initFile.variables['ssh'][0,:]
     bottomDepth = initFile.variables['bottomDepth'][:]
-    landIceFraction = initFile.variables['landIceFraction'][0,:]
+    modifySSHMask = initFile.variables['modifySSHMask'][0,:]
     landIcePressure = forcingFile.variables['landIcePressure'][0,:]
     lonCell = initFile.variables['lonCell'][:]
     latCell = initFile.variables['latCell'][:]
@@ -84,7 +84,7 @@ for iterIndex in range(args.first_iteration,args.iteration_count):
     topDensity = inSSHFile.variables['density'][nTime-1,:,0]
     inSSHFile.close()
 
-    mask = numpy.logical_and(maxLevelCell > 0, landIceFraction > 0.0)
+    mask = numpy.logical_and(maxLevelCell > 0, modifySSHMask == 1)
 
     deltaSSH = mask*(finalSSH - initSSH)
 


### PR DESCRIPTION
This merge changes to using modifySSHMask to determine where the ssh (or
landIcePressure) should be modified, whereas landIceFraction was
peviously being used.
