### PR TITLE
Adds RRS18to6km to the test infrastructure

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_driver.xml
@@ -1,0 +1,16 @@
+<driver_script name="run_test.py">
+	<case name="init_step1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message=" - Complete"/>
+	</case>
+	<case name="init_step2">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message=" - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_forward.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_init1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="init_step1">
+
+	<get_file hash="7z1uysqc5i" dest_path="mesh_database" file_name="mesh.RRS.18-6km.160828.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
+	<add_executable source="mask_creator" dest="MpasMaskCreator.x"/>
+
+	<add_link source_path="mesh_database" source="mesh.RRS.18-6km.160822.nc" dest="base_mesh.nc"/>
+	<add_link source_path="geometric_features" source="." dest="geometric_features"/>
+	<add_link source_path="script_configuration_dir" source="init_step1.py" dest="init_step1.py"/>
+
+	<run_script name="run.py">
+		<step executable="./init_step1.py">
+			<argument flag="-p">geometric_features</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/default/config_init2.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="init_step2">
+
+	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<add_executable source="metis" dest="metis"/>
+
+	<add_link source="../init_step1/culled_mesh_final.nc" dest="mesh.nc"/>
+	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source_path="initial_condition_database" source="PTemp.Jan_p3.filled.mpas100levs.160127.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
+	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
+	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_driver.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_driver.xml
@@ -1,0 +1,28 @@
+<driver_script name="run_test.py">
+	<case name="init_step1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message=" - Complete"/>
+	</case>
+	<case name="init_step2">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message=" - Complete"/>
+	</case>
+	<case name="spin_up1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up1" post_message=" - Complete"/>
+	</case>
+	<case name="spin_up2">
+		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up2" post_message=" - Complete"/>
+	</case>
+	<case name="spin_up3">
+		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up3" post_message=" - Complete"/>
+	</case>
+	<case name="spin_up4">
+		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up4" post_message=" - Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message=" - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_forward.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+	<add_link source="../spin_up4/Restart_timestamp" dest="Restart_timestamp"/>
+	<add_link source="../spin_up4/restarts" dest="restarts"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'00-00-01_00:00:00'</option>
+		<option name="config_do_restart">.true.</option>
+		<option name="config_start_time">'file'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_Rayleigh_friction">.false.</option>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-01_00:00:00</attribute>
+		</stream>
+
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_init1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="init_step1">
+
+	<get_file hash="7z1uysqc5i" dest_path="mesh_database" file_name="mesh.RRS.18-6km.160828.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+	</get_file>
+
+	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
+	<add_executable source="mask_creator" dest="MpasMaskCreator.x"/>
+
+	<add_link source_path="mesh_database" source="mesh.RRS.18-6km.160822.nc" dest="base_mesh.nc"/>
+	<add_link source_path="geometric_features" source="." dest="geometric_features"/>
+	<add_link source_path="script_configuration_dir" source="init_step1.py" dest="init_step1.py"/>
+
+	<run_script name="run.py">
+		<step executable="./init_step1.py">
+			<argument flag="-p">geometric_features</argument>
+		</step>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_init2.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_init2.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="init_step2">
+
+	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
+		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+	</get_file>
+
+	<add_executable source="metis" dest="metis"/>
+
+	<add_link source="../init_step1/culled_mesh_final.nc" dest="mesh.nc"/>
+	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source_path="initial_condition_database" source="PTemp.Jan_p3.filled.mpas100levs.160127.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
+	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
+	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up1.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<config case="spin_up1">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'00-00-00_12:00:00'</option>
+		<option name="config_dt">'00:00:30'</option>
+		<option name="config_btr_dt">'00:00:01.5'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_Rayleigh_friction">.true.</option>
+		<option name="config_Rayleigh_damping_coeff">1.0e-3</option>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-00_12:00:00</attribute>
+		</stream>
+
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up2.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up2.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<config case="spin_up2">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+	<add_link source="../spin_up1/Restart_timestamp" dest="Restart_timestamp"/>
+	<add_link source="../spin_up1/restarts" dest="restarts"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'00-00-00_12:00:00'</option>
+		<option name="config_do_restart">.true.</option>
+		<option name="config_start_time">'file'</option>
+		<option name="config_dt">'00:01:00'</option>
+		<option name="config_btr_dt">'00:00:03'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_Rayleigh_friction">.true.</option>
+		<option name="config_Rayleigh_damping_coeff">4.0e-4</option>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-00_12:00:00</attribute>
+		</stream>
+
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up3.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up3.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<config case="spin_up3">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+	<add_link source="../spin_up2/Restart_timestamp" dest="Restart_timestamp"/>
+	<add_link source="../spin_up2/restarts" dest="restarts"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'00-00-00_12:00:00'</option>
+		<option name="config_do_restart">.true.</option>
+		<option name="config_start_time">'file'</option>
+		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_Rayleigh_friction">.true.</option>
+		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-00_12:00:00</attribute>
+		</stream>
+
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up4.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/spin_up/config_spin_up4.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<config case="spin_up4">
+	<add_link source="../init_step2/ocean.nc" dest="init.nc"/>
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+	<add_link source="../spin_up3/Restart_timestamp" dest="Restart_timestamp"/>
+	<add_link source="../spin_up3/restarts" dest="restarts"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'00-00-00_12:00:00'</option>
+		<option name="config_do_restart">.true.</option>
+		<option name="config_start_time">'file'</option>
+		<option name="config_dt">'00:03:00'</option>
+		<option name="config_btr_dt">'00:00:09'</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_Rayleigh_friction">.true.</option>
+		<option name="config_Rayleigh_damping_coeff">4.0e-5</option>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-00_12:00:00</attribute>
+		</stream>
+
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats_text_only.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">1200</argument>
+		</step>
+
+		<model_run procs="1200" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_18to6km/template_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_18to6km/template_forward.xml
@@ -1,0 +1,11 @@
+<template>
+	<namelist>
+		<option name="config_dt">'00:06:00'</option>
+		<option name="config_btr_dt">'00:00:10'</option>
+		<option name="config_run_duration">'0000_00:10:00'</option>
+		<option name="config_pio_num_iotasks">75</option>
+		<option name="config_pio_stride">16</option>
+		<option name="config_mom_del4">3.2e09</option>
+		<option name="config_hmix_scaleWithMesh">.true.</option>
+	</namelist>
+</template>


### PR DESCRIPTION
This adds default and spin-up tests to the test case infrastructure for the RRS18to6km mesh (100 Layer, including:  
- default: runs for one timestep, meant for bit-for-bit comparison
- spin-up: runs through several spin-up steps where dt is increased, and Rayleigh damping is decreased, until the forward directory where the full dt and zero Rayliegh damping is used.
  This init and spin-up sequence was used to produce the ACME initial condition.
