### PR TITLE
Add support for writing time of day in seconds

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -2064,6 +2064,13 @@ module mpas_timekeeping
                          call mpas_get_time(curTime, S=second)
                          write(timePart, '(i0.2)') second
                          outString = trim(outString) // trim(timePart)
+                     case ('S')
+                         call mpas_get_time(curTime, H=hour)
+                         call mpas_get_time(curTime, M=minute)
+                         call mpas_get_time(curTime, S=second)
+                         second = second + 60 * minute + 3600 * hour
+                         write(timePart, '(i0.5)') second
+                         outString = trim(outString) // trim(timePart)
 !                    case ('G')
                         ! Expands to multi-grid level
                      case default

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -427,7 +427,7 @@ int attribute_check(ezxml_t stream)
 	nextchar = 0;
 	for (i=(len-1); i>=0; nextchar=s_filename[i--]) {
 		if (s_filename[i] == '$') {
-			if (strchr("YMDdhmsG",nextchar) == NULL) {
+			if (strchr("YMDdhmsGS",nextchar) == NULL) {
 				snprintf(msgbuf, MSGSIZE, "filename_template for stream \"%s\" contains unrecognized variable \"$%c\".", s_name, nextchar);
 				fmt_err(msgbuf);
 				return 1;


### PR DESCRIPTION
This merge adds support to stream definitions for the $S expansion
character, which expands to the number of seconds in the current day.

It can be used as a replacement for $h.$m.$s, and some frameworks
require streams to be written using a format more like $Y-$M-$D_$S to
automatically handle the output files correctly.
