### PR TITLE
Prevent 'build_tables' from being run in parallel

### DIFF
--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -27,6 +27,7 @@
 
 !local variables:
  logical, parameter:: l_mp_tables = .false.
+ integer:: istatus
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -36,8 +37,12 @@
 !--- building look-up table for rain collecting graupel:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QRacrQG_DATA.DBL'
+ open(unit=11,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ if (istatus /= 0) then
+    call print_parallel_mesg('MP_THOMPSON_QRacrQG_DATA.DBL')
+    return
+ end if
  call qr_acr_qg
- open(unit=11,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='unformatted')
  write(11) tcg_racg
  write(11) tmr_racg
  write(11) tcr_gacr
@@ -49,8 +54,12 @@
 !--- building look-up table for rain collecting snow:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QRacrQS_DATA.DBL'
+ open(unit=11,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ if (istatus /= 0) then
+    call print_parallel_mesg('MP_THOMPSON_QRacrQS_DATA.DBL')
+    return
+ end if
  call qr_acr_qs
- open(unit=11,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='unformatted',status='new')
  write(11)tcs_racs1
  write(11)tmr_racs1
  write(11)tcs_racs2
@@ -68,8 +77,12 @@
 !--- building look-up table for freezing of cloud droplets:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_freezeH2O_DATA.DBL'
+ open(unit=11,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ if (istatus /= 0) then
+    call print_parallel_mesg('MP_THOMPSON_freezeH2O_DATA.DBL')
+    return
+ end if
  call freezeH2O
- open(unit=11,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='unformatted')
  write(11) tpi_qrfz
  write(11) tni_qrfz
  write(11) tpg_qrfz
@@ -81,8 +94,12 @@
 !--- building look-up table for autoconversion of cloud ice to snow:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QIautQS_DATA.DBL'
+ open(unit=11,file='MP_THOMPSON_QIautQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ if (istatus /= 0) then
+    call print_parallel_mesg('MP_THOMPSON_QIautQS_DATA.DBL')
+    return
+ end if
  call qi_aut_qs
- open(unit=11,file='MP_THOMPSON_QIautQS_DATA.DBL',form='unformatted')
  write(11) tpi_ide
  write(11) tps_iaus
  write(11) tni_iaus
@@ -106,6 +123,22 @@
  write(0,*) '*******************************************************************************'
 
  end subroutine build_tables_thompson
+
+
+!=================================================================================================================
+ subroutine print_parallel_mesg(filename)
+!=================================================================================================================
+
+ character(len=*), intent(in) :: filename
+
+ write(0,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+ write(0,*) '! Error encountered while trying to create new file '//trim(filename)
+ write(0,*) '! '
+ write(0,*) '! Please ensure that this file does not exist before running ''build_tables'','
+ write(0,*) '! and ensure that ''build_tables'' is *NOT* run in parallel.'
+ write(0,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+
+ end subroutine print_parallel_mesg
 
 !=================================================================================================================
  end module atmphys_build_tables_thompson 


### PR DESCRIPTION
This merge adds logic to prevent erroneous parallel execution of the 'build_tables' utility.

The 'build_tables' utility is currently intended to be a serial-only program,
but since MPAS-Atmosphere itself is parallel, some people may mistakenly
run 'build_tables' in parallel. To avoid this situation -- which could allow
multiple copies of the executable to write to the same file -- we add
"status='new'" and "iostat=istatus" to the open( ) statements for the tables.

At least in C, the open( ) statement guarantees the following:

  O_EXCL Ensure that this call creates the file: if this flag is specified in
         conjunction with O_CREAT, and pathname already exists, then open()
         will fail. The behavior of O_EXCL is undefined if O_CREAT is not specified.

Under the assumption that "status='new'" enforces similar behavior in Fortran,
we can guess if (istatus /= 0) that the table file already exists from a previous
execution of the utility, or that there may be multiple instances of the utility
running in parallel and the current instance is not the one who was able to
uniquely create the table file. Then, we can print an error message and quit.