### PR TITLE
Add thread loop bounds members to the 'block_type'

### DIFF
--- a/src/framework/mpas_block_types.inc
+++ b/src/framework/mpas_block_types.inc
@@ -27,6 +27,21 @@
       ! Data structures for exchange lists for a block (exchanging standard fields)
       type (parallel_info), pointer :: parinfo
 
+      ! Loop bounds for threaded loops
+      integer :: nThreads = 0
+      integer, dimension(:), pointer :: cellThreadStart => null()
+      integer, dimension(:), pointer :: cellThreadEnd => null()
+      integer, dimension(:), pointer :: cellSolveThreadStart => null()
+      integer, dimension(:), pointer :: cellSolveThreadEnd => null()
+      integer, dimension(:), pointer :: edgeThreadStart => null()
+      integer, dimension(:), pointer :: edgeThreadEnd => null()
+      integer, dimension(:), pointer :: edgeSolveThreadStart => null()
+      integer, dimension(:), pointer :: edgeSolveThreadEnd => null()
+      integer, dimension(:), pointer :: vertexThreadStart => null()
+      integer, dimension(:), pointer :: vertexThreadEnd => null()
+      integer, dimension(:), pointer :: vertexSolveThreadStart => null()
+      integer, dimension(:), pointer :: vertexSolveThreadEnd => null()
+
       ! Linked list pointers
       type (block_type), pointer :: prev => null()
       type (block_type), pointer :: next => null()


### PR DESCRIPTION
This merge adds new members to the 'block_type' that may be used to store the number of threads as well as the loop bounds to be used by threads in cell-, edge-, or vertex-based loops.

Although the mpas_threading module in the framework does not make use of these new members, other threading implementations, such as one used in a branch of the MPAS-Atmosphere code, may. Any MPAS core may safely ignore these new block_type members, in which case they should add only the memory required for 13 pointer-type variables (perhaps 8 bytes each) to the size of a block.
