### PR TITLE
Add flags for frazil, freezing under land ice

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -681,6 +681,14 @@
 					description="Controls if fluxes related to frazil ice process are computed."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_frazil_in_open_ocean" type="logical" default_value=".true." units="unitless"
+					description="If frazil formation is used, controls if frazil fluxes are computed in the open ocean (as opposed to under land ice)."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_frazil_under_land_ice" type="logical" default_value=".true." units="unitless"
+					description="If frazil formation is used, controls if frazil fluxes are computed under land ice."
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_frazil_heat_of_fusion" type="real" default_value="3.34e5" units="J kg^{-1}"
 					description="Energy per kilogram released when sea water freezes. NOTE: test and make consistent with ACME."
 					possible_values="Any positive real number."
@@ -711,11 +719,19 @@
 		/>
 		<nml_option name="config_frazil_maximum_freezing_temperature" type="real" default_value="0.0" units="C"
 			description="Maximum freezing temperature for the creation of frazil"
-			possible_values="Any positive real number."
+			possible_values="Any real number."
 		/>
 		<nml_option name="config_frazil_use_surface_pressure" type="logical" default_value=".true." units="unitless"
 			description="Flag that controls if frazil formation will exert a surface pressure as it is formed."
 			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_frazil_use_constant_open_ocean_freezing_temperature" type="logical" default_value=".false." units="unitless"
+			description="Flag that controls if frazil formation in the open ocean (not in land-ice cavities) uses a constant freezing temperature instead of a function of P and S."
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_frazil_open_ocean_freezing_temperature" type="real" default_value="-1.8" units="C"
+			description="Freezing temperature for the creation of frazil in the open ocean if config_frazil_use_constant_open_ocean_freezing_temperature == .true."
+			possible_values="Any real number."
 		/>
 	</nml_record>
 	<nml_record name="land_ice_fluxes" mode="init;forward">

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -355,6 +355,10 @@ contains
       real (kind=RKIND), pointer :: config_frazil_land_ice_reference_salinity
       real (kind=RKIND), pointer :: config_frazil_maximum_freezing_temperature
       logical, pointer :: config_frazil_use_surface_pressure
+      logical, pointer :: config_frazil_in_open_ocean
+      logical, pointer :: config_frazil_under_land_ice
+      logical, pointer :: config_frazil_use_constant_open_ocean_freezing_temperature
+      real (kind=RKIND), pointer :: config_frazil_open_ocean_freezing_temperature
 
       real (kind=RKIND) :: newFrazilIceThickness, newThicknessWeightedSaltContent
       real (kind=RKIND) :: sumNewFrazilIceThickness, sumNewThicknessWeightedSaltContent
@@ -423,6 +427,8 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
       ! get configure parameters
+      call mpas_pool_get_config(ocnConfigs, 'config_frazil_in_open_ocean', config_frazil_in_open_ocean)
+      call mpas_pool_get_config(ocnConfigs, 'config_frazil_under_land_ice', config_frazil_under_land_ice)
       call mpas_pool_get_config(ocnConfigs, 'config_frazil_maximum_depth', config_frazil_maximum_depth)
       call mpas_pool_get_config(ocnConfigs, 'config_frazil_fractional_thickness_limit', config_frazil_fractional_thickness_limit)
       call mpas_pool_get_config(ocnConfigs, 'config_specific_heat_sea_water', config_specific_heat_sea_water)
@@ -433,6 +439,10 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_frazil_use_surface_pressure', config_frazil_use_surface_pressure)
       call mpas_pool_get_config(ocnConfigs, 'config_frazil_maximum_freezing_temperature', &
                                 config_frazil_maximum_freezing_temperature)
+      call mpas_pool_get_config(ocnConfigs, 'config_frazil_use_constant_open_ocean_freezing_temperature', &
+                                config_frazil_use_constant_open_ocean_freezing_temperature)
+      call mpas_pool_get_config(ocnConfigs, 'config_frazil_open_ocean_freezing_temperature', &
+                                config_frazil_open_ocean_freezing_temperature)
 
       ! get time step in units of seconds
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err)
@@ -457,11 +467,21 @@ contains
            underLandIce = (landIceMask(iCell) == 1)
         end if
 
+        if (underLandIce .and. .not. config_frazil_under_land_ice) then
+          ! skip this cell because we're not doing frazil under land ice
+          cycle
+        end if
+
+        if (.not. underLandIce .and. .not. config_frazil_in_open_ocean) then
+          ! skip this cell because we're not doing frazil in the open ocean
+          cycle
+        end if
+
         ! find deepest level where frazil can be created
         kBottomFrazil=maxLevelCell(iCell)
         do k=maxLevelCell(iCell), 1, -1
           ! add the ssh so frazil can form below land ice, where the ssh is depressed
-          if(-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
+          if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
             kBottomFrazil=k
             exit
           endif
@@ -476,7 +496,7 @@ contains
         enddo
 
         ! test min temperature agains max freezing temperature to see if we should even consider creating frazil
-        if(columnTemperatureMin > config_frazil_maximum_freezing_temperature) cycle
+        if (columnTemperatureMin > config_frazil_maximum_freezing_temperature) cycle
 
         ! initialize the sum of new frazil ice created
         sumNewFrazilIceThickness = 0.0_RKIND
@@ -486,8 +506,12 @@ contains
         do k = kBottomFrazil, 1, -1
 
           ! get freezing temperature
-          oceanFreezingTemperature = ocn_freezing_temperature(salinity=activeTracers(indexSalinity,k,iCell), &
-                                                              pressure=pressure(k,iCell))
+          if (underLandIce .or. .not. config_frazil_use_constant_open_ocean_freezing_temperature) then
+            oceanFreezingTemperature = ocn_freezing_temperature(salinity=activeTracers(indexSalinity,k,iCell), &
+                                                                pressure=pressure(k,iCell))
+          else
+            oceanFreezingTemperature = config_frazil_open_ocean_freezing_temperature
+          end if
 
           potential = layerThickness(k,iCell) * config_specific_heat_sea_water &
                     * rho_sw * (activeTracers(indexTemperature,k,iCell) - oceanFreezingTemperature)
@@ -498,7 +522,7 @@ contains
           if (freezingEnergy > 0) then
 
             ! get frazil salinity
-            if(underLandice) then
+            if (underLandIce) then
               frazilSalinity = config_frazil_land_ice_reference_salinity
             else
               frazilSalinity = config_frazil_sea_ice_reference_salinity
@@ -585,12 +609,11 @@ contains
                                            * config_frazil_ice_density
         accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
 
-        if ( associated(landIceMask) ) then
+        if ( underLandIce ) then
            ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
-                                                  + landIceMask(iCell) * sumNewFrazilIceThickness &
-                                                    * config_frazil_ice_density
+                                                  + sumNewFrazilIceThickness * config_frazil_ice_density
         end if
 
       enddo   ! do iCell = 1, nCells

--- a/src/core_ocean/shared/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_sea_ice.F
@@ -262,16 +262,17 @@ contains
       integer, intent(in) :: nVertLevels !< Input: Number of vertical levels suggested for level cap
       integer, intent(out) :: err !< Output: error flag
 
-      logical, pointer :: config_use_frazil_ice_formation, config_monotonic
+      logical, pointer :: config_use_frazil_ice_formation, config_monotonic, config_frazil_in_open_ocean
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_use_frazil_ice_formation', config_use_frazil_ice_formation)
+      call mpas_pool_get_config(ocnConfigs, 'config_frazil_in_open_ocean', config_frazil_in_open_ocean)
       call mpas_pool_get_config(ocnConfigs, 'config_monotonic', config_monotonic)
 
       frazilFormationOn = .false.
 
-      if(config_use_frazil_ice_formation) then
+      if(config_use_frazil_ice_formation .and. config_frazil_in_open_ocean) then
         frazilFormationOn = .true.
       end if
 


### PR DESCRIPTION
This merge adds flags to control whether frazil is computed under land ice
and in the open ocean, independently of one another.

It also adds a flag for using a constant freezing temperature in the open
ocean and a value for that constant freezing temperature.

These two sets of flags should make it easier to debug both frazil formation
and the freezing function in MPAS-O and ACME runs.
