### PR TITLE
Fix acquiring landIceDraft from pool

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -282,6 +282,8 @@ contains
 
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
+       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+
        call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
        call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
        call mpas_pool_get_array(diagnosticsPool, 'density', density)


### PR DESCRIPTION
A bug was causing seg faults in certain cases with land-ice cavities
because the landIceDraft field was not being acquired from its
pool before being used.
