### PR TITLE
New compiler options and updates of top-level makefile

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,15 +5,6 @@ For general information on how to install MPAS, see https://mpas-dev.github.io.
 Additional notes on building MPAS on specific architectures are summarized here.
 
 
-ifort-phi: Compiling MPAS on Intel Xeon Phi Knights Landing
-----------
-The compiler options specified in the Makefile apply to the Knights Landing
-architecture only, not the Knights Corner architecture. The latter requires
-cross-compiling amongst others and is not supported by this release of MPAS.
-The compiler optimization settings are conservative and users may experiment
-with additional options such as "-xMIC-AVX512" and/or "-align array64byte".
-
-
 gfortran-clang: Compiling MPAS on MacOSX (10.11 El Capitan - 10.12 Sierra)
 ----------
 MPAS should compile out of the box on MacOSX with the standard (OS) clang compiler

--- a/Makefile
+++ b/Makefile
@@ -160,31 +160,6 @@ ifort:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
 
-ifort-phi:
-	( $(MAKE) all \
-	"FC_PARALLEL = mpiifort" \
-	"CC_PARALLEL = mpiicc" \
-	"CXX_PARALLEL = mpiicpc" \
-	"FC_SERIAL = ifort" \
-	"CC_SERIAL = icc" \
-	"CXX_SERIAL = icpc" \
-	"FFLAGS_PROMOTION = -real-size 64" \
-	"FFLAGS_OPT = -O3 -convert big_endian -FR" \
-	"CFLAGS_OPT = -O3" \
-	"CXXFLAGS_OPT = -O3" \
-	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -O0 -g -convert big_endian -FR -CU -CB -check all -fpe0 -traceback" \
-	"CFLAGS_DEBUG = -O0 -g -traceback" \
-	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
-	"LDFLAGS_DEBUG = -O0 -g -fpe0 -traceback" \
-	"FFLAGS_OMP = -qopenmp" \
-	"CFLAGS_OMP = -qopenmp" \
-	"CORE = $(CORE)" \
-	"DEBUG = $(DEBUG)" \
-	"USE_PAPI = $(USE_PAPI)" \
-	"OPENMP = $(OPENMP)" \
-	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE" )
-
 ifort-scorep:
 	( $(MAKE) all \
 	"FC_PARALLEL = scorep --compiler mpif90" \


### PR DESCRIPTION
New compiler options ifort-mic, ifort-scorep and gfortran-clang are added. The legacy openmp flags for the intel compiler are updated, and GPTL support is added for every compiler option.

Further, this version also supports netCDF installations in which the netCDF-fortran libraries reside in a different place than the c libraries (common practice at several HPC centres). The environment variable used for this is usually NETCDFF.
