### PR TITLE
New input/output interval option "final_only"

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -1329,7 +1329,11 @@ module mpas_stream_manager
 
         threadNum = mpas_threading_get_thread_num()
         
-        STREAM_DEBUG_WRITE('-- Called MPAS_stream_mgr_reset_alarms()')
+        if (present(streamID)) then
+            STREAM_DEBUG_WRITE('-- Called MPAS_stream_mgr_reset_alarms() for stream ' // trim(streamID))
+        else
+            STREAM_DEBUG_WRITE('-- Called MPAS_stream_mgr_reset_alarms()')
+        end if
 
         if (present(ierr)) ierr = MPAS_STREAM_MGR_NOERR
 
@@ -3011,7 +3015,6 @@ module mpas_stream_manager
            else
                if ( stream % filename_interval /= 'none' ) then
                    call mpas_set_timeInterval(filename_interval, timeString=stream % filename_interval)
-    
                    call mpas_build_stream_filename(stream % referenceTime, writeTime, filename_interval, stream % filename_template, blockID, temp_filename, ierr=local_ierr)
                else
                    call mpas_get_time(stream % referenceTime, dateTimeString=time_string)
@@ -3906,13 +3909,13 @@ module mpas_stream_manager
            direction = -1
         end if
 
-!       call mpas_get_time(when, dateTimeString=temp_string)
+        call mpas_get_time(when, dateTimeString=temp_string)
         STREAM_DEBUG_WRITE(' ** when is: ' COMMA trim(temp_string))
 
-!       call mpas_get_time(ref_time, dateTimeString=temp_string)
+        call mpas_get_time(ref_time, dateTimeString=temp_string)
         STREAM_DEBUG_WRITE(' ** ref_time is: ' COMMA trim(temp_string))
 
-!       call mpas_get_timeInterval(intv, timeString=temp_string)
+        call mpas_get_timeInterval(intv, timeString=temp_string)
         STREAM_DEBUG_WRITE(' ** intv is: ' COMMA trim(temp_string))
 
         call mpas_interval_division(ref_time, intv, filename_interval, nrecs, rem) 
@@ -5813,10 +5816,11 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
     use mpas_derived_types, only : MPAS_streamManager_type, MPAS_Clock_type, MPAS_Time_type, MPAS_TimeInterval_type, &
-                                        MPAS_STREAM_MGR_NOERR, MPAS_STREAM_INPUT, MPAS_STREAM_OUTPUT, MPAS_START_TIME
-    use mpas_stream_manager, only : MPAS_stream_mgr_get_clock, MPAS_stream_mgr_add_alarm
+                                   MPAS_STREAM_MGR_NOERR, MPAS_STREAM_INPUT, MPAS_STREAM_OUTPUT, MPAS_START_TIME, &
+                                   MPAS_STOP_TIME, MPAS_STREAM_PROPERTY_REF_TIME
+    use mpas_stream_manager, only : MPAS_stream_mgr_get_clock, MPAS_stream_mgr_add_alarm, MPAS_stream_mgr_set_property
     use mpas_kind_types, only : StrKIND
-    use mpas_timekeeping, only : mpas_add_clock_alarm, mpas_set_time, mpas_set_timeInterval, mpas_get_clock_time
+    use mpas_timekeeping, only : mpas_add_clock_alarm, mpas_set_time, mpas_get_time, mpas_set_timeInterval, mpas_get_clock_time
 
     implicit none
 
@@ -5829,7 +5833,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
 
     type (MPAS_streamManager_type), pointer :: manager
     type (MPAS_Clock_type), pointer :: clock
-    character(len=StrKIND) :: streamID, direction, alarmID, alarmTime, alarmInterval
+    character(len=StrKIND) :: streamID, direction, alarmID, alarmTime, alarmInterval, alarmString
     type (MPAS_Time_type) :: alarmTime_local
     type (MPAS_TimeInterval_type) :: alarmInterval_local
     integer :: idirection
@@ -5858,13 +5862,17 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
 
     call MPAS_stream_mgr_get_clock(manager, clock)
 
-    if (trim(alarmTime) == 'start') then
+    if (trim(alarmTime) == 'start' .and. trim(alarmInterval) == 'final_only') then
+        alarmTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr)
+        call mpas_get_time(alarmTime_local, dateTimeString=alarmString)
+        call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, alarmString, ierr=ierr)
+    else if (trim(alarmTime) == 'start') then
         alarmTime_local = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr)
     else
         call mpas_set_time(alarmTime_local, dateTimeString=alarmTime)
     end if
 
-    if (trim(alarmInterval) == 'initial_only') then
+    if (trim(alarmInterval) == 'initial_only' .or. trim(alarmInterval) == 'final_only') then
         call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, ierr=ierr)
     else
         call mpas_set_timeInterval(alarmInterval_local, timeString=alarmInterval)

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -415,6 +415,16 @@ int attribute_check(ezxml_t stream)
 			fmt_err(msgbuf);
 			return 1;
 		}
+		if ( strstr(s_filename_intv, "input_interval") != NULL && strstr(s_input, "final_only") != NULL) {
+			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"input_interval\" for the \"filename_interval\" attribute, when \"input_interval\" is set to \"final_only\".", s_name);
+			fmt_err(msgbuf);
+			return 1;
+		}
+		if ( strstr(s_filename_intv, "output_interval") != NULL && strstr(s_output, "final_only") != NULL) {
+			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"output_interval\" for the \"filename_interval\" attribute, when \"output_interval\" is set to \"final_only\".", s_name);
+			fmt_err(msgbuf);
+			return 1;
+		}
 	}
 
 
@@ -1119,23 +1129,21 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			/* Check for an input;output stream. Handle first as this is the most complicated case. */
 			if ( strstr(direction, "input") != NULL && strstr(direction, "output") != NULL ) {
 
-				/* If input interval is an interval (i.e. not initial_only or none) set filename_interval to the interval. */
-				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "none") == NULL ){
+				/* If input interval is an interval (i.e. not initial_only/final_only or none) set filename_interval to the interval. */
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ){
 					filename_interval = interval_in2;
-
-				/* If output interval is an interval (i.e. not initial_only or none) set filename_interval to the interval. */
-				} else if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ){
+				/* If output interval is an interval (i.e. not initial_only/final_only or none) set filename_interval to the interval. */
+				} else if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ){
 					filename_interval = interval_out2;
 				}
 			/* Check for an input stream. */
 			} else if ( strstr(direction, "input") != NULL ) {
-				if ( strstr(interval_in2, "initial_only") == NULL && strstr(interval_in2, "none") == NULL ){
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ){
 					filename_interval = interval_in2;
 				}
-
 			/* Check for an output stream. */
 			} else if ( strstr(direction, "output") != NULL ) {
-				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ){
+				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ){
 					filename_interval = interval_out2;
 				}
 			}
@@ -1148,13 +1156,13 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			 * to force it's value to be none as well.
 			 */
 			if ( strstr(filename_interval, "input_interval") != NULL ) {
-				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "none") == NULL ) {
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ) {
 					filename_interval = interval_in2;
 				} else {
 					filename_interval = NULL;
 				}
 			} else if ( strstr(filename_interval, "output_interval") != NULL ) {
-				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ) {
+				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ) {
 					filename_interval = interval_out2;
 				} else {
 					filename_interval = NULL;
@@ -1401,23 +1409,21 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			/* Check for an input;output stream. Handle first as this is the most complicated case. */
 			if ( strstr(direction, "input") != NULL && strstr(direction, "output") != NULL ) {
 
-				/* If input interval is an interval (i.e. not initial_only or none) set filename_interval to the interval. */
-				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "none") == NULL ){
+				/* If input interval is an interval (i.e. not initial_only/final_only or none) set filename_interval to the interval. */
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ){
 					filename_interval = interval_in2;
-
-				/* If output interval is an interval (i.e. not initial_only or none) set filename_interval to the interval. */
-				} else if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ){
+				/* If output interval is an interval (i.e. not initial_only/final_only or none) set filename_interval to the interval. */
+				} else if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ){
 					filename_interval = interval_out2;
 				}
 			/* Check for an input stream. */
 			} else if ( strstr(direction, "input") != NULL ) {
-				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "none") == NULL ){
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ){
 					filename_interval = interval_in2;
 				}
-
 			/* Check for an output stream. */
 			} else if ( strstr(direction, "output") != NULL ) {
-				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ){
+				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ){
 					filename_interval = interval_out2;
 				}
 			}
@@ -1430,13 +1436,13 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			 * to force it's value to be none as well.
 			 */
 			if ( strstr(filename_interval, "input_interval") != NULL ) {
-				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "none") == NULL ) {
+				if ( strstr(interval_in, "initial_only") == NULL && strstr(interval_in, "final_only") == NULL && strstr(interval_in, "none") == NULL ) {
 					filename_interval = interval_in2;
 				} else {
 					filename_interval = NULL;
 				}
 			} else if ( strstr(filename_interval, "output_interval") != NULL ) {
-				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "none") == NULL ) {
+				if ( strstr(interval_out, "initial_only") == NULL && strstr(interval_out, "final_only") == NULL && strstr(interval_out, "none") == NULL ) {
 					filename_interval = interval_out2;
 				} else {
 					filename_interval = NULL;


### PR DESCRIPTION
In several occasions, I found it useful to have an additional option "final_only" for input/output intervals in the MPAS I/O layer. For instance, writing restart files at "final_only" output interval saves you from redefining the output interval when you change start/end time in the namelist. Likewise, converting/processing restart files in the postproc core (not yet in the MPAS-Dev tree) profits from this feature.

This pull request contains all required changes to implement this option in the usual way, i.e. through the streams.whatevercoreyouuse files. It also contains an additional compiler option in the top-level makefile for gfortran+clang compilers (I need that for my dev work on my mac) and a small change to correctly initialise pointers in mpas_timekeeping_types.

Edit 20170426 - suggested commit message for merge:

This merge extends the input_interval and output_interval properties of streams
by an additional option 'final_only'. The implementation is similar to the
'initial_only' option and does not change the code behaviour for any of the
existing options ('none', 'initial_only' or a valid time interval string).
A stream with output_interval 'final_only' will only be written at the end
of the model integration time, which is useful for specific diagnostics such
as accumulated values or minimum/maximum/average values, but also for restart
files. While this new option was added primarily on stream output, it is
also fully supported on stream input.

* src/framework/mpas_stream_manager.F:
  Minor modifications of debugging output, and extension of routine
  stream_mgr_add_alarm_c to support the interval type 'final_only'.
* src/framework/xml_stream_parser.c:
  Additional logic for basic sanity checks for the new input/output interval
  option similar to the existing options.
