### PR TITLE
Fix OpenMP related issues with halo exchanges and OMP directives

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1155,6 +1155,7 @@ module ocn_time_integration_split
                call mpas_dmpar_exch_group_add_field(domain, subcycleGroupName, 'sshSubcycle', timeLevel=newBtrSubcycleTime)
                call mpas_dmpar_exch_group_add_field(domain, subcycleGroupName, 'normalBarotropicVelocitySubcycle', timeLevel=newBtrSubcycleTime)
 
+               call mpas_threading_barrier()
                call mpas_dmpar_exch_group_full_halo_exch(domain, subcycleGroupName)
 
                call mpas_dmpar_exch_group_destroy(domain, subcycleGroupName)
@@ -1254,6 +1255,7 @@ module ocn_time_integration_split
             call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'barotropicThicknessFlux')
             call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'normalBarotropicVelocity', timeLevel=2)
 
+            call mpas_threading_barrier()
             call mpas_dmpar_exch_group_full_halo_exch(domain, finalBtrGroupName)
 
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -346,7 +346,7 @@ module ocn_tracer_advection_mono
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
         !$omp do schedule(runtime) private(k, tracer_max_new, tracer_min_new, tracer_upwind_new, scale_factor, invAreaCell1, i, &
-        !$omp                              iEdge, cell1, cell2, k, flux_upwind, signedFactor)
+        !$omp                              iEdge, cell1, cell2, flux_upwind, signedFactor)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 


### PR DESCRIPTION
This merge fixes two issues with OpenMP in the ocean model.

The first is adding threading barriers to exchange groups, to prevent
threads from using the exchange group before it's been created or after
it's been destroyed.

The second is removing a redundant variable from a private clause.
