### PR TITLE
Revert "Fixes an array initialization for debugging"

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -453,8 +453,6 @@ contains
               bulkRichardsonFlag = .false.
               topIndex = 1
 !             call mpas_timer_start('Bulk Richardson kIndexOBL loops')
-              ! compute the index of the last cell in the KPP defined surface layer
-              ! this index is used for the necessary surface layer averages of buoyancy and momentum
               do kIndexOBL = 1, maxLevelCell(iCell)
 
                  ! Reset deltaVelocitySquared and bulkRichardsonNumber at this layer for the later computation
@@ -468,8 +466,6 @@ contains
                  OBLDepths(kIndexOBL) = abs(cvmix_variables % zw_iface(kIndexOBL+1))
                  interfaceForcings(kIndexOBL) = cvmix_variables % SurfaceBuoyancyForcing
 
-                 ! initialize the surfaceAverageIndex for cases when the if statement below is not true 
-                 surfaceAverageIndex(kIndexOBL) = 1
                  ! move progressively downward to find the bottom most layer within the surface layer
                  sfc_layer_depth = cvmix_variables % BoundaryLayerDepth * config_cvmix_kpp_surface_layer_extent
                  do kav=topIndex,kIndexOBL


### PR DESCRIPTION
This merge reverts commit 8f9da6758454435217610869544f322ed47c1f77. This is reverted because commit 8f9da6758454435217610869544f322ed47c1f77 introduced an issue with exact restart tests within ACME.
