### PR TITLE
 Add landIceMask to init and restart streams

### DIFF
--- a/src/core_cice/Registry.xml
+++ b/src/core_cice/Registry.xml
@@ -441,6 +441,7 @@
 		  immutable="true">
 	    <stream name="mesh"/>
 	    <var name="fVertex"/>
+	    <var name="landIceMask"/>
 	  </stream>
 
 	  <stream name="regions"
@@ -498,6 +499,7 @@
 	    <var name="oceanStressCellU"/>
 	    <var name="oceanStressCellV"/>
 	    <var name="seaSurfaceTemperature"/>
+	    <var name="landIceMask"/>
 	    <var name="freezingMeltingPotential"/>
 	    <var name="airOceanDragCoefficientRatio"/>
 	    <var name="skeletalAlgaeConc"/>


### PR DESCRIPTION
landIceMask needs to be read into ACME on init and start-up.  We could add an additional stream in the ACME streams file, but it is more straight forward to read it in the init and restart stream in MPAS-seaIce.  If landIceMask is not available, it fills in as zeros.
