### PR TITLE
Turn off forcing during adjust_ssh in global_ocean

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_adjust_ssh.xml
@@ -10,18 +10,14 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
 		<option name="config_pio_num_iotasks">8</option>
 		<option name="config_pio_stride">16</option>
-		<option name="config_AM_globalStats_enable">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>
-		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
-		<option name="config_check_ssh_consistency">.false.</option>
 		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
 		<option name="config_dt">'00:20:00'</option>
 		<option name="config_run_duration">'0000_01:00:00'</option>
-		<option name="config_write_output_on_startup">.false.</option>
-		<option name="config_land_ice_flux_mode">'pressure_only'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_adjust_ssh.xml
@@ -10,15 +10,11 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-		<option name="config_AM_globalStats_enable">.false.</option>
-		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
-		<option name="config_check_ssh_consistency">.false.</option>
+		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
 		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
 		<option name="config_run_duration">'0000_04:00:00'</option>
-		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_pio_num_iotasks">1</option>
 		<option name="config_pio_stride">16</option>
-		<option name="config_land_ice_flux_mode">'pressure_only'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_adjust_ssh.xml
@@ -8,11 +8,9 @@
 	<namelist name="namelist.ocean" mode="forward">
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
-		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
-		<option name="config_check_ssh_consistency">.false.</option>
+		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
 		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
 		<option name="config_run_duration">'0000_06:00:00'</option>
-		<option name="config_land_ice_flux_mode">'pressure_only'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/test_cases/ocean/ocean/global_ocean/template_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/template_adjust_ssh.xml
@@ -1,4 +1,12 @@
 <template>
+	<namelist>
+		<option name="config_AM_globalStats_enable">.false.</option>
+		<option name="config_check_ssh_consistency">.false.</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_land_ice_flux_mode">'pressure_only'</option>
+		<option name="config_use_bulk_wind_stress">.false.</option>
+		<option name="config_use_activeTracers_surface_restoring">.false.</option>
+	</namelist>
 	<streams>
 		<stream name="mesh">
 			<attribute name="filename_template">init.nc</attribute>


### PR DESCRIPTION
Wind stress and surface restoring have been turned off during the
adjust_ssh step of global_ocean runs with land-ice cavities.
