### PR TITLE
Added region support to Meridional Heat Transport analysis member

### DIFF
--- a/src/core_ocean/analysis_members/Registry_meridional_heat_transport.xml
+++ b/src/core_ocean/analysis_members/Registry_meridional_heat_transport.xml
@@ -31,27 +31,43 @@
 			description="maximum bin boundary value.  If set to -1.0e34, the maximum value in the domain is found."
 			possible_values="Any real number."
 		/>
+		<nml_option name="config_AM_meridionalHeatTransport_region_group" type="character" default_value="all" units="unitless"
+			description="The name of the region group, for which the MHT should be computed in addition to the global MHT."
+			possible_values="'all', '', or the name of a region group."
+		/>
 	</nml_record>
 	<dims>
 		<dim name="nMerHeatTransBins" definition="namelist:config_AM_meridionalHeatTransport_num_bins" units="unitless"
 			 description="Maximum number of bins for meridional heat transport."
 		/>
 		<dim name="nMerHeatTransBinsP1" definition="nMerHeatTransBins+1" units="unitless"
-			 description="Maximum number of bins for meridional heat transport, plus one."
+			description="Maximum number of bins for meridional heat transport, plus one."
 		/>
 	</dims>
 	<packages>
-		<package name="meridionalHeatTransportAMPKG" description="This package includes variables required for the meridional heat transport analysis member."/>
+		<package name="meridionalHeatTransportAMPKG"
+			description="This package includes variables required for the meridional heat transport analysis member."
+		/>
 	</packages>
 	<var_struct name="meridionalHeatTransportAM" time_levs="1" packages="meridionalHeatTransportAMPKG">
 		<var name="binBoundaryMerHeatTrans" type="real" dimensions="nMerHeatTransBinsP1" units="varies"
 			 description="Coordinate of southern edge of meridional heat transport bin, either in latitude or y, for plotting."
 		/>
 		<var name="meridionalHeatTransportLatZ" type="real" dimensions="nVertLevels nMerHeatTransBinsP1 Time" units="petawatts"
-			 description="Northward heat transport at locations defined at the binBoundaryMerHeatTrans coordinates, by vertical level."
+			description="Northward heat transport at locations defined at the binBoundaryMerHeatTrans coordinates by vertical level."
+		/>
+		 <var name="merHeatTransLatZRegion" type="real" dimensions="nVertLevels nMerHeatTransBinsP1 maxRegionsInGroup Time"
+			units="petawatts"
+			description="Northward heat transport by vertical level and region."
 		/>
 		<var name="meridionalHeatTransportLat" type="real" dimensions="nMerHeatTransBinsP1 Time" units="petawatts"
-			 description="Northward heat transport at locations defined at the binBoundaryMerHeatTrans coordinates."
+			description="Northward heat transport at locations defined at the binBoundaryMerHeatTrans coordinates."
+		/>
+		<var name="merHeatTransLatRegion" type="real" dimensions="nMerHeatTransBinsP1 maxRegionsInGroup Time" units="petawatts"
+			description="Northward heat transport at locations defined at the binBoundaryMerHeatTrans coordinates, by region."
+		/>
+		<var name="minMaxLatRegionMHT" type="real" dimensions="TWO maxRegionsInGroup" units="varies"
+			description="Coordinates of the southern and northern edge of each region (for drawing)."
 		/>
 	</var_struct>
 	<streams>
@@ -71,6 +87,14 @@
 			<var name="meridionalHeatTransportLat"/>
 			<var name="refZMid"/>
 			<var name="refBottomDepth"/>
+
+			<!-- needed to correctly plot the regional MHT -->
+			<var name="regionGroupNames"/>
+			<var name="regionNames"/>
+			<var name="nRegionsInGroup"/>
+			<var name="regionsInGroup"/>
+			<var name="merHeatTransLatZRegion"/>
+			<var name="merHeatTransLatRegion"/>
 		</stream>
 	</streams>
 

--- a/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -116,12 +116,78 @@ contains
       real (kind=RKIND) :: binWidth
       ! These are array size 1 because mpas_dmpar_min_real_array calls require arrays.
       real (kind=RKIND), dimension(1) :: minBin, maxBin, minBinDomain, maxBinDomain
+      ! the variable used to discriminate cells into Bins (either the y-value or the latitude)
       real (kind=RKIND), dimension(:), pointer ::  binBoundaryMerHeatTrans, binVariable
 
+      !number of latitude bins specified in the config
       integer, pointer :: config_AM_meridionalHeatTransport_num_bins
+      !smallest and highest latitude specified in the config
       real (kind=RKIND), pointer :: config_AM_meridionalHeatTransport_min_bin, config_AM_meridionalHeatTransport_max_bin
 
+      !determines if the simulation was run on a sphere or on a plane
       logical, pointer :: on_a_sphere
+
+      !!!! Region variables
+      !! region MHT calculation variables
+      real (kind=RKIND) :: maskFactor
+      integer :: curRegion, i, j, iCell
+
+      !! region arrays/variables
+      character (len=STRKIND), dimension(:), pointer :: regionGroupNames
+      integer, dimension(:, :), pointer :: regionCellMasks, regionsInGroup
+      integer, dimension(:), pointer ::  nRegionsInGroup
+      integer, pointer :: nRegions, nRegionGroups, maxRegionsInGroup, nCellsSolve
+      real (kind=RKIND), dimension(:), pointer :: minLatRegionLocal, maxLatRegionLocal, &
+                                                  minLatRegionGlobal, maxLatRegionGlobal
+      character (len=STRKIND), pointer :: additionalRegion
+
+      !! region preliminary variables
+      integer :: regionGroupNumber, regionsInAddGroup, regionGroupOffset
+
+      !!region pool
+      type (mpas_pool_type), pointer :: regionPool
+
+      !! region dimensions
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nRegions', nRegions)
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nRegionGroups', nRegionGroups)
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'maxRegionsInGroup', maxRegionsInGroup)
+
+      !! region config for MHT
+      call mpas_pool_get_config(domain % configs, 'config_AM_meridionalHeatTransport_region_group', &
+                                additionalRegion)
+
+      !! get region values
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'regions', regionPool)
+      call mpas_pool_get_array(regionPool, 'regionsInGroup', regionsInGroup)
+      call mpas_pool_get_array(regionPool, 'nRegionsInGroup', nRegionsInGroup)
+      call mpas_pool_get_array(regionPool, 'regionGroupNames', regionGroupNames)
+
+      regionGroupOffset = 1
+      regionGroupNumber = 0
+
+      if(additionalRegion /= '') then
+         !!! region preliminaries
+         !!! figure out the region group number that matches the configured additional region's name
+         do i = 1, nRegionGroups
+            if (regionGroupNames(i) .eq. additionalRegion) then
+               regionGroupNumber = i
+               !!! determine offset to compensate for several region groups in the
+               !!! regions file
+               do j = 1, i - 1
+                 regionGroupOffset = regionGroupOffset + nRegionsInGroup(j)
+               end do
+            end if
+         end do
+      end if
+
+      if(additionalRegion /= '') then
+         regionsInAddGroup = nRegionsInGroup(regionGroupNumber)
+         allocate(minLatRegionLocal(maxRegionsInGroup))
+         allocate(maxLatRegionLocal(maxRegionsInGroup))
+         allocate(minLatRegionGlobal(maxRegionsInGroup))
+         allocate(maxLatRegionGlobal(maxRegionsInGroup))
+      end if
+      !!!! END Region variables
 
       dminfo = domain % dminfo
 
@@ -150,6 +216,12 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
 
+         ! Get region-specific variables from pools
+         if(additionalRegion /= '') then
+            call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
+            call mpas_pool_get_array(regionPool, 'regionCellMasks', regionCellMasks)
+         end if
+
          ! Bin by latitude on a sphere, by yCell otherwise.
          if (on_a_sphere) then
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
@@ -160,6 +232,18 @@ contains
          minBin = min(minBin, minval(binVariable) )
          maxBin = max(maxBin, maxval(binVariable) )
 
+         ! If using regions, iterate through groups and add as needed
+         if(additionalRegion /= '') then
+            do i = 1, regionsInAddGroup
+               curRegion = regionsInGroup(i, regionGroupNumber)
+               do iCell = 1, nCellsSolve
+                  if (regionCellMasks(curRegion, iCell) .eq. 1) then
+                     minLatRegionLocal(i) = min(minLatRegionLocal(i), binVariable(iCell))
+                     maxLatRegionLocal(i) = max(maxLatRegionLocal(i), binVariable(iCell))
+                  end if
+               end do
+            end do
+         end if
          block => block % next
       end do
 
@@ -247,6 +331,8 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: diagnosticsPool
+      ! REGION POOL
+      type (mpas_pool_type), pointer :: regionPool
 
       integer :: iTracer, k, iCell, kMax, i, iEdge
       integer :: iBin, iField, nMerHeatTransVariables
@@ -256,14 +342,30 @@ contains
 
       real (kind=RKIND) :: div_huT
       real (kind=RKIND), dimension(:), pointer ::  areaCell, binVariable, binBoundaryMerHeatTrans, dvEdge
-      real (kind=RKIND), dimension(:), pointer ::  meridionalHeatTransportLat
+      real (kind=RKIND), dimension(:), pointer ::  merHeatTransLat
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalTransportVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: meridionalHeatTransportLatZ
+      real (kind=RKIND), dimension(:,:), pointer :: merHeatTransLatZ
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       real (kind=RKIND), dimension(:,:), allocatable :: mht_meridional_integral
       real (kind=RKIND), dimension(:,:,:), allocatable :: sumMerHeatTrans, totalSumMerHeatTrans
 
       logical, pointer :: on_a_sphere
+
+      !!!! REGION VARIABLES
+      real (kind=RKIND) :: maskFactor
+      integer :: curRegion, regionGroupOffset, j
+      character (len=STRKIND) :: currentName
+      real (kind=RKIND), dimension(:,:,:,:), allocatable :: sumMerHeatTransRegion, totalSumMerHeatTransRegion
+      real (kind=RKIND), dimension(:,:,:), pointer :: merHeatTransLatZRegion
+      real (kind=RKIND), dimension(:,:), pointer :: merHeatTransLatRegion
+      character (len=STRKIND), dimension(:), pointer :: regionNames, regionGroupNames
+      integer, dimension(:, :), pointer :: regionCellMasks, regionVertexMasks, regionsInGroup
+      integer, dimension(:), pointer ::  nRegionsInGroup
+      integer, pointer :: nRegions, nRegionGroups, maxRegionsInGroup
+      character (len=STRKIND), pointer :: additionalRegion
+      integer :: regionGroupNumber, regionsInAddGroup
+      real (kind=RKIND), dimension(:,:,:), allocatable :: mht_meridional_integral_region
+      !!!! END REGION VARIABLES
 
       err = 0
       dminfo = domain % dminfo
@@ -279,11 +381,67 @@ contains
 
       call mpas_pool_get_array(meridionalHeatTransportAMPool, 'binBoundaryMerHeatTrans', binBoundaryMerHeatTrans)
 
+      !!!! v
+      !! region dimensions
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nRegions', nRegions)
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nRegionGroups', nRegionGroups)
+      call mpas_pool_get_dimension(domain % blocklist % dimensions, 'maxRegionsInGroup', maxRegionsInGroup)
+
+      !! region config for MHT
+      call mpas_pool_get_config(domain % configs, 'config_AM_meridionalHeatTransport_region_group', &
+                                additionalRegion)
+
+      !! get region values
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'regions', regionPool)
+      call mpas_pool_get_array(regionPool, 'regionsInGroup', regionsInGroup)
+      call mpas_pool_get_array(regionPool, 'nRegionsInGroup', nRegionsInGroup)
+      call mpas_pool_get_array(regionPool, 'regionNames', regionNames)
+      call mpas_pool_get_array(regionPool, 'regionGroupNames', regionGroupNames)
+      call mpas_pool_get_array(meridionalHeatTransportAMPool, 'merHeatTransLatRegion', merHeatTransLatRegion)
+      call mpas_pool_get_array(meridionalHeatTransportAMPool, 'merHeatTransLatZRegion', merHeatTransLatZRegion)
+
+      regionGroupOffset = 1
+      regionGroupNumber = 0
+
+      !! if a region is selected, set up region group offsets etc
+      if(additionalRegion /= '') then
+         !!! region preliminaries
+         !!! figure out the region group number that matches the configured additional region's name
+         do i = 1, nRegionGroups
+            if (regionGroupNames(i) .eq. additionalRegion) then
+               regionGroupNumber = i
+               !!! determine offset to compensate for several region groups in the
+               !!! regions file
+               do j = 1, i - 1
+                 regionGroupOffset = regionGroupOffset + nRegionsInGroup(j)
+               end do
+            end if
+         end do
+      end if
+
+      if(additionalRegion /= '') then
+         regionsInAddGroup = nRegionsInGroup(regionGroupNumber)
+      end if
+      !!!! end region initialization
+
+      !! allocate MHT calculation arrays
       allocate(sumMerHeatTrans(nMerHeatTransVariables,nVertLevels,nMerHeatTransBinsUsed))
       allocate(totalSumMerHeatTrans(nMerHeatTransVariables,nVertLevels,nMerHeatTransBinsUsed))
       allocate(mht_meridional_integral(nVertLevels,nMerHeatTransBinsUsed))
 
+      !! allocate region-specific arrays
+      if(additionalRegion /= '') then
+!         allocate(totalSumMerHeatTransLatZRegion(nVertLevels, nMerHeatTransBinsUsed + 1, maxRegionsInGroup))
+         allocate(sumMerHeatTransRegion(nMerHeatTransVariables, nVertLevels, nMerHeatTransBinsUsed, maxRegionsInGroup))
+         allocate(totalSumMerHeatTransRegion(nMerHeatTransVariables, nVertLevels, nMerHeatTransBinsUsed, maxRegionsInGroup))
+         allocate(mht_meridional_integral_region(nVertLevels,nMerHeatTransBinsUsed, maxRegionsInGroup))
+      end if
+
       sumMerHeatTrans = 0.0_RKIND
+      if(additionalRegion /= '') then
+         sumMerHeatTransRegion = 0.0_RKIND
+         totalSumMerHeatTrans = 0.0_RKIND
+      end if
 
       block => domain % blocklist
       do while (associated(block))
@@ -292,7 +450,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
 
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
@@ -310,6 +467,10 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
          call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
+         if(additionalRegion /= '') then
+            call mpas_pool_get_array(regionPool, 'regionCellMasks', regionCellMasks)
+         end if
+
          ! Bin by latitude on a sphere, by yCell otherwise.
          if (on_a_sphere) then
             call mpas_pool_get_array(meshPool, 'latCell', binVariable)
@@ -323,11 +484,11 @@ contains
             if (binVariable(iCell) .lt. binBoundaryMerHeatTrans(1)) cycle
 
             do iBin = 1, nMerHeatTransBinsUsed
-               if (binVariable(iCell) .lt. binBoundaryMerHeatTrans(iBin+1) ) then
+               if (binVariable(iCell) .lt. binBoundaryMerHeatTrans(iBin+1)) then
 
                   do k = 1, kMax
 
-                     ! Compute divergence of huT, i.e. layerThicknessEdge * normalVelocity * temperature, at an edge
+                     ! Compute divergence of huT, i.e. layerThicknessEdge * normalTransportVelocity * temperature, at an edge
                      ! for meridional heat transport.  Here we use a centered difference to compute the temperature at
                      ! the edge, which is an approximation to the actual edge temperature used in the horizontal
                      ! advection scheme (for example, FCT).  We expect that the error in this approximation is small.
@@ -344,12 +505,20 @@ contains
                      end do
                      sumMerHeatTrans(iField,k,iBin) = sumMerHeatTrans(iField,k,iBin) + div_huT
 
+                     !!!!! region-specific MHT
+                     if(additionalRegion /= '') then
+                        do i = 1, regionsInAddGroup
+                           curRegion = regionsInGroup(i, regionGroupNumber)
+                           sumMerHeatTransRegion(iField,k,iBin,curRegion) = sumMerHeatTrans(iField,k,iBin) * &
+                                                                    regionCellMasks(curRegion, iCell)
+                        end do
+                        !!!!! end region-specific MHT
+                     end if
+
                   end do
                   exit
-
                endif
             end do
-
          end do
 
          block => block % next
@@ -360,6 +529,16 @@ contains
       ! over the domain decompositon (by processor), not over an array index.
       call mpas_dmpar_sum_real_array(dminfo, nVertLevels*nMerHeatTransBinsUsed*nMerHeatTransVariables, &
                                      sumMerHeatTrans, totalSumMerHeatTrans)
+
+      !!!! Region version
+      if(additionalRegion /= '') then
+         do i = 1, regionsInAddGroup
+            curRegion = regionsInGroup(i, regionGroupNumber)
+            call mpas_dmpar_sum_real_array(dminfo, nVertLevels*nMerHeatTransBinsUsed*nMerHeatTransVariables, &
+                                           sumMerHeatTransRegion(:,:,:,curRegion), &
+                                        totalSumMerHeatTransRegion(:,:,:,curRegion))
+         end do
+      end if
 
       ! Even though these variables do not include an index that is decomposed amongst
       ! domain partitions, we assign them within a block loop so that all blocks have the
@@ -372,8 +551,13 @@ contains
          call mpas_pool_get_subpool(block % structs, 'meridionalHeatTransportAM', meridionalHeatTransportAMPool)
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
 
-         call mpas_pool_get_array(meridionalHeatTransportAMPool, 'meridionalHeatTransportLat', meridionalHeatTransportLat)
-         call mpas_pool_get_array(meridionalHeatTransportAMPool, 'meridionalHeatTransportLatZ', meridionalHeatTransportLatZ)
+         call mpas_pool_get_array(meridionalHeatTransportAMPool, 'meridionalHeatTransportLat', merHeatTransLat)
+         call mpas_pool_get_array(meridionalHeatTransportAMPool, 'meridionalHeatTransportLatZ', merHeatTransLatZ)
+
+         if(additionalRegion /= '') then
+            call mpas_pool_get_array(meridionalHeatTransportAMPool, 'merHeatTransLatRegion', merHeatTransLatRegion)
+            call mpas_pool_get_array(meridionalHeatTransportAMPool, 'merHeatTransLatZRegion', merHeatTransLatZRegion)
+         end if
 
          do iBin = 1, nMerHeatTransBinsUsed
             do k = 1, nVertLevels
@@ -383,33 +567,62 @@ contains
                ! Here we simply multiply by (rho c_p) and convert to PW:
                iField = 1
                mht_meridional_integral(k,iBin) = totalSumMerHeatTrans(iField,k,iBin)*rho_sw*cp_sw*1.0e-15_RKIND
-
+               ! compute MHT per bin for regions
+               if(additionalRegion /= '') then
+                  do i = 1, regionsInAddGroup
+                     curRegion = regionsInGroup(i, regionGroupNumber)
+                     mht_meridional_integral_region(k,iBin,curRegion) = totalSumMerHeatTransRegion(iField,k,iBin,curRegion) &
+                                * rho_sw*cp_sw*1.0e-15_RKIND
+                  end do
+               end if
             end do
          end do
 
          ! Compute integral of ( sum ( div(huT) A ) * rho c_p ) from southernmost latitude to bin boundary.
          ! Note that mht_meridional_integral is indexed by bin, spanning 1:nMerHeatTransBinsUsed, while
-         ! meridionalHeatTransportLatZ (second dimension) is indexed by bin boundary, spanning 1:nMerHeatTransBinsUsed+1
-         meridionalHeatTransportLatZ(:,1) = 0.0_RKIND
+         ! merHeatTransLatZ (second dimension) is indexed by bin boundary, spanning 1:nMerHeatTransBinsUsed+1
+         merHeatTransLatZ(:,1) = 0.0_RKIND
          do iBin = 2, nMerHeatTransBinsUsed+1
-            meridionalHeatTransportLatZ(:,iBin) = meridionalHeatTransportLatZ(:,iBin-1) + mht_meridional_integral(:,iBin-1)
+            merHeatTransLatZ(:,iBin) = merHeatTransLatZ(:,iBin-1) + mht_meridional_integral(:,iBin-1)
+            ! integrate MHT for regions
+            if(additionalRegion /= '') then
+               do i = 1, regionsInAddGroup
+                  curRegion = regionsInGroup(i, regionGroupNumber)
+                  merHeatTransLatZRegion(:,iBin,curRegion) = merHeatTransLatZRegion(:,iBin-1,curRegion) +&
+                            mht_meridional_integral_region(:,iBin-1,curRegion)
+               end do
+            end if
          end do
 
-         ! meridionalHeatTransportLatZ is a function of depth.  Sum in vertical to get
-         ! meridionalHeatTransportLat, a single value for each latitude bin boundary.
-         ! meridionalHeatTransportLat is indexed by bin boundary, spanning 1:nMerHeatTransBinsUsed+1
+         ! merHeatTransLatZ is a function of depth.  Sum in vertical to get
+         ! merHeatTransLat, a single value for each latitude bin boundary.
+         ! merHeatTransLat is indexed by bin boundary, spanning 1:nMerHeatTransBinsUsed+1
          do iBin = 1, nMerHeatTransBinsUsed+1
-            meridionalHeatTransportLat(iBin) = sum(meridionalHeatTransportLatZ(:,iBin))
+            merHeatTransLat(iBin) = sum(merHeatTransLatZ(:,iBin))
+            ! sum up MHT for regions
+            if(additionalRegion /= '') then
+               do i = 1, regionsInAddGroup
+                  curRegion = regionsInGroup(i, regionGroupNumber)
+                  merHeatTransLatRegion(iBin,curRegion) = sum(merHeatTransLatZRegion(:,iBin,curRegion))
+               end do
+            end if
          end do
-
 
          block => block % next
       end do
+
+      call mpas_dmpar_sum_real_array(dminfo, nVertLevels*nMerHeatTransBinsUsed*nMerHeatTransVariables, &
+                                     sumMerHeatTrans, totalSumMerHeatTrans)
 
       deallocate(sumMerHeatTrans)
       deallocate(totalSumMerHeatTrans)
       deallocate(mht_meridional_integral)
 
+      !!!! region clean-up
+      if(additionalRegion /= '') then
+         deallocate(totalSumMerHeatTransRegion)
+         deallocate(sumMerHeatTransRegion)
+      end if
    end subroutine ocn_compute_meridional_heat_transport!}}}
 
 !***********************************************************************


### PR DESCRIPTION
Regional support for Meridional Heat Transport:
- computes global MHT (as before), with or without regional MHT
- namelist option to select no regions, all regions, or a specific region group
- computes MHT for specific region groups that are specified through a mask file
- additional variables for regional results in output stream
