### PR TITLE
add land ice variables to input

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1300,6 +1300,10 @@
 			<var name="lowFreqDivergence"/>
 			<var name="effectiveDensityInLandIce"/>
 			<var_struct name="ecosysAuxiliary"/>
+			<var name="landIceMask"/>
+			<var name="landIcePressure"/>
+			<var name="landIceFraction"/>
+			<var name="landIceDraft"/>
 		</stream>
 		<stream name="KPP_testing"
 				type="output"


### PR DESCRIPTION
If available in init file, read in land ice variables.  This is needed so that an extra input stream is not required in ACME.  These variables are already in the restart stream, so then need to be in the input stream to use a restart file from stand-alone when starting a new ACME run.
