### PR TITLE
Make print format for pass thresholds match difference

### DIFF
--- a/test_cases/ocean/utility_scripts/compare_fields.py
+++ b/test_cases/ocean/utility_scripts/compare_fields.py
@@ -141,7 +141,7 @@ else:
 	if np.amax(diff) > linf_norm:
 		linf_norm = np.amax(diff)
 
-	diff_str = '%d: '%(t)
+	diff_str = ''
 	if args.l1_norm:
 		if float(args.l1_norm) < l1_norm:
 			pass_val = False


### PR DESCRIPTION
The script compare_field.py in the test case infrastructure compares
differences between a model run's output and specified thresholds.  The
threshold is always printed, and if the run does not pass the comparison,
the difference is also printed.

However, the threshold print format is a floating point number, meaning
that small thresholds (smaller than the number of decimals printed)
print as zero.

For example, with a threshold set to 1.0e-12 the following is printed:
    Pass thresholds are:
       L1: 0.000000

This commit changes the print format for thresholds to the same
exponential format used by the difference so that no precision is lost.
This is the same threshold as printed after this change:
    Pass thresholds are:
       L1: 1.00000000000000e-12

Making it the identical format to the difference also means that the two
values can be appropriately compared.

This branch also fixes a minor bug where the script errs if run on a file with no time levels.
