### PR TITLE
Speed up sub_ice_shelf_2D testing

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_adjust_ssh.xml
@@ -25,7 +25,7 @@
 			<argument flag="graph.info">4</argument>
 		</step>
 		<step executable="./iterate_init.py">
-			<argument flag="">--iteration_count=15</argument>
+			<argument flag="">--iteration_count=2</argument>
 			<argument flag="">--variable_to_modify=landIcePressure</argument>
 		</step>
 	</run_script>

--- a/test_cases/ocean/ocean/regression_suites/nightly.xml
+++ b/test_cases/ocean/ocean/regression_suites/nightly.xml
@@ -32,12 +32,6 @@
 	<test name="Global Ocean 240km - Smoke Test with land ice" core="ocean" configuration="global_ocean" resolution="QU_240km" test="with_land_ice">
 		<script name="run_test.py"/>
 	</test>
-	<test name="sub-ice-shelf 2D - Smoke Test" core="ocean" configuration="sub_ice_shelf_2D" resolution="5km" test="Haney_number_iterative_init">
-		<script name="run_test.py"/>
-	</test>
-	<test name="sub-ice-shelf 2D - Smoke Test with frazil" core="ocean" configuration="sub_ice_shelf_2D" resolution="5km" test="with_frazil">
-		<script name="run_test.py"/>
-	</test>
 	<test name="sub-ice-shelf 2D - restart test" core="ocean" configuration="sub_ice_shelf_2D" resolution="5km" test="restart_test">
 		<script name="run_test.py"/>
 	</test>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_adjust_ssh.xml
@@ -21,7 +21,7 @@
 			<argument flag="graph.info">4</argument>
 		</step>
 		<step executable="./iterate_init.py">
-			<argument flag="">--iteration_count=15</argument>
+			<argument flag="">--iteration_count=2</argument>
 			<argument flag="">--variable_to_modify=landIcePressure</argument>
 		</step>
 	</run_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_driver.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_driver.xml
@@ -21,5 +21,8 @@
 		<compare_fields file1="full_run/land_ice_fluxes.nc" file2="restart_run/land_ice_fluxes.nc">
 			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
 		</compare_fields>
+		<compare_fields file1="full_run/frazil.nc" file2="restart_run/frazil.nc">
+			<template file="frazil_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
 	</validation>
 </driver_script>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_full_run.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_full_run.xml
@@ -9,11 +9,19 @@
 	<namelist name="namelist.ocean" mode="forward">
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
+		<option name="config_use_frazil_ice_formation">.true.</option>
+		<option name="config_frazil_maximum_depth">2000.0</option>
+		<option name="config_freezing_temperature_coeff_0">-1.8</option>
+		<option name="config_freezing_temperature_coeff_S">0.0</option>
+		<option name="config_freezing_temperature_coeff_p">6.64670038e-08</option>
+		<option name="config_freezing_temperature_coeff_pS">-4.44655526e-09</option>
+		<option name="config_freezing_temperature_reference_pressure">1e5</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="frazil.xml" path_base="script_core_dir" path="templates/streams"/>
 		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
 	</streams>
 

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
@@ -14,9 +14,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
-		<option name="config_use_rx1_constraint">.true.</option>
-		<option name="config_rx1_max">5.0</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
@@ -8,6 +8,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
+                <option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.false.</option>
 		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_restart_run.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_restart_run.xml
@@ -7,11 +7,18 @@
 	<add_executable source="metis" dest="metis"/>
 
 	<namelist name="namelist.ocean" mode="forward">
-		<template file="template_forward.xml" path_base="script_resolution_dir"/>
-		<template file="restart_setup_template.xml" path_base="script_test_dir"/>
-		<option name="config_do_restart">.true.</option>
-		<option name="config_run_duration">0000_00:05:00</option>
-		<option name="config_start_time">0001-01-01_00:05:00</option>
+                <template file="template_forward.xml" path_base="script_resolution_dir"/>
+                <template file="restart_setup_template.xml" path_base="script_test_dir"/>
+                <option name="config_do_restart">.true.</option>
+                <option name="config_run_duration">0000_00:05:00</option>
+                <option name="config_start_time">0001-01-01_00:05:00</option>
+		<option name="config_use_frazil_ice_formation">.true.</option>
+		<option name="config_frazil_maximum_depth">2000.0</option>
+		<option name="config_freezing_temperature_coeff_0">-1.8</option>
+		<option name="config_freezing_temperature_coeff_S">0.0</option>
+		<option name="config_freezing_temperature_coeff_p">6.64670038e-08</option>
+		<option name="config_freezing_temperature_coeff_pS">-4.44655526e-09</option>
+		<option name="config_freezing_temperature_reference_pressure">1e5</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
@@ -22,6 +29,10 @@
 		</stream>
 		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="land_ice_fluxes">
+			<attribute name="output_interval">0000-00-00_00:05:00</attribute>
+		</stream>
+		<template file="frazil.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="frazil">
 			<attribute name="output_interval">0000-00-00_00:05:00</attribute>
 		</stream>
 	</streams>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/restart_setup_template.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/restart_setup_template.xml
@@ -11,6 +11,9 @@
 		<stream name="land_ice_fluxes">
 			<attribute name="output_interval">0000-00-00_00:10:00</attribute>
 		</stream>
+                <stream name="frazil">
+			<attribute name="output_interval">0000-00-00_00:10:00</attribute>
+		</stream>
 		<stream name="restart">
 			<attribute name="filename_template">../restarts/rst.$Y-$M-$D_$h.$m.$s.nc</attribute>
 			<attribute name="filename_interval">output_interval</attribute>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
@@ -13,12 +13,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
-		<option name="config_sub_ice_shelf_2D_vert_levels">100</option>
-		<option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
-		<option name="config_use_rx1_constraint">.true.</option>
-		<option name="config_rx1_max">5.0</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">


### PR DESCRIPTION
Speed up sub_ice_shelf_2D testing

This changes the following in the nightly regression test:
- use 2 iterations in QU_240km/with_land_ice/config_adjust_ssh.xml
- use 2 iterations in sub_ice_shelf_2D/5km/restart_test/config_adjust_ssh.xml
- add frazil flags and output to restart test
- remove 'smoke test' and 'frazil' test, covered now by restart test
- remove some unneeded flags from config_init1
