### PR TITLE
Use more robust string comparison in init_atmosphere core

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2753,7 +2753,7 @@ module init_atm_cases
 
       call read_next_met_field(field, istatus)
       do while (istatus == 0)
-         if (index(field % field, 'SOILHGT') /= 0) then
+         if (trim(field % field) == 'SOILHGT') then
 
             !
             ! Set up projection
@@ -2771,7 +2771,7 @@ module init_atm_cases
             end if
 
 
-            if (index(field % field, 'SOILHGT') /= 0) then
+            if (trim(field % field) == 'SOILHGT') then
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
@@ -3139,7 +3139,7 @@ module init_atm_cases
       call read_next_met_field(field, istatus)
 
       do while (istatus == 0)
-         if (index(field % field, 'LANDSEA') /= 0) then
+         if (trim(field % field) == 'LANDSEA') then
 
             allocate(maskslab(-2:field % nx+3, field % ny))
             maskslab(1:field % nx, 1:field % ny) = field % slab(1:field % nx, 1:field % ny)
@@ -3201,62 +3201,62 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
 
          mask_array => landmask
 
-         if (index(field % field, 'UU') /= 0 .or. &
-             index(field % field, 'VV') /= 0 .or. &
-             index(field % field, 'TT') /= 0 .or. &
-             index(field % field, 'RH') /= 0 .or. &
-             index(field % field, 'GHT') /= 0 .or. &
-             index(field % field, 'PMSL') /= 0 .or. &
-             index(field % field, 'PSFC') /= 0 .or. &
-             index(field % field, 'SOILHGT') /= 0 .or. &
-             index(field % field, 'SM000010') /= 0 .or. &
-             index(field % field, 'SM010040') /= 0 .or. &
-             index(field % field, 'SM040100') /= 0 .or. &
-             index(field % field, 'SM100200') /= 0 .or. &
-             index(field % field, 'SM010200') /= 0 .or. &
-             index(field % field, 'SM000007') /= 0 .or. &
-             index(field % field, 'SM007028') /= 0 .or. &
-             index(field % field, 'SM028100') /= 0 .or. &
-             index(field % field, 'SM100255') /= 0 .or. &
-             index(field % field, 'ST000010') /= 0 .or. &
-             index(field % field, 'ST010040') /= 0 .or. &
-             index(field % field, 'ST040100') /= 0 .or. &
-             index(field % field, 'ST100200') /= 0 .or. &
-             index(field % field, 'ST010200') /= 0 .or. &
-             index(field % field, 'ST000007') /= 0 .or. &
-             index(field % field, 'ST007028') /= 0 .or. &
-             index(field % field, 'ST028100') /= 0 .or. &
-             index(field % field, 'ST100255') /= 0 .or. &
-             index(field % field, 'PRES') /= 0 .or. &
-             index(field % field, 'SNOW') /= 0 .or. &
-             index(field % field, 'SEAICE') /= 0 .or. &
-             index(field % field, 'SKINTEMP') /= 0) then
+         if (trim(field % field) == 'UU' .or. &
+             trim(field % field) == 'VV' .or. &
+             trim(field % field) == 'TT' .or. &
+             trim(field % field) == 'RH' .or. &
+             trim(field % field) == 'GHT' .or. &
+             trim(field % field) == 'PMSL' .or. &
+             trim(field % field) == 'PSFC' .or. &
+             trim(field % field) == 'SOILHGT' .or. &
+             trim(field % field) == 'SM000010' .or. &
+             trim(field % field) == 'SM010040' .or. &
+             trim(field % field) == 'SM040100' .or. &
+             trim(field % field) == 'SM100200' .or. &
+             trim(field % field) == 'SM010200' .or. &
+             trim(field % field) == 'SM000007' .or. &
+             trim(field % field) == 'SM007028' .or. &
+             trim(field % field) == 'SM028100' .or. &
+             trim(field % field) == 'SM100255' .or. &
+             trim(field % field) == 'ST000010' .or. &
+             trim(field % field) == 'ST010040' .or. &
+             trim(field % field) == 'ST040100' .or. &
+             trim(field % field) == 'ST100200' .or. &
+             trim(field % field) == 'ST010200' .or. &
+             trim(field % field) == 'ST000007' .or. &
+             trim(field % field) == 'ST007028' .or. &
+             trim(field % field) == 'ST028100' .or. &
+             trim(field % field) == 'ST100255' .or. &
+             trim(field % field) == 'PRES' .or. &
+             trim(field % field) == 'SNOW' .or. &
+             trim(field % field) == 'SEAICE' .or. &
+             trim(field % field) == 'SKINTEMP') then
 
-            if (index(field % field, 'SM000010') /= 0 .or. &
-                index(field % field, 'SM010040') /= 0 .or. &
-                index(field % field, 'SM040100') /= 0 .or. &
-                index(field % field, 'SM100200') /= 0 .or. &
-                index(field % field, 'SM010200') /= 0 .or. &
-                index(field % field, 'SM000007') /= 0 .or. &
-                index(field % field, 'SM007028') /= 0 .or. &
-                index(field % field, 'SM028100') /= 0 .or. &
-                index(field % field, 'SM100255') /= 0 .or. &
-                index(field % field, 'ST000010') /= 0 .or. &
-                index(field % field, 'ST010040') /= 0 .or. &
-                index(field % field, 'ST040100') /= 0 .or. &
-                index(field % field, 'ST100200') /= 0 .or. &
-                index(field % field, 'ST010200') /= 0 .or. &
-                index(field % field, 'ST000007') /= 0 .or. &
-                index(field % field, 'ST007028') /= 0 .or. &
-                index(field % field, 'ST028100') /= 0 .or. &
-                index(field % field, 'ST100255') /= 0 .or. &
-                index(field % field, 'SNOW') /= 0 .or. &
-                index(field % field, 'SEAICE') /= 0 .or. &
-                index(field % field, 'SKINTEMP') /= 0) then
+            if (trim(field % field) == 'SM000010' .or. &
+                trim(field % field) == 'SM010040' .or. &
+                trim(field % field) == 'SM040100' .or. &
+                trim(field % field) == 'SM100200' .or. &
+                trim(field % field) == 'SM010200' .or. &
+                trim(field % field) == 'SM000007' .or. &
+                trim(field % field) == 'SM007028' .or. &
+                trim(field % field) == 'SM028100' .or. &
+                trim(field % field) == 'SM100255' .or. &
+                trim(field % field) == 'ST000010' .or. &
+                trim(field % field) == 'ST010040' .or. &
+                trim(field % field) == 'ST040100' .or. &
+                trim(field % field) == 'ST100200' .or. &
+                trim(field % field) == 'ST010200' .or. &
+                trim(field % field) == 'ST000007' .or. &
+                trim(field % field) == 'ST007028' .or. &
+                trim(field % field) == 'ST028100' .or. &
+                trim(field % field) == 'ST100255' .or. &
+                trim(field % field) == 'SNOW' .or. &
+                trim(field % field) == 'SEAICE' .or. &
+                trim(field % field) == 'SKINTEMP') then
                k = 1
-            else if (index(field % field, 'PMSL') == 0 .and. &
-                     index(field % field, 'PSFC') == 0 .and. &
-                     index(field % field, 'SOILHGT') == 0) then
+            else if (trim(field % field) /= 'PMSL' .and. &
+                     trim(field % field) /='PSFC' .and. &
+                     trim(field % field) /= 'SOILHGT')  then
                do k=1,config_nfglevels
                   if (vert_level(k) == field % xlvl .or. vert_level(k) == -1.0) exit
                end do
@@ -3298,7 +3298,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
             !
             ! Horizontally interpolate the field at level k
             !
-            if (index(field % field, 'UU') /= 0) then
+            if (trim(field % field) == 'UU') then
 write(0,*) 'Interpolating U at ', k, vert_level(k)
 
                mask_array => edge_mask
@@ -3308,7 +3308,7 @@ write(0,*) 'Interpolating U at ', k, vert_level(k)
                lonPoints => lonEdge
                call mpas_pool_get_array(fg, 'u', destField2d)
                ndims = 2
-            else if (index(field % field, 'VV') /= 0) then
+            else if (trim(field % field) == 'VV') then
 write(0,*) 'Interpolating V at ', k, vert_level(k)
 
                mask_array => edge_mask
@@ -3318,56 +3318,56 @@ write(0,*) 'Interpolating V at ', k, vert_level(k)
                lonPoints => lonEdge
                call mpas_pool_get_array(fg, 'v', destField2d)
                ndims = 2
-            else if (index(field % field, 'TT') /= 0) then
+            else if (trim(field % field) == 'TT') then
 write(0,*) 'Interpolating T at ', k, vert_level(k)
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 't', destField2d)
                ndims = 2
-            else if (index(field % field, 'RH') /= 0) then
+            else if (trim(field % field) == 'RH') then
 write(0,*) 'Interpolating RH at ', k, vert_level(k)
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'rh', destField2d)
                ndims = 2
-            else if (index(field % field, 'GHT') /= 0) then
+            else if (trim(field % field) == 'GHT') then
 write(0,*) 'Interpolating GHT at ', k, vert_level(k)
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'z', destField2d)
                ndims = 2
-            else if (index(field % field, 'PRES') /= 0) then
+            else if (trim(field % field) == 'PRES') then
 write(0,*) 'Interpolating PRES at ', k, vert_level(k)
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'p', destField2d)
                ndims = 2
-            else if (index(field % field, 'PMSL') /= 0) then
+            else if (trim(field % field) == 'PMSL') then
 write(0,*) 'Interpolating PMSL'
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'pmsl', destField1d)
                ndims = 1
-            else if (index(field % field, 'PSFC') /= 0) then
+            else if (trim(field % field) == 'PSFC') then
 write(0,*) 'Interpolating PSFC'
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'psfc', destField1d)
                ndims = 1
-            else if (index(field % field, 'SOILHGT') /= 0) then
+            else if (trim(field % field) == 'SOILHGT') then
 write(0,*) 'Interpolating SOILHGT'
                nInterpPoints = nCells
                latPoints => latCell
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'soilz', destField1d)
                ndims = 1
-            else if (index(field % field, 'SM000010') /= 0) then
+            else if (trim(field % field) == 'SM000010') then
 write(0,*) 'Interpolating SM000010'
 
                interp_list(1) = FOUR_POINT
@@ -3387,7 +3387,7 @@ write(0,*) 'Interpolating SM000010'
                ndims = 2
                dzs_fg(k,:) = 10.
                zs_fg(k,:) = 10.
-            else if (index(field % field, 'SM010200') /= 0) then
+            else if (trim(field % field) == 'SM010200') then
 write(0,*) 'Interpolating SM010200'
 
                interp_list(1) = FOUR_POINT
@@ -3407,7 +3407,7 @@ write(0,*) 'Interpolating SM010200'
                ndims = 2
                dzs_fg(k,:) = 200.-10.
                zs_fg(k,:) = 200.
-            else if (index(field % field, 'SM010040') /= 0) then
+            else if (trim(field % field) == 'SM010040') then
 write(0,*) 'Interpolating SM010040'
 
                interp_list(1) = FOUR_POINT
@@ -3427,7 +3427,7 @@ write(0,*) 'Interpolating SM010040'
                ndims = 2
                dzs_fg(k,:) = 40.-10.
                zs_fg(k,:) = 40.
-            else if (index(field % field, 'SM040100') /= 0) then
+            else if (trim(field % field) == 'SM040100') then
 write(0,*) 'Interpolating SM040100'
 
                interp_list(1) = FOUR_POINT
@@ -3447,7 +3447,7 @@ write(0,*) 'Interpolating SM040100'
                ndims = 2
                dzs_fg(k,:) = 100.-40.
                zs_fg(k,:) = 100.
-            else if (index(field % field, 'SM100200') /= 0) then
+            else if (trim(field % field) == 'SM100200') then
 write(0,*) 'Interpolating SM100200'
 
                interp_list(1) = FOUR_POINT
@@ -3467,7 +3467,7 @@ write(0,*) 'Interpolating SM100200'
                ndims = 2
                dzs_fg(k,:) = 200.-100.
                zs_fg(k,:) = 200.
-            else if (index(field % field, 'SM000007') /= 0) then
+            else if (trim(field % field) == 'SM000007') then
 write(0,*) 'Interpolating SM000007'
 
                interp_list(1) = FOUR_POINT
@@ -3487,7 +3487,7 @@ write(0,*) 'Interpolating SM000007'
                ndims = 2
                dzs_fg(k,:) = 7.
                zs_fg(k,:) = 7.
-            else if (index(field % field, 'SM007028') /= 0) then
+            else if (trim(field % field) == 'SM007028') then
 write(0,*) 'Interpolating SM007028'
 
                interp_list(1) = FOUR_POINT
@@ -3507,7 +3507,7 @@ write(0,*) 'Interpolating SM007028'
                ndims = 2
                dzs_fg(k,:) = 28.-7.
                zs_fg(k,:) = 28.
-            else if (index(field % field, 'SM028100') /= 0) then
+            else if (trim(field % field) == 'SM028100') then
 write(0,*) 'Interpolating SM028100'
 
                interp_list(1) = FOUR_POINT
@@ -3527,7 +3527,7 @@ write(0,*) 'Interpolating SM028100'
                ndims = 2
                dzs_fg(k,:) = 100.-28.
                zs_fg(k,:) = 100.
-            else if (index(field % field, 'SM100255') /= 0) then
+            else if (trim(field % field) == 'SM100255') then
 write(0,*) 'Interpolating SM100255'
 
                interp_list(1) = FOUR_POINT
@@ -3547,7 +3547,7 @@ write(0,*) 'Interpolating SM100255'
                ndims = 2
                dzs_fg(k,:) = 255.-100.
                zs_fg(k,:) = 255.
-            else if (index(field % field, 'ST000010') /= 0) then
+            else if (trim(field % field) == 'ST000010') then
 write(0,*) 'Interpolating ST000010'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3568,7 +3568,7 @@ write(0,*) 'Interpolating ST000010'
                ndims = 2
                dzs_fg(k,:) = 10.
                zs_fg(k,:) = 10.
-            else if (index(field % field, 'ST010200') /= 0) then
+            else if (trim(field % field) == 'ST010200') then
 write(0,*) 'Interpolating ST010200'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3589,7 +3589,7 @@ write(0,*) 'Interpolating ST010200'
                ndims = 2
                dzs_fg(k,:) = 200.-10.
                zs_fg(k,:) = 200.
-            else if (index(field % field, 'ST010040') /= 0) then
+            else if (trim(field % field) == 'ST010040') then
 write(0,*) 'Interpolating ST010040'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3610,7 +3610,7 @@ write(0,*) 'Interpolating ST010040'
                ndims = 2
                dzs_fg(k,:) = 40.-10.               
                zs_fg(k,:) = 40.
-            else if (index(field % field, 'ST040100') /= 0) then
+            else if (trim(field % field) == 'ST040100') then
 write(0,*) 'Interpolating ST040100'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3631,7 +3631,7 @@ write(0,*) 'Interpolating ST040100'
                ndims = 2
                dzs_fg(k,:) = 100.-40.             
                zs_fg(k,:) = 100.
-            else if (index(field % field, 'ST100200') /= 0) then
+            else if (trim(field % field) == 'ST100200') then
 write(0,*) 'Interpolating ST100200'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3652,7 +3652,7 @@ write(0,*) 'Interpolating ST100200'
                ndims = 2
                dzs_fg(k,:) = 200.-100.
                zs_fg(k,:) = 200.
-            else if (index(field % field, 'ST000007') /= 0) then
+            else if (trim(field % field) == 'ST000007') then
 write(0,*) 'Interpolating ST000007'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3673,7 +3673,7 @@ write(0,*) 'Interpolating ST000007'
                ndims = 2
                dzs_fg(k,:) = 7.
                zs_fg(k,:) = 7.
-            else if (index(field % field, 'ST007028') /= 0) then
+            else if (trim(field % field) == 'ST007028') then
 write(0,*) 'Interpolating ST007028'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3694,7 +3694,7 @@ write(0,*) 'Interpolating ST007028'
                ndims = 2
                dzs_fg(k,:) = 28.-7.
                zs_fg(k,:) = 28.
-            else if (index(field % field, 'ST028100') /= 0) then
+            else if (trim(field % field) == 'ST028100') then
 write(0,*) 'Interpolating ST028100'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3715,7 +3715,7 @@ write(0,*) 'Interpolating ST028100'
                ndims = 2
                dzs_fg(k,:) = 100.-28.
                zs_fg(k,:) = 100.
-            else if (index(field % field, 'ST100255') /= 0) then
+            else if (trim(field % field) == 'ST100255') then
 write(0,*) 'Interpolating ST100255'
 
                interp_list(1) = SIXTEEN_POINT
@@ -3736,7 +3736,7 @@ write(0,*) 'Interpolating ST100255'
                ndims = 2
                dzs_fg(k,:) = 255.-100.
                zs_fg(k,:) = 255.
-            else if (index(field % field, 'SNOW') /= 0) then
+            else if (trim(field % field) == 'SNOW') then
 write(0,*) 'Interpolating SNOW'
 
                interp_list(1) = FOUR_POINT
@@ -3751,7 +3751,7 @@ write(0,*) 'Interpolating SNOW'
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'snow', destField1d)
                ndims = 1
-            else if (index(field % field, 'SEAICE') /= 0) then
+            else if (trim(field % field) == 'SEAICE') then
 write(0,*) 'Interpolating SEAICE'
 
                interp_list(1) = FOUR_POINT
@@ -3768,7 +3768,7 @@ write(0,*) 'Interpolating SEAICE'
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'xice', destField1d)
                ndims = 1
-            else if (index(field % field, 'SKINTEMP') /= 0) then
+            else if (trim(field % field) == 'SKINTEMP') then
 write(0,*) 'Interpolating SKINTEMP'
                nInterpPoints = nCells
                latPoints => latCell
@@ -3912,7 +3912,7 @@ write(0,*) 'Done with soil consistency check'
       if (istatus == 0) then
          call read_next_met_field(field, istatus)
          do while (istatus == 0)
-            if (index(field % field, 'SEAICE') /= 0) then
+            if (trim(field % field) == 'SEAICE') then
 
 write(0,*) 'PROCESSING SEAICE'
 
@@ -3932,7 +3932,7 @@ write(0,*) 'PROCESSING SEAICE'
                                lon1 = real(field % startlon,RKIND))
                end if
 
-               if (index(field % field, 'SEAICE') /= 0) then
+               if (trim(field % field) == 'SEAICE') then
                   nInterpPoints = nCells
                   latPoints => latCell
                   lonPoints => lonCell

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -145,7 +145,7 @@
  have_landmask = .false.
  call read_next_met_field(field,istatus)
  do while (istatus == 0)
-    if(index(field % field, 'LANDSEA') /= 0) then
+    if(trim(field % field) == 'LANDSEA') then
        have_landmask = .true.
        if(.not.allocated(maskslab)) allocate(maskslab(-2:field % nx+3, field % ny))
        maskslab(1:field % nx, 1:field % ny) = field % slab(1:field % nx, 1:field % ny)
@@ -183,7 +183,7 @@
  do while (istatus == 0)
 
     !sea-surface data:
-    if(index(field % field, 'SKINTEMP') /= 0 .or. index(field % field, 'SST') /= 0) then
+    if((trim(field % field) == 'SKINTEMP') .or. (trim(field % field) ==  'SST')) then
 !      write(0,*) '... Processing SST:'
        sst(1:nCells) = 0.0_RKIND
        destField1d => sst
@@ -208,7 +208,7 @@
        deallocate(field%slab)
 
     !sea-ice data:
-    else if(index(field % field, 'SEAICE') /= 0) then
+    else if(trim(field % field) == 'SEAICE') then
 !      write(0,*) '... Processing SEAICE:'
        xice(1:nCells) = 0.0_RKIND
        destField1d => xice


### PR DESCRIPTION
This merge improves the comparison of strings -- particularly when comparing literal strings to names of fields in intermediate files -- by switch from 'index(name, "VAL") /= 0' to 'trim(name) == "VAL"' in the init_atmosphere core.

The old method of comparing names of fields in intermediate files to determine which block
of code is used to handle the interpolation of the field led to false matches, e.g., "HGTTROP"
matching "TT", or "SNOWH" matching "SNOW". So, we switch to a more robust method of comparing.
