### PR TITLE
Fix testing infrastructure setup of EC_60to30km/with_land_ice

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_driver.xml
@@ -6,8 +6,7 @@
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
 	</case>
 	<step executable="./scripts/iterate_init.py">
- 		<argument flag="">--iteration_count=5</argument>
- 		<argument flag="">--plot_globalStats</argument>
+ 		<argument flag="">--iteration_count=15</argument>
  		<argument flag="">--variable_to_modify=landIcePressure</argument>
 	</step>
 	<case name="spin_up1">

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_forward.xml
@@ -4,6 +4,9 @@
 	<add_link source="../forward_iter/init.nc" dest="init.nc"/>
 	<add_link source="../forward_iter/forcing_data.nc" dest="forcing_data.nc"/>
 
+	<add_link source="../spin_up1/Restart_timestamp" dest="Restart_timestamp"/>
+	<add_link source="../spin_up1/restarts" dest="restarts"/>
+
 	<add_executable source="metis" dest="metis"/>
 
 	<namelist name="namelist.ocean" mode="forward">
@@ -11,8 +14,11 @@
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
 		<option name="config_check_ssh_consistency">.false.</option>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_land_ice_flux_mode">'standalone'</option>
+		<option name="config_run_duration">'00-00-10_00:00:00'</option>
+		<option name="config_do_restart">.true.</option>
+		<option name="config_start_time">'file'</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
@@ -25,10 +31,13 @@
 		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="output">
-			<attribute name="output_interval">00-01-00_00:00:00</attribute>
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 		<stream name="restart">
-			<attribute name="output_interval">00-01-00_00:00:00</attribute>
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="land_ice_fluxes">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
 		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_forward_iter.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_forward_iter.xml
@@ -8,6 +8,7 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_AM_globalStats_enable">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>
 		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_spin_up1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <config case="spin_up1">
-	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
-	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+	<add_link source="../forward_iter/init.nc" dest="init.nc"/>
+	<add_link source="../forward_iter/forcing_data.nc" dest="forcing_data.nc"/>
 
 	<add_executable source="metis" dest="metis"/>
 
@@ -14,6 +14,8 @@
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>
 		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
+		<option name="config_check_ssh_consistency">.false.</option>
+		<option name="config_land_ice_flux_mode">'pressure_only'</option>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 	</namelist>
 
@@ -29,6 +31,9 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 		<stream name="restart">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="land_ice_fluxes">
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 


### PR DESCRIPTION
This merge makes several changes necessary for the global_ocean/EC_60to30km/with_land_ice test case to work properly:
- increase ssh-adjustment iterations from 5 to 15
- fix links and namelist settings in spin_up1 and forward steps
- add land_ice_fluxes to forward run
- reduce output interval for output and restart to 10 days from monthly
- disable globalStats AM during iterative ssh adjustment
