### PR TITLE
Bugfix in atmphys_manager when setting the alarm for surface boundary condition update

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -375,6 +375,7 @@
                                   config_camrad_abs_update,      &
                                   config_greeness_update
 
+ logical,pointer:: config_sst_update
  logical,pointer:: config_frac_seaice
  logical,pointer:: config_microp_re
 
@@ -413,6 +414,7 @@
  call mpas_pool_get_config(configs,'config_bucket_update'    ,config_bucket_update    )
  call mpas_pool_get_config(configs,'config_camrad_abs_update',config_camrad_abs_update)
  call mpas_pool_get_config(configs,'config_greeness_update'  ,config_greeness_update  )
+ call mpas_pool_get_config(configs,'config_sst_update'       ,config_sst_update       )
  call mpas_pool_get_config(configs,'config_frac_seaice'      ,config_frac_seaice      )
  call mpas_pool_get_config(configs,'config_microp_re'        ,config_microp_re        )
 
@@ -548,9 +550,9 @@
        call physics_error_fatal('subroutine physics_init: error creating alarm greeness')
 
 !set alarm for updating the surface boundary conditions:
- call MPAS_stream_mgr_get_property(stream_manager, 'surface', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
-                                   direction=MPAS_STREAM_INPUT, ierr=ierr)
- if(trim(stream_interval) /= 'none') then
+ if (config_sst_update) then
+    call MPAS_stream_mgr_get_property(stream_manager, 'surface', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
+                                      direction=MPAS_STREAM_INPUT, ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=stream_interval,ierr=ierr)
     alarmStartTime = startTime
     call mpas_add_clock_alarm(clock,sfcbdyAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)


### PR DESCRIPTION
Release 5.0 tries to access a stream 'surface' in atmphys_manager in order to set up the alarm for surface boundary condition updates. In case the stream surface is not present in streams.atmosphere, the code aborts:

ERROR: Stream surface does not exist in call to MPAS_stream_mgr_get_property()

The solution suggested here checks if the config_sst_update is true before querying the stream, assuming that one would set config_sst_update to true only when the stream is actually present.

@mgduda In a separate branch/commit against atmosphere/develop, I will suggest a cleaner handling of the surface stream in the atmosphere core, which performs sanity checks and ensures consistency between config_sst_update being true/false and the stream being defined or not. For release 5.0, I believe that the simple fix here should be sufficient.