### PR TITLE
Change 'cp' in mpas_constants module from 1003 to 1004.5 J kg^{-1} K^{-1}

### DIFF
--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -29,7 +29,8 @@ module mpas_constants
    real (kind=RKIND), parameter :: rgas    = 287.0               !< Constant: Gas constant for dry air [J kg-1 K-1]
    real (kind=RKIND), parameter :: rv      = 461.6               !< Constant: Gas constant for water vapor [J kg-1 K-1]
    real (kind=RKIND), parameter :: rvord   = rv/rgas             !
-   real (kind=RKIND), parameter :: cp      = 1003.0              !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
+!  real (kind=RKIND), parameter :: cp      = 1003.0              !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
+   real (kind=RKIND), parameter :: cp      = 7.*rgas/2.          !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
    real (kind=RKIND), parameter :: cv      = cp - rgas           !< Constant: Specific heat of dry air at constant volume [J kg-1 K-1]
    real (kind=RKIND), parameter :: cvpm    = -cv/cp              !
    real (kind=RKIND), parameter :: prandtl = 1.0                 !< Constant: Prandtl number


### PR DESCRIPTION
This merge modifies the constant for the specific heat of dry air at constant pressure (cp) from 1003.0 to 7*Rgas/2 (1004.5) J kg^{-1} K^{-1}.