### PR TITLE
Fix three bugs in globalStats

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -701,6 +701,8 @@ contains
             sumSquares_tmp(variableIndex) = 0.0_RKIND
             mins_tmp(variableIndex) = 0.0_RKIND
             maxes_tmp(variableIndex) = 0.0_RKIND
+            verticalSumMins_tmp(variableIndex) = 0.0_RKIND
+            verticalSumMaxes_tmp(variableIndex) = 0.0_RKIND
          end if
          sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
          sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
@@ -930,7 +932,6 @@ contains
          verticalSumMaxes(variableIndex) = maxes(variableIndex)
 
 
-
          deallocate(workArray)
 
          nVariables = variableIndex
@@ -963,8 +964,8 @@ contains
          nMaxes = nMaxes + 1
          maxes(nMaxes) = localCFL
          do i = 1, nVariables
-            mins(nMins+i) = min(mins(nMins+i),verticalSumMins_tmp(i))
-            maxes(nMaxes+i) = max(maxes(nMaxes+i),verticalSumMaxes_tmp(i))
+            mins(nMins+i) = min(mins(nMins+i),verticalSumMins(i))
+            maxes(nMaxes+i) = max(maxes(nMaxes+i),verticalSumMaxes(i))
          end do
 
          nMins = nMins + nVariables


### PR DESCRIPTION
MinVertSum and MaxVertSum:
Previously the variables verticalSumMins_tmp and verticalSumMaxes_tmp
were being used to compute min/max of vertical sums even though
they were not being initialized for computations involving
surface variables.  Now, verticalSumMins and verticalSumMaxes
are used instead

frazilLayerThicknessTendency:
The MinVertSum and MaxVertSum were not being given a value when
frazil is not present, so a garbage value is written out.
