### PR TITLE
Bug fix in MPAS_stream_mgr_add_att_int that prevents adding integer attributes

### DIFF
--- a/src/framework/mpas_stream_list.F
+++ b/src/framework/mpas_stream_list.F
@@ -255,7 +255,7 @@ module mpas_stream_list
 
         ! Return if no streams exist in stream list
         if ( list % nItems == 0 ) then
-            LIST_DEBUG_WRITE(' -- Not items matching '//trim(streamPattern)//' found in list.')
+            LIST_DEBUG_WRITE(' -- No items matching '//trim(streamPattern)//' found in list.')
             nullify(stream)
             return
         end if

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -2140,7 +2140,7 @@ module mpas_stream_manager
         if (present(streamID)) then
             addedAttribute = .false.
             nullify(stream_cursor)
-            do while (.not. MPAS_stream_list_query(manager % streams, streamID, stream_cursor, ierr=err_local))
+            do while (MPAS_stream_list_query(manager % streams, streamID, stream_cursor, ierr=err_local))
                 addedAttribute = .true.
                 att_pool => stream_cursor % att_pool
                 err_level = mpas_pool_get_error_level()


### PR DESCRIPTION
Subroutine MPAS_stream_mgr_add_att_int contains a bug when searching for a stream with given streamID. The do-while statement tests for .not. MPAS_stream_list_query(..) where it should test for the opposite (as it is the case for add_att_real and all others). Second fix is a typo in a debug message in mpas_stream_list.F.