### PR TITLE
Move computation of daysSinceStartOfSim to before AM init

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -133,6 +133,32 @@ module ocn_forward_mode
       call mpas_get_time(startTime, dateTimeString=startTimeStamp)
       ierr = ior(ierr, err_tmp)
 
+      ! Setup time step and daysSinceStartOfSim information.
+      timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
+      call mpas_get_timeInterval(timeStep, dt=dt)
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+         xtime = startTimeStamp
+
+         ! Set simulationStartTime only if that variable is not read from the restart file.
+         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
+         if (trim(simulationStartTime)=="no_date_available") then
+            simulationStartTime = startTimeStamp
+         end if
+
+         ! compute time since start of simulation, in days
+         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
+         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
+         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
+         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
+         block => block % next
+      end do
+
       ! Setup ocean config pool
       call ocn_constants_init(domain % configs, domain % packages)
 
@@ -307,9 +333,6 @@ module ocn_forward_mode
       !
       ! Initialize core
       !
-      timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
-      call mpas_get_timeInterval(timeStep, dt=dt)
-
       block => domain % blocklist
       do while (associated(block))
          call ocn_init_routines_block(block, dt, ierr)
@@ -317,23 +340,6 @@ module ocn_forward_mode
          if(ierr.eq.1) then
              call mpas_dmpar_global_abort('MPAS-ocean: ERROR: An error was encountered in ocn_init_routines_block')
          endif
-
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-         xtime = startTimeStamp
-
-         ! Set simulationStartTime only if that variable is not read from the restart file.
-         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
-         if (trim(simulationStartTime)=="no_date_available") then
-            simulationStartTime = startTimeStamp
-         end if
-
-         ! compute time since start of simulation, in days
-         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
-         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
-         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
-         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
-         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
 
          block => block % next
       end do


### PR DESCRIPTION
This merge moves the computation of daysSinceStartOfSim to before the
analysis members are initialized. Without this merge, the value written
on startup for daysSinceStartOfSim of any analysis member that depends on this (globalStats for
example) is garbage.
