### PR TITLE
Write all output streams at end of init_atm_core_run()

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_core.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core.F
@@ -87,7 +87,7 @@ module init_atm_core
    !   call atm_initialize_advection_rk(mesh)
    !   call atm_initialize_deformation_weights(mesh)
   
-      call mpas_stream_mgr_write(domain % streamManager, streamID='output', ierr=ierr)
+      call mpas_stream_mgr_write(domain % streamManager, ierr=ierr)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
    
    end function init_atm_core_run

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -81,6 +81,13 @@
 
  end do
 
+ !
+ ! Ensure that no output alarms are still ringing for the 'surface' stream after
+ ! we exit the time loop above; the main run routine may write out all other
+ ! output streams with ringing alarms.
+ !
+ call mpas_stream_mgr_reset_alarms(stream_manager, streamID='surface', direction=MPAS_STREAM_OUTPUT, ierr=ierr)
+
  end subroutine init_atm_case_sfc
 
 !==================================================================================================


### PR DESCRIPTION
This merge modifies the call to mpas_stream_mgr_write() at the end of 
the init_atm_core_run() routine so that all output streams with active 
packages (or no packages) are written.

The init_atm_core_run() routine previously only wrote the stream
named 'output'. However, it can be useful at times to create new mutable
streams at runtime with the init_atmosphere core.
