### PR TITLE
Add block debugging stream prefix "block_" to state validator

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -503,6 +503,11 @@ module ocn_forward_mode
          call mpas_timer_stop('io_read')
          call mpas_timer_start('reset_io_alarms')
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=ierr)
+
+         ! Also restart all block_* streams, if any are defined.
+         if ( mpas_stream_mgr_stream_exists(domain % streamManager, 'block_.*') ) then
+            call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='block_.*', ierr=ierr)
+         end if
          call mpas_timer_stop('reset_io_alarms')
 
          itimestep = itimestep + 1

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -26,6 +26,7 @@ module ocn_diagnostics
    use mpas_constants
    use mpas_threading
    use mpas_vector_reconstruction
+   use mpas_stream_manager
 
    use ocn_constants
    use ocn_gm
@@ -2051,6 +2052,10 @@ contains
 
             write(debugUnit, *) 'ERROR: NaN Detected in state see below for which field contained a NaN.'
             write(debugUnit, *) '  -- Statistics information for block fields'
+
+            if ( mpas_stream_mgr_stream_exists(domain % streamManager, 'block_.*') ) then
+               call mpas_stream_mgr_block_Write(domain % streamManager, writeBlock=block, streamID='block_.*', forceWriteNow=.true.)
+            end if
 
             ! Also, write general block information, like lat/lon bounds
 


### PR DESCRIPTION
This merge adds support for block debugging streams to the ocean model.
Block debugging streams have the name prefix "block_". Any streams with
this name will be written as block write streams when the model is going
to fail, to help give additional debugging information.
