### PR TITLE
smooth all layers in global init

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -2182,7 +2182,6 @@ contains
       if (config_global_ocean_smooth_TS_iterations .gt. 0) then
          call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
 
-
          do iSmooth = 1,config_global_ocean_smooth_TS_iterations
 
             block_ptr => domain % blocklist
@@ -2192,7 +2191,6 @@ contains
 
                call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-               call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
                call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
                call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
 
@@ -2212,9 +2210,10 @@ contains
 
                      do j = 1, nEdgesOnCell(iCell)
                         coc = cellsOnCell(j, iCell)
-
-                        smoothedTracer(k, iCell) = smoothedTracer(k, iCell) + interpTracer (k, coc)
-                        counter = counter + 1
+                        if (coc<nCells+1) then
+                           smoothedTracer(k, iCell) = smoothedTracer(k, iCell) + interpTracer (k, coc)
+                           counter = counter + 1
+                        end if
 
                      end do ! edgesOnCell
 


### PR DESCRIPTION
This is the second PR required to allow input tracer data initial conditions (IC) to be on a different vertical grid as the final grid produced in init_step2.  The first, #1030, made many changes and all were bit-for-bit.  This PR makes the minimal non-bit-for-bit changes.  This effects all global_ocean test cases.

Previously, smoothing was conducted down to maxLevelCell.  This does not make any sense on an arbitrary input data IC.  The initialization process is now:
- interpolate IC horizontally
- horizontal smoothing: smooth each ocean column down to nVertLevels (previously maxLevelCell)
- vertical interpolation

This requires that the input tracer data IC has sensible values into land at all depths, but that is already the case with our current data files.

This PR also allows development of global sigma and hybrid vertical coordinate grids.
