### PR TITLE
fix to Makefile to avoid bad interpreter error

### DIFF
--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -46,11 +46,11 @@ post_build:
 	( cp $(ROOT_DIR)/default_inputs/streams.ocean.init $(ROOT_DIR)/streams.ocean.init )
 
 cvmix_source: get_cvmix.sh
-	(chmod a+x get_cvmix.sh; ./get_cvmix.sh)
+	(/bin/bash ./get_cvmix.sh)
 	(cd cvmix)
 
 BGC_source: get_BGC.sh
-	(chmod a+x get_BGC.sh; ./get_BGC.sh)
+	(/bin/bash ./get_BGC.sh)
 	(cd BGC)
 
 libcvmix: cvmix_source


### PR DESCRIPTION
In the Makefile for core_ocean, the scripts to update cvmix and BGC can encounter a bash error: bad interpreter: text file busy 

The is due to a line in the makefile that uses chmod to make the get scripts executable. When bash attempts to execute the script, it appears the file is still in use on some filesystems. Solution is to have bash execute the scripts as a command rather than trying to create an executable.

Only impacts build, does not change solutions.