### PR TITLE
Add seaSurfacePressure to restart file

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1356,6 +1356,7 @@
 			<var name="xtime"/>
 			<var name="simulationStartTime"/>
 			<var name="boundaryLayerDepth"/>
+			<var name="seaSurfacePressure"/>
 			<var name="landIcePressure" packages="restartForcingFields"/>
 			<var name="landIceFraction" packages="restartForcingFields"/>
 			<var name="landIceMask" packages="restartForcingFields"/>


### PR DESCRIPTION
This merge adds seaSurfacePressure to the restart stream. It was
previously removed, but it is required for bit restarts within ACME.
