### PR TITLE
Fix print statements for L1 and L2 norms

### DIFF
--- a/test_cases/ocean/utility_scripts/compare_fields.py
+++ b/test_cases/ocean/utility_scripts/compare_fields.py
@@ -72,9 +72,9 @@ print "Beginning variable comparisons for all time levels of field '%s'. Note an
 if ( args.l2_norm or args.l1_norm or args.linf_norm ):
 	print "    Pass thresholds are:"
 	if ( args.l1_norm ):
-		print "       L1: %f"%(float(args.l2_norm))
+		print "       L1: %f"%(float(args.l1_norm))
 	if ( args.l2_norm ):
-		print "       L2: %f"%(float(args.l1_norm))
+		print "       L2: %f"%(float(args.l2_norm))
 	if ( args.linf_norm ):
 		print "       L_Infinity: %f"%(float(args.linf_norm))
 


### PR DESCRIPTION
In test_cases/ocean/utility_scripts/compare_fields.py, the pass
thresholds for L1 and L2 norms were accidentally switched in print
statements telling the user what the thresholds are.  This only affects
the value written to stdout and not the comparison itself, but it can
also lead to an error if only one of the two norms is set.  This merge
fixes this.
