### PR TITLE
change landIceMask to integer

### DIFF
--- a/src/core_cice/Registry.xml
+++ b/src/core_cice/Registry.xml
@@ -1671,7 +1671,7 @@
 		<var name="seaSurfaceTiltV"                   type="real"     dimensions="nCells Time"              name_in_code="seaSurfaceTiltV"/>
 		<var name="oceanMixedLayerDepth"              type="real"     dimensions="nCells Time"              name_in_code="oceanMixedLayerDepth"       default_value="20.0"/>
 		<var name="oceanHeatFluxConvergence"          type="real"     dimensions="nCells Time"              name_in_code="oceanHeatFluxConvergence"/>
-		<var name="landIceMask"                       type="real"     dimensions="nCells Time"              name_in_code="landIceMask"/>
+		<var name="landIceMask"                       type="integer"  dimensions="nCells Time"              name_in_code="landIceMask"/>
 		<var name="landIceMaskVertex"                 type="integer"  dimensions="nVertices Time"           name_in_code="landIceMaskVertex"/>
 	</var_struct>
 

--- a/src/core_cice/analysis_members/mpas_cice_ice_shelves.F
+++ b/src/core_cice/analysis_members/mpas_cice_ice_shelves.F
@@ -267,9 +267,11 @@ contains
            iceAreaOverIceShelves
 
       real(kind=RKIND), dimension(:), pointer :: &
-           landIceMask, &
            iceAreaCell, &
            areaCell
+
+      integer, dimension(:), pointer :: &
+           landIceMask
 
       real(kind=RKIND) :: &
            iceAreaOverIceShelvesThisProc
@@ -297,7 +299,7 @@ contains
          
          do iCell = 1, nCellsSolve
 
-            if (landIceMask(iCell) == 1.0_RKIND) then
+            if (landIceMask(iCell) == 1) then
             
                iceAreaOverIceShelvesThisProc = iceAreaOverIceShelvesThisProc + iceAreaCell(iCell) * areaCell(iCell)
 

--- a/src/core_cice/shared/mpas_cice_column.F
+++ b/src/core_cice/shared/mpas_cice_column.F
@@ -4242,8 +4242,7 @@ contains
          albedoVisibleDirectOcean, &
          albedoIRDirectOcean, &
          albedoVisibleDiffuseOcean, &
-         albedoIRDiffuseOcean, &
-         landIceMask
+         albedoIRDiffuseOcean
 
     real(kind=RKIND) :: &
          sensibleTransferCoefficient, &
@@ -4259,6 +4258,9 @@ contains
 
     integer, pointer :: &
          nCellsSolve
+
+    integer, dimension(:), pointer :: &
+           landIceMask
 
     logical, pointer :: &
          config_use_test_ice_shelf
@@ -4397,7 +4399,7 @@ contains
 
           do iCell = 1, nCellsSolve
 
-             if (landIceMask(iCell) == 1.0_RKIND) then
+             if (landIceMask(iCell) == 1) then
                 freezingMeltingPotential(iCell) = 0.0_RKIND
              endif
 

--- a/src/core_cice/shared/mpas_cice_initialize.F
+++ b/src/core_cice/shared/mpas_cice_initialize.F
@@ -557,8 +557,10 @@ contains
          latCell, &
          airTemperature, &
          seaSurfaceTemperature, &
-         seaFreezingTemperature, &
-         landIceMask
+         seaFreezingTemperature
+
+      integer, dimension(:), pointer :: &
+           landIceMask
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          initialSalinityProfile, &
@@ -636,7 +638,7 @@ contains
        if (seaSurfaceTemperature(iCell) <= seaFreezingTemperature(iCell) + 0.2_RKIND .and. &
           (latCell(iCell) > config_initial_latitude_north * ciceDegreesToRadians .or. &
            latCell(iCell) < config_initial_latitude_south * ciceDegreesToRadians) .and. &
-          landIceMask(iCell) == 0.0_RKIND) then
+          landIceMask(iCell) == 0) then
 
           ! has ice
           do iCategory = 1, nCategories
@@ -1981,11 +1983,11 @@ contains
                  lonCell(iCell) < lonLimitEast * ciceDegreesToRadians .and. &
                  latCell(iCell) < latLimit     * ciceDegreesToRadians) then
 
-                landIceMask(iCell) = 1.0_RKIND
+                landIceMask(iCell) = 1
 
              else
 
-                landIceMask(iCell) = 0.0_RKIND
+                landIceMask(iCell) = 0
 
              endif
 

--- a/src/core_cice/shared/mpas_cice_velocity_solver.F
+++ b/src/core_cice/shared/mpas_cice_velocity_solver.F
@@ -281,11 +281,9 @@ contains
          oceanCouplingPool, &
          meshPool
 
-    real(kind=RKIND), dimension(:), pointer :: &
-         landIceMask
-
     integer, dimension(:), pointer :: &
-         landIceMaskVertex
+         landIceMaskVertex, &
+         landIceMask
 
     integer, dimension(:,:), pointer :: &
          cellsOnVertex
@@ -321,7 +319,7 @@ contains
 
              iCell = cellsOnVertex(iCellOnVertex,iVertex)
 
-             if (landIceMask(iCell) == 1.0_RKIND) then
+             if (landIceMask(iCell) == 1) then
 
                 landIceMaskVertex(iVertex) = 1
 
@@ -677,8 +675,7 @@ contains
 
     real(kind=RKIND), dimension(:), pointer :: &
          iceAreaCellInitial, &
-         totalMassCell, &
-         landIceMask
+         totalMassCell
 
     integer :: &
          iCell, &
@@ -689,7 +686,8 @@ contains
          nCells
 
     integer, dimension(:), pointer :: &
-         nEdgesOnCell
+         nEdgesOnCell, &
+         landIceMask
     
     integer, dimension(:,:), pointer :: &
          cellsOnCell
@@ -720,7 +718,7 @@ contains
 
           if (iceAreaCellInitial(iCell) > ciceAreaMinimum .and. &
               totalMassCell(iCell) > ciceMassMinimum .and. &
-              landIceMask(iCell) == 0.0_RKIND) then
+              landIceMask(iCell) == 0) then
 
              ! this cell has sufficient ice
              solveStress(iCell) = 1
@@ -734,7 +732,7 @@ contains
 
                 if (iceAreaCellInitial(iCellNeighbour) > ciceAreaMinimum .and. &
                     totalMassCell(iCellNeighbour) > ciceMassMinimum .and. &
-                    landIceMask(iCellNeighbour) == 0.0_RKIND) then
+                    landIceMask(iCellNeighbour) == 0) then
 
                    solveStress(iCell) = 1
                    exit


### PR DESCRIPTION
landIceMask is an integer in the ocean model and in the input files, so it needs to be an integer in MPAS-SeaIce.  This bug fix is required to run coupled simulations in ACME with ice shelf cavities.
