### PR TITLE
Remove mesh from output when testing AMs.

### DIFF
--- a/test_cases/ocean/ocean/templates/analysis_members/high_frequency_output.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/high_frequency_output.xml
@@ -19,7 +19,6 @@
 			<attribute name="packages">highFrequencyOutputAMPKG</attribute>
 			<attribute name="type">output</attribute>
 			<add_contents>
-				<member name="mesh" type="stream"/>
 				<member name="xtime" type="var"/>
 				<member name="kineticEnergyAt100m" type="var"/>
 				<member name="relativeVorticityAt100m" type="var"/>

--- a/test_cases/ocean/ocean/templates/analysis_members/mixed_layer_depths.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/mixed_layer_depths.xml
@@ -29,7 +29,6 @@
 			<attribute name="packages">mixedLayerDepthsAMPKG</attribute>
 			<attribute name="type">output</attribute>
 			<add_contents>
-				<member name="mesh" type="stream"/>
 				<member name="xtime" type="var"/>
 				<member name="tThreshMLD" type="var"/>
 				<member name="dThreshMLD" type="var"/>

--- a/test_cases/ocean/ocean/templates/analysis_members/okubo_weiss.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/okubo_weiss.xml
@@ -26,7 +26,6 @@
 			<attribute name="packages">okuboWeissAMPKG</attribute>
 			<attribute name="type">output</attribute>
 			<add_contents>
-				<member name="mesh" type="stream"/>
 				<member name="xtime" type="var"/>
 				<member name="okuboWeiss" type="var"/>
 				<member name="vorticity" type="var"/>

--- a/test_cases/ocean/ocean/templates/analysis_members/time_series_stats.xml
+++ b/test_cases/ocean/ocean/templates/analysis_members/time_series_stats.xml
@@ -6,7 +6,7 @@
 		<option name="config_AM_timeSeriesStats_compute_interval">'dt'</option>
 		<option name="config_AM_timeSeriesStats_output_stream">'timeSeriesStatsOutput'</option>
 		<option name="config_AM_timeSeriesStats_restart_stream">'timeSeriesStatsRestart'</option>
-		<option name="config_AM_timeSeriesStats_add_mesh">.true.</option>
+		<option name="config_AM_timeSeriesStats_add_mesh">.false.</option>
 		<option name="config_AM_timeSeriesStats_operation">'avg'</option>
 		<option name="config_AM_timeSeriesStats_reference_times">'initial_time'</option>
 		<option name="config_AM_timeSeriesStats_duration_intervals">'repeat_interval'</option>


### PR DESCRIPTION
The mesh is simply no longer needed in all output files, because we can join the mesh with the `paraview_vtk_field_extractor.py` tool.  This saves a lot of disk space.  Here I just remove them from the templates, which is mostly used for the nightly regression test right now.  This saves about 400 MB of output on the 'Analysis Test' used in the nightly regression test.

These changes are only in the template.  Users can always add the mesh to their local stream file.
