### PR TITLE
Correct time step flags in RRS30to10 spin-ups

### DIFF
--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/default/config_forward.xml
@@ -11,6 +11,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_dt">'00:01:00'</option>
+		<option name="config_btr_dt">'00:00:03'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_forward.xml
@@ -15,7 +15,6 @@
 		<option name="config_run_duration">'00-00-01_00:00:00'</option>
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'file'</option>
-		<option name="config_dt">'00:08:00'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.false.</option>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up1.xml
@@ -12,6 +12,7 @@
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<option name="config_run_duration">'00-00-00_04:00:00'</option>
 		<option name="config_dt">'00:01:00'</option>
+		<option name="config_btr_dt">'00:00:03'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-3</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up2.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up2.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'file'</option>
 		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">4.0e-4</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up3.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up3.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'file'</option>
 		<option name="config_dt">'00:04:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up4.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/spin_up/config_spin_up4.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'file'</option>
 		<option name="config_dt">'00:06:00'</option>
+		<option name="config_btr_dt">'00:00:12'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">4.0e-5</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/template_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/template_forward.xml
@@ -1,7 +1,7 @@
 <template>
 	<namelist>
-		<option name="config_dt">'00:01:00'</option>
-		<option name="config_btr_dt">'00:00:03'</option>
+		<option name="config_dt">'00:10:00'</option>
+		<option name="config_btr_dt">'00:00:24'</option>
 		<option name="config_run_duration">'0000_00:01:00'</option>
 		<option name="config_mom_del4">1.5e10</option>
 		<option name="config_hmix_scaleWithMesh">.true.</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_adjust_ssh.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_adjust_ssh.xml
@@ -16,6 +16,7 @@
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-3</option>
 		<option name="config_dt">'00:01:00'</option>
+		<option name="config_btr_dt">'00:00:03'</option>
 		<option name="config_run_duration">'0000_01:00:00'</option>
 	</namelist>
 

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_forward.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_forward.xml
@@ -19,7 +19,6 @@
 		<option name="config_start_time">'file'</option>
 		<option name="config_pio_num_iotasks">30</option>
 		<option name="config_pio_stride">16</option>
-		<option name="config_dt">'00:08:00'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 	</namelist>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up1.xml
@@ -12,6 +12,7 @@
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<option name="config_run_duration">'00-00-00_04:00:00'</option>
 		<option name="config_dt">'00:01:00'</option>
+		<option name="config_btr_dt">'00:00:03'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-3</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up2.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up2.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'0001-01-01_04:00:00'</option>
 		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">4.0e-4</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up3.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up3.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'0001-01-02_00:00:00'</option>
 		<option name="config_dt">'00:04:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">1.0e-4</option>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up4.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_spin_up4.xml
@@ -16,6 +16,7 @@
 		<option name="config_do_restart">.true.</option>
 		<option name="config_start_time">'0001-01-03_00:00:00'</option>
 		<option name="config_dt">'00:06:00'</option>
+		<option name="config_btr_dt">'00:00:12'</option>
 		<option name="config_write_output_on_startup">.false.</option>
 		<option name="config_Rayleigh_friction">.true.</option>
 		<option name="config_Rayleigh_damping_coeff">4.0e-5</option>


### PR DESCRIPTION
We can run the RRS30to10 at dt=10 minutes.  This has been confirmed in MPAS-O and ACME with both standard and with land ice simulations.  The test suite did not reflect that.  In addition, the barotropic step is updated to be about 30 subcycles per time step.  Previously, it remained at 3 sec, which is way to small.
