### PR TITLE
fix memory error in initialization of landuse

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2211,10 +2211,6 @@
                      description="z/L height over Monin-Obukhov length"
                      packages="bl_mynn_in;bl_ysu_in"/>
 
-                <var name="znt" type="real" dimensions="nCells Time" units="m"
-                     description="Roughness length"
-                     packages="bl_mynn_in;bl_ysu_in"/>
-
                 <var name="br" type="real" dimensions="nCells Time" units="unitless"
                      description="Richardson number"
                      packages="bl_mynn_in;bl_ysu_in"/>
@@ -2664,6 +2660,9 @@
 
                 <var name="z0" type="real" dimensions="nCells Time" units="m"
                      description="roughness height"/>
+
+                <var name="znt" type="real" dimensions="nCells Time" units="m"
+                     description="roughness length"/>
 
                 <var name="zs" type="real" dimensions="nCells Time" units="m"
                      description="depth of centers of soil layers"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -145,6 +145,8 @@
  call mpas_pool_get_array(sfc_input,'xland'     , xland     )
  call mpas_pool_get_array(sfc_input,'sfc_albbck', albbck    )
 
+ nullify(mavail)
+ nullify(ust)
  call mpas_pool_get_array(diag_physics,'sfc_emibck', embck     )
  call mpas_pool_get_array(diag_physics,'mavail'    , mavail    )
  call mpas_pool_get_array(diag_physics,'sfc_albedo', sfc_albedo)
@@ -275,14 +277,15 @@
           sfc_albedo(iCell) = albbck(iCell) / (1+scfx(is,isn))
        endif
     endif
-    ust(iCell)    = 0.0001
     thc(iCell)    = therin(is,isn) / 100.
     z0(iCell)     = sfz0(is,isn) / 100.
-    znt(iCell)    = z0(iCell)
-    mavail(iCell) = slmo(is,isn)
+    znt(iCell)    = z0(icell)
     embck(iCell)  = sfem(is,isn)
     sfc_emiss(iCell) = embck(iCell)
 
+    if(associated(mavail)) mavail(iCell) = slmo(is,isn)
+    if(associated(ust)) ust(iCell) = 0.0001
+ 
     !set sea-ice points to land with ice/snow surface properties:
     if(xice(iCell) .ge. xice_threshold) then
        albbck(iCell) = albd(isice,isn) / 100.
@@ -299,7 +302,8 @@
        thc(iCell) = therin(isice,isn) / 100.
        z0(icell)  = sfz0(isice,isn) / 100.
        znt(iCell) = z0(iCell)
-       mavail(iCell) = slmo(isice,isn)
+
+       if(associated(mavail)) mavail(iCell) = slmo(isice,isn)
     endif
 
  enddo


### PR DESCRIPTION
This pull request removes all boundary layer packages from variable znt because znt is also used in the land surface scheme.

It also correct memory errors to variables ust and mavail so that the landuse initialization does not crash when the surface layer and PBL schemes are turned off.
