### PR TITLE
Fix mem leak in mpas_set_timeInterval

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1316,6 +1316,8 @@ module mpas_timekeeping
             if (present(ierr)) ierr = 1
             write(stderrUnit,*) 'ERROR: Invalid TimeInterval string ', trim(timeString)
             return
+         else ! no second decimals are present - do nothing here
+            deallocate(subStrings)
          end if
 
          call mpas_split_string(timeString_, "_", subStrings)


### PR DESCRIPTION
In existing code, a small memory leak can occur in
mpas_set_timeInterval.  Specifically, if size(subStrings) is 1 on line
1302 (which happens when there are no decimal seconds), a memory leak
occurs.  This commit moves the deallocate statement for subStrings to
after the if-construct to ensure subStrings is always deallocated,
regardless of its size.