### PR TITLE
Open streams associated with external communicators

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -259,12 +259,8 @@ include 'mpif.h'
       dminfo % nprocs = mpi_size
       dminfo % my_proc_id = mpi_rank
 
-      if ( dminfo % initialized_mpi ) then
-         write(stderrUnit,'(a,i5,a,i5,a)') 'task ', mpi_rank, ' of ', mpi_size, &
-           ' is running'
-
-         call open_streams(dminfo % my_proc_id)
-      end if
+      write(stderrUnit,'(a,i5,a,i5,a)') 'task ', mpi_rank, ' of ', mpi_size, ' is running'
+      call open_streams(dminfo % my_proc_id)
 
       dminfo % info = MPI_INFO_NULL
 #else


### PR DESCRIPTION
This merge modifies mpas_dmpar_init so that open_streams is called even for externally supplied MPI communicators - existing code does not call open_streams when the MPI communicator is externally supplied.   This allows, e.g., standard out and err for the per-process output to be directed to /dev/null (based on evaluation of ifdef-constructs in open_streams).