### PR TITLE
Modified ocean get scripts for cvmix and BGC to skip update if current version correct

### DIFF
--- a/src/core_ocean/get_BGC.sh
+++ b/src/core_ocean/get_BGC.sh
@@ -16,18 +16,22 @@ GIT=`which git`
 SVN=`which svn`
 PROTOCOL=""
 
-# BGC exists. Need to make sure it's updated if it is git.
+# BGC exists. Check to see if it is the correct version.
 # Otherwise, flush the directory to ensure it's updated.
 if [ -d BGC ]; then
-	unlink BGC
 
 	if [ -d .BGC_all/.git ]; then
 		cd .BGC_all
-		git fetch origin &> /dev/null
-		git checkout ${BGC_TAG} &> /dev/null
+		CURR_TAG=$(git rev-parse --short HEAD)
 		cd ../
-		ln -sf .BGC_all/${BGC_SUBDIR} BGC
+		if [ "${CURR_TAG}" == "${BGC_TAG}" ]; then
+			echo "BGC version is current. Skip update"
+		else
+			unlink BGC
+			rm -rf .BGC_all
+		fi
 	else
+		unlink BGC
 		rm -rf .BGC_all
 	fi
 fi

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -15,21 +15,26 @@ GIT=`which git`
 SVN=`which svn`
 PROTOCOL=""
 
-# CVMix exists. Need to make sure it's updated if it is git.
+# CVMix exists. Check to see if it is the correct version.
 # Otherwise, flush the directory to ensure it's updated.
 if [ -d cvmix ]; then
-	unlink cvmix
 
 	if [ -d .cvmix_all/.git ]; then
 		cd .cvmix_all
-		git fetch origin &> /dev/null
-		git checkout ${CVMIX_TAG} &> /dev/null
+		CURR_TAG=$(git describe --tags)
 		cd ../
-		ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix
+		if [ "${CURR_TAG}" == "${CVMIX_TAG}" ]; then
+			echo "CVmix version is current. Skip update"
+		else
+			unlink cvmix
+			rm -rf .cvmix_all
+		fi
 	else
+		unlink cvmix
 		rm -rf .cvmix_all
 	fi
 fi
+
 
 # CVmix Doesn't exist, need to acquire souce code
 # If might have been flushed from the above if, in the case where it was svn or wget that acquired the source.


### PR DESCRIPTION
Modifies get_cvmix.sh and get_BGC.sh to skip a git checkout if the current version in the local directory is already the correct version. Impacts only the build process and is meant to fix the ACME/Climate issue 1111.
Replaces pull request #1143 with a cleaner version.