### PR TITLE
Add missing template to EC_60to30km/with_land_ice

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_spin_up1.xml
@@ -27,6 +27,7 @@
 			<attribute name="filename_template">init.nc</attribute>
 		</stream>
 		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="output">
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>


### PR DESCRIPTION
The land-ice fluxes template was missing from the spin_up1 case.
