### PR TITLE
Add -i and -o flags to all mesh conversion calls in ocean test cases

### DIFF
--- a/test_cases/ocean/ocean/baroclinic_channel/10km/decomp_test/config_init1.xml
+++ b/test_cases/ocean/ocean/baroclinic_channel/10km/decomp_test/config_init1.xml
@@ -50,14 +50,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/baroclinic_channel/10km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/baroclinic_channel/10km/default/config_init1.xml
@@ -50,14 +50,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/baroclinic_channel/10km/restart_test/config_init1.xml
+++ b/test_cases/ocean/ocean/baroclinic_channel/10km/restart_test/config_init1.xml
@@ -50,14 +50,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/baroclinic_channel/10km/threads_test/config_init1.xml
+++ b/test_cases/ocean/ocean/baroclinic_channel/10km/threads_test/config_init1.xml
@@ -50,14 +50,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/default/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/spin_up/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/EC_60to30km/with_land_ice/config_init1.xml
@@ -15,8 +15,8 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_cavities"></argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_cavities</argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/default/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/ecosys_60_layer/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/ecosys_60_layer/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_120km/with_land_ice/config_init1.xml
@@ -15,8 +15,8 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_cavities"></argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_cavities</argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/analysis_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/analysis_test/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/default/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/performance_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/performance_test/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/restart_test/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/rk4_blocks_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/rk4_blocks_test/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/se_blocks_test/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/se_blocks_test/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice/config_init1.xml
@@ -15,8 +15,8 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_cavities"></argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_cavities</argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice_no_iter/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/with_land_ice_no_iter/config_init1.xml
@@ -15,8 +15,8 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_cavities"></argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_cavities</argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_240km/zstar_128_layers/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_240km/zstar_128_layers/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/QU_480km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/QU_480km/default/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_critical_passages"></argument>
+			<argument flag="">--with_critical_passages</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_init1.xml
+++ b/test_cases/ocean/ocean/global_ocean/RRS_30to10km/with_land_ice/config_init1.xml
@@ -15,7 +15,7 @@
 	<run_script name="run.py">
 		<step executable="./init_step1.py">
 			<argument flag="-p">geometric_features</argument>
-			<argument flag="--with_cavities"></argument>
+			<argument flag="">--with_cavities</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/global_ocean/init_step1.py
+++ b/test_cases/ocean/ocean/global_ocean/init_step1.py
@@ -65,8 +65,8 @@ shutil.move(defaultFileName,outName)
 
 # create the land mask based on the land coverage
 # Run command is:
-# ./MpasMaskCreator.x  base_mesh.nc land_mask.nc -f land_coverage.geojson
-subprocess.check_call(['./MpasMaskCreator.x', 'base_mesh.nc', 'land_mask.nc', 
+# ./MpasMaskCreator.x  -i base_mesh.nc -o land_mask.nc -f land_coverage.geojson
+subprocess.check_call(['./MpasMaskCreator.x', '-i', 'base_mesh.nc', '-o', 'land_mask.nc', 
                        '-f', 'land_coverage.geojson'], env=os.environ.copy())
 
 # create seed points for a flood fill of the ocean
@@ -91,8 +91,8 @@ if options.with_critical_passages:
 
     # create masks from the transects
     # Run command is:
-    # ./MpasMaskCreator.x  base_mesh.nc critical_passages_mask.nc -f critical_passages.geojson
-    args = ['./MpasMaskCreator.x', 'base_mesh.nc', 'critical_passages_mask.nc',
+    # ./MpasMaskCreator.x  -i base_mesh.nc -o critical_passages_mask.nc -f critical_passages.geojson
+    args = ['./MpasMaskCreator.x', '-i', 'base_mesh.nc', '-o', 'critical_passages_mask.nc',
             '-f', 'critical_passages.geojson']
     print "running", ' '.join(args)
     subprocess.check_call(args, env=os.environ.copy())
@@ -100,8 +100,8 @@ if options.with_critical_passages:
 
     # cull the mesh based on the land mask and keeping critical passages open
     # Run command is:
-    # ./MpasCellCuller.x  base_mesh.nc culled_mesh.nc -m land_mask.nc -p critical_passages_mask.nc
-    args = ['./MpasCellCuller.x', 'base_mesh.nc', 'culled_mesh.nc', 
+    # ./MpasCellCuller.x  -i base_mesh.nc -o culled_mesh.nc -m land_mask.nc -p critical_passages_mask.nc
+    args = ['./MpasCellCuller.x', '-i', 'base_mesh.nc', '-o', 'culled_mesh.nc', 
             '-m', 'land_mask.nc', '-p', 'critical_passages_mask.nc']
     print "running", ' '.join(args)
     subprocess.check_call(args, env=os.environ.copy())
@@ -109,16 +109,16 @@ else:
 
     # cull the mesh based on the land mask
     # Run command is:
-    # ./MpasCellCuller.x  base_mesh.nc culled_mesh.nc -m land_mask.nc
-    args = ['./MpasCellCuller.x', 'base_mesh.nc', 'culled_mesh.nc', 
+    # ./MpasCellCuller.x  -i base_mesh.nc -o culled_mesh.nc -m land_mask.nc
+    args = ['./MpasCellCuller.x', '-i', 'base_mesh.nc', '-o', 'culled_mesh.nc', 
             '-m', 'land_mask.nc']
     print "running", ' '.join(args)
     subprocess.check_call(args, env=os.environ.copy())
 
 # create a mask for the flood fill seed points
 # Run command is:
-# ./MpasMaskCreator.x  culled_mesh.nc seed_mask.nc -s seed_points.geojson
-args = ['./MpasMaskCreator.x', 'culled_mesh.nc', 'seed_mask.nc',
+# ./MpasMaskCreator.x  -i culled_mesh.nc -o seed_mask.nc -s seed_points.geojson
+args = ['./MpasMaskCreator.x', '-i', 'culled_mesh.nc', '-o', 'seed_mask.nc',
         '-s', 'seed_points.geojson']
 print "running", ' '.join(args)
 subprocess.check_call(args, env=os.environ.copy())
@@ -126,9 +126,9 @@ subprocess.check_call(args, env=os.environ.copy())
 
 # cull the mesh a second time using a flood fill from the seed points
 # Run command is:
-# ./MpasCellCuller.x  culled_mesh.nc culled_mesh_final.nc -i seed_mask.nc
-args = ['./MpasCellCuller.x', 'culled_mesh.nc', 'culled_mesh_final.nc', 
-        '-i', 'seed_mask.nc']
+# ./MpasCellCuller.x  -i culled_mesh.nc -o culled_mesh_final.nc -v seed_mask.nc
+args = ['./MpasCellCuller.x', '-i', 'culled_mesh.nc', '-o', 'culled_mesh_final.nc', 
+        '-v', 'seed_mask.nc']
 
 print "running", ' '.join(args)
 subprocess.check_call(args, env=os.environ.copy())
@@ -136,9 +136,9 @@ subprocess.check_call(args, env=os.environ.copy())
 if options.with_critical_passages:
     # make a new version of the critical passages mask on the culled mesh
     # Run command is:
-    # ./MpasMaskCreator.x  culled_mesh_final.nc critical_passages_mask_final.nc -f critical_passages.geojson
-    args = ['./MpasMaskCreator.x', 'culled_mesh_final.nc', 
-            'critical_passages_mask_final.nc', 
+    # ./MpasMaskCreator.x -i culled_mesh_final.nc -o critical_passages_mask_final.nc -f critical_passages.geojson
+    args = ['./MpasMaskCreator.x', '-i', 'culled_mesh_final.nc', 
+            '-o', 'critical_passages_mask_final.nc', 
             '-f', 'critical_passages.geojson']
     print "running", ' '.join(args)
     subprocess.check_call(args, env=os.environ.copy())

--- a/test_cases/ocean/ocean/isomip/10km/expt1.01/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt1.01/config_init1.xml
@@ -24,8 +24,8 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<step executable="./metis">
@@ -34,7 +34,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip/10km/expt2.01/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip/10km/expt2.01/config_init1.xml
@@ -29,8 +29,8 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<step executable="./metis">
@@ -39,7 +39,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/2km/Ocean0/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/2km/Ocean0/config_init1.xml
@@ -39,8 +39,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">4</argument>
@@ -49,7 +49,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/2km/Ocean1/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/2km/Ocean1/config_init1.xml
@@ -39,8 +39,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">16</argument>
@@ -49,7 +49,7 @@
 		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/2km/Ocean2/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/2km/Ocean2/config_init1.xml
@@ -41,8 +41,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">16</argument>
@@ -51,7 +51,7 @@
 		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/5km/Ocean0/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/5km/Ocean0/config_init1.xml
@@ -39,8 +39,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">4</argument>
@@ -49,7 +49,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/5km/Ocean1/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/5km/Ocean1/config_init1.xml
@@ -39,8 +39,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">4</argument>
@@ -49,7 +49,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/isomip_plus/5km/Ocean2/config_init1.xml
+++ b/test_cases/ocean/ocean/isomip_plus/5km/Ocean2/config_init1.xml
@@ -41,8 +41,8 @@
 		</step>
 
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		<step executable="./metis">
 			<argument flag="graph.info">4</argument>
@@ -51,7 +51,7 @@
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/lock_exchange/0.5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/lock_exchange/0.5km/default/config_init1.xml
@@ -50,14 +50,14 @@ v		<option name="config_vert_levels">1</option>
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/lock_exchange/16km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/lock_exchange/16km/default/config_init1.xml
@@ -50,14 +50,14 @@ v		<option name="config_vert_levels">1</option>
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/overflow/10km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/overflow/10km/default/config_init1.xml
@@ -51,14 +51,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/periodic_planar/20km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/periodic_planar/20km/default/config_init1.xml
@@ -51,14 +51,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/periodic_planar/20km/region_reset_test/config_init1.xml
+++ b/test_cases/ocean/ocean/periodic_planar/20km/region_reset_test/config_init1.xml
@@ -51,14 +51,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/periodic_planar/20km/time_reset_test/config_init1.xml
+++ b/test_cases/ocean/ocean/periodic_planar/20km/time_reset_test/config_init1.xml
@@ -51,14 +51,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sea_mount/6.7km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/sea_mount/6.7km/default/config_init1.xml
@@ -50,14 +50,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_init.xml
+++ b/test_cases/ocean/ocean/single_column_model/planar/cvmix_test/config_init.xml
@@ -106,8 +106,8 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		
 		<step executable="mpirun">

--- a/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_init.xml
+++ b/test_cases/ocean/ocean/single_column_model/sphere/cvmix_test/config_init.xml
@@ -107,8 +107,8 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 		
 		<step executable="mpirun">

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
@@ -24,14 +24,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
@@ -25,14 +25,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/default/config_init1.xml
@@ -22,14 +22,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
@@ -23,14 +23,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
@@ -22,14 +22,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
+++ b/test_cases/ocean/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
@@ -22,14 +22,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/ziso/10km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/10km/default/config_forward.xml
@@ -43,7 +43,7 @@
 		</step>
 		<step executable="python">
 			<argument flag="">make_particle_resets.py</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
 			<argument flag="">11</argument>

--- a/test_cases/ocean/ocean/ziso/10km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/10km/default/config_init1.xml
@@ -57,14 +57,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/ziso/2.5km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/2.5km/default/config_forward.xml
@@ -43,7 +43,7 @@
 		</step>
 		<step executable="python">
 			<argument flag="">make_particle_resets.py</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
 			<argument flag="">11</argument>

--- a/test_cases/ocean/ocean/ziso/2.5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/2.5km/default/config_init1.xml
@@ -57,14 +57,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/ziso/20km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/20km/default/config_forward.xml
@@ -48,7 +48,7 @@
 		</step>
 		<step executable="python">
 			<argument flag="">make_particle_resets.py</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
 			<argument flag="">11</argument>

--- a/test_cases/ocean/ocean/ziso/20km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/20km/default/config_init1.xml
@@ -57,14 +57,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/ziso/20km/with_frazil/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/20km/with_frazil/config_init1.xml
@@ -58,14 +58,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/test_cases/ocean/ocean/ziso/5km/default/config_forward.xml
+++ b/test_cases/ocean/ocean/ziso/5km/default/config_forward.xml
@@ -43,7 +43,7 @@
 		</step>
 		<step executable="python">
 			<argument flag="">make_particle_resets.py</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 			<argument flag="">particles.nc</argument>
 			<argument flag="">graph.info.part.4</argument>
 			<argument flag="">11</argument>

--- a/test_cases/ocean/ocean/ziso/5km/default/config_init1.xml
+++ b/test_cases/ocean/ocean/ziso/5km/default/config_init1.xml
@@ -57,14 +57,14 @@
 
 	<run_script name="run.py">
 		<step executable="./MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
+			<argument flag="-i">base_mesh.nc</argument>
+			<argument flag="-o">mesh.nc</argument>
 		</step>
 
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="./MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
+			<argument flag="-i">ocean.nc</argument>
 		</step>
 	</run_script>
 </config>


### PR DESCRIPTION
All calls to `MpasMaskCreator.x`, `MpasMeshConverter.x` and `MpasCellCuller.x` require `-i` and `-o` flags to be compatible with changes made to the syntax of these tools in https://github.com/MPAS-Dev/MPAS-Tools/pull/149. Also based on the same PR, the flag for inverse masking in the cell culler has been changed from `-i` to `-v`.

This merge also fixes a minor issue with the syntax in calls to the script `init_step1.py` in some `global_ocean` test cases.