### PR TITLE
Framework nullify decompList

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -251,6 +251,10 @@ module atm_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -298,6 +298,10 @@ module init_atm_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp

--- a/src/core_landice/mpas_li_core_interface.F
+++ b/src/core_landice/mpas_li_core_interface.F
@@ -196,6 +196,10 @@ module li_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -201,6 +201,10 @@ module ocn_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -130,6 +130,10 @@ module sw_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -130,6 +130,10 @@ module test_core_interface
 
       ierr = 0
 
+      if ( associated(decompList) ) then
+         nullify(decompList)
+      endif
+
       call mpas_decomp_create_decomp_list(decompList)
 
       decompFunc => mpas_uniform_decomp


### PR DESCRIPTION
On some machines/compilers (e.g. MacOSX and certain versions of gfortran<=4.9), the pointers decompList are "associated" by default, pointing to some random location. This fix tests for each core if decompList is associated at model initialisation and nullifies them.