### PR TITLE
Add landIceFloatingArea to globalStats

### DIFF
--- a/src/core_ocean/analysis_members/Registry_global_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_global_stats.xml
@@ -56,6 +56,10 @@
 			 description="maximum CFL number over the full domain"
 			 packages="forwardMode;analysisMode"
 		/>
+		<var name="landIceFloatingAreaSum" type="real" dimensions="Time" units="m^2"
+			 description="sum of areaCell where landIceMask == 1, used to normalize global statistics in land-ice cavities"
+			 packages="forwardMode;analysisMode"
+		/>
 		<var_array name="minGlobalStats" type="real" dimensions="Time">
 			<var name="layerThicknessMin" array_group="mins" units="m"
 				 description="Minimum global value of layerThickness in ocean cells."
@@ -130,16 +134,16 @@
 				 description="Minimum global value of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
-				 description="Minimum global value of landIceFreshwaterFlux in ocean cells."
+				 description="Minimum value of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassMin" array_group="mins" units="kg m^{-2}"
-				 description="Minimum global value of accumulatedLandIceMass in ocean cells."
+				 description="Minimum value of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatMin" array_group="mins" units="J m^{-2}"
-				 description="Minimum global value of accumulatedLandIceHeat in ocean cells."
+				 description="Minimum value of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassMin" array_group="mins" units="kg m^{-2}"
-				 description="Minimum global value of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Minimum value of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -217,16 +221,16 @@
 				 description="Maximum global value of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
-				 description="Maximum global value of landIceFreshwaterFlux in ocean cells."
+				 description="Maximum value of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassMax" array_group="maxes" units="kg m^{-2}"
-				 description="Maximum global value of accumulatedLandIceMass in ocean cells."
+				 description="Maximum value of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatMax" array_group="maxes" units="J m^{-2}"
-				 description="Maximum global value of accumulatedLandIceHeat in ocean cells."
+				 description="Maximum value of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassMax" array_group="maxes" units="kg m^{-2}"
-				 description="Maximum global value of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Maximum value of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -304,16 +308,16 @@
 				 description="Accumulated global value of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxSum" array_group="sums" units="kg s^{-1}"
-				 description="Accumulated global value of landIceFreshwaterFlux in ocean cells."
+				 description="Sum of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassSum" array_group="sums" units="kg"
-				 description="Accumulated global value of accumulatedLandIceMass in ocean cells."
+				 description="Sum of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatSum" array_group="sums" units="J"
-				 description="Accumulated global value of accumulatedLandIceHeat in ocean cells."
+				 description="Sum of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassSum" array_group="sums" units="kg"
-				 description="Accumulated global value of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Sum of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -391,16 +395,16 @@
 				 description="Global root mean square value of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
-				 description="Global root mean square value of landIceFreshwaterFlux in ocean cells."
+				 description="Root-mean-squared value of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassRms" array_group="rms" units="kg m^{-2}"
-				 description="Global root mean square value of accumulatedLandIceMass in ocean cells."
+				 description="Root-mean-squared value of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatRms" array_group="rms" units="J m^{-2}"
-				 description="Global root mean square value of accumulatedLandIceHeat in ocean cells."
+				 description="Root-mean-squared value of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassRms" array_group="rms" units="kg m^{-2}"
-				 description="Global root mean square value of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Root-mean-squared value of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -478,16 +482,16 @@
 				 description="Average value of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
-				 description="Average value of landIceFreshwaterFlux in ocean cells."
+				 description="Average value of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassAvg" array_group="avg" units="kg m^{-2}"
-				 description="Average value of accumulatedLandIceMass in ocean cells."
+				 description="Average value of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatAvg" array_group="avg" units="J m^{-2}"
-				 description="Average value of accumulatedLandIceHeat in ocean cells."
+				 description="Average value of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassAvg" array_group="avg" units="kg m^{-2}"
-				 description="Average value of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Average value of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -565,16 +569,16 @@
 				 description="Minimum vertical sum of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
-				 description="Minimum vertical sum of landIceFreshwaterFlux in ocean cells."
+				 description="Minimum vertical sum of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassMinVertSum" array_group="vertSumMin" units="kg m^{-2}"
-				 description="Minimum vertical sum of accumulatedLandIceMass in ocean cells."
+				 description="Minimum vertical sum of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatMinVertSum" array_group="vertSumMin" units="J m^{-2}"
-				 description="Minimum vertical sum of accumulatedLandIceHeat in ocean cells."
+				 description="Minimum vertical sum of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassMinVertSum" array_group="vertSumMin" units="kg m^{-2}"
-				 description="Minimum vertical sum of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Minimum vertical sum of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 
@@ -652,16 +656,16 @@
 				 description="Maximum vertical sum of iceRunoffFlux in ocean cells."
 			/>
 			<var name="landIceFreshwaterFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}m"
-				 description="Maximum vertical sum of landIceFreshwaterFlux in ocean cells."
+				 description="Maximum vertical sum of landIceFreshwaterFlux in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceMassMaxVertSum" array_group="vertSumMax" units="kg m^{-2}"
-				 description="Maximum vertical sum of accumulatedLandIceMass in ocean cells."
+				 description="Maximum vertical sum of accumulatedLandIceMass in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceHeatMaxVertSum" array_group="vertSumMax" units="J m^{-2}"
-				 description="Maximum vertical sum of accumulatedLandIceHeat in ocean cells."
+				 description="Maximum vertical sum of accumulatedLandIceHeat in ocean cells where landIceMask == 1."
 			/>
 			<var name="accumulatedLandIceFrazilMassMaxVertSum" array_group="vertSumMax" units="kg m^{-2}"
-				 description="Maximum vertical sum of accumulatedLandIceFrazilMass in ocean cells."
+				 description="Maximum vertical sum of accumulatedLandIceFrazilMass in ocean cells where landIceMask == 1."
 			/>
 		</var_array>
 		<var name="totalVolumeChange" type="real" dimensions="Time" units="m"

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -235,7 +235,8 @@ contains
       integer, pointer :: nVertLevels, nCellsSolve, nEdgesSolve, nVerticesSolve, num_activeTracers
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot
+      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot, &
+                                        landiceMask
 
       character (len=StrKIND), pointer :: xtime, simulationStartTime
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
@@ -244,8 +245,9 @@ contains
       real (kind=RKIND) :: localCFL, localSum, dt, currentVolume
       real (kind=RKIND), pointer :: volumeCellGlobal, volumeEdgeGlobal, CFLNumberGlobal, areaCellGlobal, &
                                     areaEdgeGlobal, areaTriangleGlobal, totalVolumeChange, netFreshwaterInput, &
-                                    absoluteFreshWaterConservation, relativeFreshWaterConservation
-      real (kind=RKIND), dimension(:), pointer ::  areaCell, dcEdge, dvEdge, areaTriangle, areaEdge
+                                    absoluteFreshWaterConservation, relativeFreshWaterConservation, &
+                                    landIceFloatingAreaSum
+      real (kind=RKIND), dimension(:), pointer ::  areaCell, dcEdge, dvEdge, areaTriangle, areaEdge, landIceFloatingArea
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity, tangentialVelocity, layerThicknessEdge, &
                                                     relativeVorticity, kineticEnergyCell, normalizedRelativeVorticityEdge, &
                                                     normalizedPlanetaryVorticityEdge, pressure, montgomeryPotential, &
@@ -296,6 +298,7 @@ contains
       call mpas_pool_get_array(globalStatsAMPool, 'volumeCellGlobal', volumeCellGlobal)
       call mpas_pool_get_array(globalStatsAMPool, 'volumeEdgeGlobal', volumeEdgeGlobal)
       call mpas_pool_get_array(globalStatsAMPool, 'CFLNumberGlobal', CFLNumberGlobal)
+      call mpas_pool_get_array(globalStatsAMPool, 'landIceFloatingAreaSum', landIceFloatingAreaSum)
 
       call mpas_pool_get_array(globalStatsAMPool, 'totalVolumeChange', totalVolumeChange)
       call mpas_pool_get_array(globalStatsAMPool, 'netFreshwaterInput', netFreshwaterInput)
@@ -371,6 +374,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
          call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
          call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
          call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMass, 1)
          call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeat, 1)
@@ -378,6 +382,13 @@ contains
 
          allocate(areaEdge(1:nEdgesSolve))
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
+
+         allocate(landIceFloatingArea(1:nCellsSolve))
+         if ( associated(landIceMask) ) then
+            landIceFloatingArea = landIceMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
+         else
+            landIceFloatingArea = 0.
+         end if
 
          allocate(workArray(nVertLevels,nCellsSolve))
 
@@ -847,7 +858,7 @@ contains
          variableIndex = variableIndex + 1
          if ( associated(landIceFreshwaterFlux) ) then
             call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
-                                                                 areaCell(1:nCellsSolve), &
+                                                                 landIceFloatingArea, &
                                                                  landIceFreshwaterFlux(1:nCellsSolve), sums_tmp(variableIndex), &
                                                                  sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                                                                  maxes_tmp(variableIndex))
@@ -869,7 +880,7 @@ contains
          variableIndex = variableIndex + 1
          if ( associated(accumulatedLandIceMass) ) then
             call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
-                                                                 areaCell(1:nCellsSolve), &
+                                                                 landIceFloatingArea, &
                                                                  accumulatedLandIceMass(1:nCellsSolve), sums_tmp(variableIndex), &
                                                                  sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                                                                  maxes_tmp(variableIndex))
@@ -891,7 +902,7 @@ contains
          variableIndex = variableIndex + 1
          if ( associated(accumulatedLandIceHeat) ) then
             call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
-                                                                 areaCell(1:nCellsSolve), &
+                                                                 landIceFloatingArea, &
                                                                  accumulatedLandIceHeat(1:nCellsSolve), sums_tmp(variableIndex), &
                                                                  sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                                                                  maxes_tmp(variableIndex))
@@ -913,7 +924,7 @@ contains
          variableIndex = variableIndex + 1
          if ( associated(accumulatedLandIceFrazilMass) ) then
             call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
-                                                                 areaCell(1:nCellsSolve), &
+                                                                 landIceFloatingArea, &
                                                                  accumulatedLandIceFrazilMass(1:nCellsSolve), sums_tmp(variableIndex), &
                                                                  sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                                                                  maxes_tmp(variableIndex))
@@ -957,6 +968,9 @@ contains
          nSums = nSums + 1
          sums(nSums) = sums(nSums) + nVerticesSolve
 
+         nSums = nSums + 1
+         sums(nSums) = sums(nSums) + sum(landIceFloatingArea)
+
          localCFL = 0.0_RKIND
          do iEdge = 1,nEdgesSolve
             localCFL = max(localCFL, maxval(dt*abs(normalVelocity(1:maxLevelEdgeTop(iEdge),iEdge))/dcEdge(iEdge)))
@@ -973,6 +987,8 @@ contains
 
          deallocate(areaEdge)
 
+         deallocate(landIceFloatingArea)
+
          block => block % next
       end do
 
@@ -985,6 +1001,7 @@ contains
       nCellsGlobal = int(reductions(nVariables+4))
       nEdgesGlobal = int(reductions(nVariables+5))
       nVerticesGlobal = int(reductions(nVariables+6))
+      landIceFloatingAreaSum = reductions(nVariables+7)
       call mpas_dmpar_sum_real_array(dminfo, nVariables, sumSquares(1:nVariables), reductions(1:nVariables))
       sumSquares(1:nVariables) = reductions(1:nVariables)
 
@@ -1161,26 +1178,26 @@ contains
 
       ! landIceFreshwaterFlux
       variableIndex = variableIndex + 1
-      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
-      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+      averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
 
       ! continue accumulating fresh water inputs
       netFreshwaterInput = netFreshwaterInput + sums(variableIndex) * dt/rho_sw
 
       ! accumulatedLandIceMass
       variableIndex = variableIndex + 1
-      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
-      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+      averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
 
       ! accumulatedLandIceHeat
       variableIndex = variableIndex + 1
-      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
-      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+      averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
 
       ! accumulatedLandIceFrazilMass
       variableIndex = variableIndex + 1
-      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
-      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+      averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
 
       ! calculate fresh water conservation check quantities
       absoluteFreshWaterConservation = totalVolumeChange - netFreshwaterInput


### PR DESCRIPTION
landIceFloatingArea is the the cell area multiplied by the landIceMask.

Use this area instead of the total area to compute global stats
related to land-ice cavities.

Add landIceFloatingAreaSum as the total area of cells with
landIceMask == 1.
