### PR TITLE
Add accumulated land-ice mass and heat, and accumulated frazil under land ice

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1367,6 +1367,10 @@
 			<var name="effectiveDensityInLandIce"/>
 			<var_struct name="ecosysAuxiliary"/>
 			<var name="accumulatedFrazilIceMass"/>
+			<var name="accumulatedFrazilIceSalinity"/>
+			<var name="accumulatedLandIceMass"/>
+			<var name="accumulatedLandIceHeat"/>
+			<var name="accumulatedLandIceFrazilMass"/>
 			<var name="frazilSurfacePressure"/>
 		</stream>
 
@@ -1683,6 +1687,20 @@
 		<var name="accumulatedFrazilIceSalinity" type="real" dimensions="nCells Time" units="kg m^{-2}"
 			 description="Salinity associated with accumulatedFrazilIceMass. Reset to zero at each coupling interval"
 			 packages="frazilIce"
+		/>
+
+		<!-- FIELDS FOR LAND ICE STORAGE -->
+		<var name="accumulatedLandIceMass" type="real" dimensions="nCells Time" units="kg m^{-2}"
+			description="Mass per unit area of land ice produced at land ice-ocean interface. Only computed in 'standalone' mode where land-ice fluxes are computed in MPAS-O."
+			packages="landIceFluxesPKG"
+		/>
+		<var name="accumulatedLandIceHeat" type="real" dimensions="nCells Time" units="J m^{-2}"
+			description="Heat per unit area stored in land ice produced at land ice-ocean interface. Only computed in 'standalone' mode where land-ice fluxes are computed in MPAS-O."
+			packages="landIceFluxesPKG"
+		/>
+		<var name="accumulatedLandIceFrazilMass" type="real" dimensions="nCells Time" units="kg m^{-2}"
+			description="Mass per unit area of frazil ice produced under land ice.  Only computed when not coupled to a dynamic land-ice model."
+			packages="frazilIce"
 		/>
 
 		<!-- FIELDS FOR SPLIT EXPLICIT TIME INTEGRATOR -->

--- a/src/core_ocean/analysis_members/Registry_global_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_global_stats.xml
@@ -129,6 +129,18 @@
 			<var name="iceRunoffFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
 				 description="Minimum global value of iceRunoffFlux in ocean cells."
 			/>
+			<var name="landIceFreshwaterFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
+				 description="Minimum global value of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassMin" array_group="mins" units="kg m^{-2}"
+				 description="Minimum global value of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatMin" array_group="mins" units="J m^{-2}"
+				 description="Minimum global value of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassMin" array_group="mins" units="kg m^{-2}"
+				 description="Minimum global value of accumulatedLandIceFrazilMass in ocean cells."
+			/>
 		</var_array>
 
 		<var_array name="maxGlobalStats" type="real" dimensions="Time">
@@ -203,6 +215,18 @@
 			/>
 			<var name="iceRunoffFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
 				 description="Maximum global value of iceRunoffFlux in ocean cells."
+			/>
+			<var name="landIceFreshwaterFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
+				 description="Maximum global value of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassMax" array_group="maxes" units="kg m^{-2}"
+				 description="Maximum global value of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatMax" array_group="maxes" units="J m^{-2}"
+				 description="Maximum global value of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassMax" array_group="maxes" units="kg m^{-2}"
+				 description="Maximum global value of accumulatedLandIceFrazilMass in ocean cells."
 			/>
 		</var_array>
 
@@ -279,6 +303,18 @@
 			<var name="iceRunoffFluxSum" array_group="sums" units="kg s^{-1}"
 				 description="Accumulated global value of iceRunoffFlux in ocean cells."
 			/>
+			<var name="landIceFreshwaterFluxSum" array_group="sums" units="kg s^{-1}"
+				 description="Accumulated global value of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassSum" array_group="sums" units="kg"
+				 description="Accumulated global value of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatSum" array_group="sums" units="J"
+				 description="Accumulated global value of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassSum" array_group="sums" units="kg"
+				 description="Accumulated global value of accumulatedLandIceFrazilMass in ocean cells."
+			/>
 		</var_array>
 
 		<var_array name="rmsGlobalStats" type="real" dimensions="Time">
@@ -353,6 +389,18 @@
 			/>
 			<var name="iceRunoffFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
 				 description="Global root mean square value of iceRunoffFlux in ocean cells."
+			/>
+			<var name="landIceFreshwaterFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
+				 description="Global root mean square value of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassRms" array_group="rms" units="kg m^{-2}"
+				 description="Global root mean square value of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatRms" array_group="rms" units="J m^{-2}"
+				 description="Global root mean square value of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassRms" array_group="rms" units="kg m^{-2}"
+				 description="Global root mean square value of accumulatedLandIceFrazilMass in ocean cells."
 			/>
 		</var_array>
 
@@ -429,6 +477,18 @@
 			<var name="iceRunoffFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
 				 description="Average value of iceRunoffFlux in ocean cells."
 			/>
+			<var name="landIceFreshwaterFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
+				 description="Average value of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassAvg" array_group="avg" units="kg m^{-2}"
+				 description="Average value of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatAvg" array_group="avg" units="J m^{-2}"
+				 description="Average value of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassAvg" array_group="avg" units="kg m^{-2}"
+				 description="Average value of accumulatedLandIceFrazilMass in ocean cells."
+			/>
 		</var_array>
 
 		<var_array name="vertSumMinGlobalStats" type="real" dimensions="Time">
@@ -504,6 +564,18 @@
 			<var name="iceRunoffFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
 				 description="Minimum vertical sum of iceRunoffFlux in ocean cells."
 			/>
+			<var name="landIceFreshwaterFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
+				 description="Minimum vertical sum of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassMinVertSum" array_group="vertSumMin" units="kg m^{-2}"
+				 description="Minimum vertical sum of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatMinVertSum" array_group="vertSumMin" units="J m^{-2}"
+				 description="Minimum vertical sum of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassMinVertSum" array_group="vertSumMin" units="kg m^{-2}"
+				 description="Minimum vertical sum of accumulatedLandIceFrazilMass in ocean cells."
+			/>
 		</var_array>
 
 		<var_array name="vertSumMaxGlobalStats" type="real" dimensions="Time">
@@ -578,6 +650,18 @@
 			/>
 			<var name="iceRunoffFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}"
 				 description="Maximum vertical sum of iceRunoffFlux in ocean cells."
+			/>
+			<var name="landIceFreshwaterFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}m"
+				 description="Maximum vertical sum of landIceFreshwaterFlux in ocean cells."
+			/>
+			<var name="accumulatedLandIceMassMaxVertSum" array_group="vertSumMax" units="kg m^{-2}"
+				 description="Maximum vertical sum of accumulatedLandIceMass in ocean cells."
+			/>
+			<var name="accumulatedLandIceHeatMaxVertSum" array_group="vertSumMax" units="J m^{-2}"
+				 description="Maximum vertical sum of accumulatedLandIceHeat in ocean cells."
+			/>
+			<var name="accumulatedLandIceFrazilMassMaxVertSum" array_group="vertSumMax" units="kg m^{-2}"
+				 description="Maximum vertical sum of accumulatedLandIceFrazilMass in ocean cells."
 			/>
 		</var_array>
 		<var name="totalVolumeChange" type="real" dimensions="Time" units="m"

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -233,7 +233,7 @@ contains
       integer :: k, i, fileID
       integer :: timeYYYY, timeMM, timeDD, timeH, timeM, timeS
       integer, pointer :: nVertLevels, nCellsSolve, nEdgesSolve, nVerticesSolve, num_activeTracers
-      character*1 timeChar
+
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot
 
@@ -256,7 +256,9 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: evaporationFlux, snowFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
-      real (kind=RKIND), dimension(:), pointer :: rainFlux
+      real (kind=RKIND), dimension(:), pointer :: rainFlux, landIceFreshwaterFlux
+      real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMass, accumulatedLandIceHeat, &
+                                                  accumulatedLandIceFrazilMass
 
       real (kind=RKIND), dimension(:,:), pointer :: frazilLayerThicknessTendency
 
@@ -368,6 +370,11 @@ contains
          call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
          call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
+         call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+
+         call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMass, 1)
+         call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeat, 1)
+         call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMass, 1)
 
          allocate(areaEdge(1:nEdgesSolve))
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
@@ -834,6 +841,96 @@ contains
          verticalSumMins(variableIndex) = mins(variableIndex)
          verticalSumMaxes(variableIndex) = maxes(variableIndex)
 
+         ! landIceFreshwaterFlux
+         variableIndex = variableIndex + 1
+         if ( associated(landIceFreshwaterFlux) ) then
+            call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
+                                                                 areaCell(1:nCellsSolve), &
+                                                                 landIceFreshwaterFlux(1:nCellsSolve), sums_tmp(variableIndex), &
+                                                                 sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
+                                                                 maxes_tmp(variableIndex))
+         else
+            sums_tmp(variableIndex) = 0.0_RKIND
+            sumSquares_tmp(variableIndex) = 0.0_RKIND
+            mins_tmp(variableIndex) = 0.0_RKIND
+            maxes_tmp(variableIndex) = 0.0_RKIND
+         end if
+
+         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
+         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
+         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
+         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
+         verticalSumMins(variableIndex) = mins(variableIndex)
+         verticalSumMaxes(variableIndex) = maxes(variableIndex)
+
+         ! accumulatedLandIceMass
+         variableIndex = variableIndex + 1
+         if ( associated(accumulatedLandIceMass) ) then
+            call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
+                                                                 areaCell(1:nCellsSolve), &
+                                                                 accumulatedLandIceMass(1:nCellsSolve), sums_tmp(variableIndex), &
+                                                                 sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
+                                                                 maxes_tmp(variableIndex))
+         else
+            sums_tmp(variableIndex) = 0.0_RKIND
+            sumSquares_tmp(variableIndex) = 0.0_RKIND
+            mins_tmp(variableIndex) = 0.0_RKIND
+            maxes_tmp(variableIndex) = 0.0_RKIND
+         end if
+
+         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
+         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
+         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
+         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
+         verticalSumMins(variableIndex) = mins(variableIndex)
+         verticalSumMaxes(variableIndex) = maxes(variableIndex)
+
+         ! accumulatedLandIceHeat
+         variableIndex = variableIndex + 1
+         if ( associated(accumulatedLandIceHeat) ) then
+            call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
+                                                                 areaCell(1:nCellsSolve), &
+                                                                 accumulatedLandIceHeat(1:nCellsSolve), sums_tmp(variableIndex), &
+                                                                 sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
+                                                                 maxes_tmp(variableIndex))
+         else
+            sums_tmp(variableIndex) = 0.0_RKIND
+            sumSquares_tmp(variableIndex) = 0.0_RKIND
+            mins_tmp(variableIndex) = 0.0_RKIND
+            maxes_tmp(variableIndex) = 0.0_RKIND
+         end if
+
+         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
+         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
+         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
+         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
+         verticalSumMins(variableIndex) = mins(variableIndex)
+         verticalSumMaxes(variableIndex) = maxes(variableIndex)
+
+         ! accumulatedLandIceFrazilMass
+         variableIndex = variableIndex + 1
+         if ( associated(accumulatedLandIceFrazilMass) ) then
+            call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
+                                                                 areaCell(1:nCellsSolve), &
+                                                                 accumulatedLandIceFrazilMass(1:nCellsSolve), sums_tmp(variableIndex), &
+                                                                 sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
+                                                                 maxes_tmp(variableIndex))
+         else
+            sums_tmp(variableIndex) = 0.0_RKIND
+            sumSquares_tmp(variableIndex) = 0.0_RKIND
+            mins_tmp(variableIndex) = 0.0_RKIND
+            maxes_tmp(variableIndex) = 0.0_RKIND
+         end if
+
+         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
+         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
+         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
+         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
+         verticalSumMins(variableIndex) = mins(variableIndex)
+         verticalSumMaxes(variableIndex) = maxes(variableIndex)
+
+
+
          deallocate(workArray)
 
          nVariables = variableIndex
@@ -1060,6 +1157,29 @@ contains
 
       ! continue accumulating fresh water inputs
       netFreshwaterInput = netFreshwaterInput + sums(variableIndex) * dt/rho_sw
+
+      ! landIceFreshwaterFlux
+      variableIndex = variableIndex + 1
+      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+
+      ! continue accumulating fresh water inputs
+      netFreshwaterInput = netFreshwaterInput + sums(variableIndex) * dt/rho_sw
+
+      ! accumulatedLandIceMass
+      variableIndex = variableIndex + 1
+      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+
+      ! accumulatedLandIceHeat
+      variableIndex = variableIndex + 1
+      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+
+      ! accumulatedLandIceFrazilMass
+      variableIndex = variableIndex + 1
+      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
 
       ! calculate fresh water conservation check quantities
       absoluteFreshWaterConservation = totalVolumeChange - netFreshwaterInput

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -515,7 +515,7 @@ module ocn_forward_mode
            call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, ierr, 1)
            call mpas_timer_start("land_ice_build_arrays")
            call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
-                                                         forcingPool, scratchPool, err)
+                                                         forcingPool, scratchPool, statePool, dt, err)
            call mpas_timer_stop("land_ice_build_arrays")
 
            call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -365,6 +365,8 @@ contains
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceMassOld
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceSalinityNew
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedFrazilIceSalinityOld
+      real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassNew
+      real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassOld
       real (kind=RKIND), pointer, dimension(:)     :: ssh
       real (kind=RKIND), pointer, dimension(:,:)   :: zMid
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
@@ -407,6 +409,8 @@ contains
       call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMassOld, 1)
       call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityNew, 2)
       call mpas_pool_get_array(statePool, 'accumulatedFrazilIceSalinity', accumulatedFrazilIceSalinityOld, 1)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
@@ -580,6 +584,14 @@ contains
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
                                            * config_frazil_ice_density
         accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
+
+        if ( associated(landIceMask) ) then
+           ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
+           ! for freshwater budgets
+           accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
+                                                  + landIceMask(iCell) * sumNewFrazilIceThickness &
+                                                    * config_frazil_ice_density
+        end if
 
       enddo   ! do iCell = 1, nCells
       !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -680,7 +680,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err1, 1)
       err = ior(err, err1)
       call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
-                                                    forcingPool, scratchPool, err1)
+                                                    forcingPool, scratchPool, statePool, dt, err1)
       err = ior(err, err1)
 
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -355,7 +355,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
-      forcingPool, scratchPool, err) !{{{
+      forcingPool, scratchPool, statePool, dt, err) !{{{
 
       !-----------------------------------------------------------------
       !
@@ -366,6 +366,7 @@ contains
       type (mpas_pool_type), intent(in) :: &
          meshPool, &     !< Input: mesh information
          diagnosticsPool !< Input: diagnostics information
+      real(kind=RKIND), intent(in) :: dt ! the time step over which to accumulate fluxes
 
       !-----------------------------------------------------------------
       !
@@ -374,7 +375,8 @@ contains
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(inout) :: &
          forcingPool, & !< Input: Forcing information
-         scratchPool    !< Input: scratch field information
+         scratchPool, & !< Input: scratch field information
+         statePool      !< Input: state field information
 
       !-----------------------------------------------------------------
       !
@@ -410,6 +412,10 @@ contains
                                                   freezeInterfaceSalinity, freezeInterfaceTemperature, &
                                                   freezeFreshwaterFlux, freezeHeatFlux, &
                                                   freezeIceHeatFlux
+      real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMassOld, &
+                                                  accumulatedLandIceMassNew, &
+                                                  accumulatedLandIceHeatOld, &
+                                                  accumulatedLandIceHeatNew
 
       real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, &
                                                     landIceInterfaceTracers, &
@@ -455,6 +461,10 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracers)
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassNew, 2)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassOld, 1)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)
+      call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatOld, 1)
 
       if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
@@ -583,6 +593,12 @@ contains
          call mpas_deallocate_scratch_field(freezeHeatFluxField, .true.)
          call mpas_deallocate_scratch_field(freezeIceHeatFluxField, .true.)
       end if
+
+      ! accumulate land-ice mass and heat
+      do iCell = 1, nCellsSolve
+        accumulatedLandIceMassNew(iCell) = accumulatedLandIceMassOld(iCell) - dt*landIceFreshwaterFlux(iCell)
+        accumulatedLandIceHeatNew(iCell) = accumulatedLandIceHeatOld(iCell) + dt*heatFluxToLandIce(iCell)
+      end do
 
       call mpas_timer_stop("land_ice_build_arrays")
 


### PR DESCRIPTION
Fields accumulatedLandIceMass, accumulatedLandIceHeat and accumulatedLandIceFrazilMass are now computed along with land-ice fluxes and frazil formation.

landIceFreshwaterFlux and these new fields have been added to the globalStats AM.

The volume sums accumulatedLandIceMassSum, accumulatedLandIceHeatSum and accumulatedLandIceFrazilMassSum are in globalStats, indicating the total mass and heat stored in land ice, should be used to close global mass and heat budgets when not coupling to a dynamic land-ice model.

Clean up:
- accumulatedFrazilIceSalinity has been added to restart.
- units of several globalStats have been corrected in the registry
- addition of frazil to the net freshwater input has been fixed
