### PR TITLE
Fix for 'cape', 'cin', 'relhum', and isobaric 'dewpoint' computation

### DIFF
--- a/src/core_atmosphere/diagnostics/convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/convective_diagnostics.F
@@ -359,14 +359,14 @@ module convective_diagnostics
 
             do iCell = 1,nCells
             do k = 1,nVertLevels
-                temperature(k,iCell) = (theta_m(k,iCell)/(1._RKIND+rvord*scalars(index_qv,k,iCell)))*exner(k,iCell) 
+                temperature(k,iCell) = (theta_m(k,iCell)/(1._RKIND+rvord*scalars(index_qv,k,iCell)))*exner(k,iCell)
                 tempC = temperature(k,iCell) - 273.15
-                relhum(k,iCell) = max(1.e-08,min(1.,relhum(k,iCell)))
-                logrelhum = log(relhum(k,iCell))
-                dewpoint(k,iCell) = 243.04*(logrelhum+(17.625*tempC/(243.04+tempC))) & 
-                                    /(17.625-logrelhum-((17.625*tempC)/(243.04+tempC))) 
-            end do
-            end do
+                logrelhum = log(max(1.e-08,min(100.,relhum(k,iCell)))*0.01)
+                dewpoint(k,iCell) = 243.04*(logrelhum+(17.625*tempC/(243.04+tempC))) &
+                                    /(17.625-logrelhum-((17.625*tempC)/(243.04+tempC)))
+            enddo
+            enddo
+
 
             ! first the shear values.  We will use lowest model level velocity for surface velocity
             do iCell=1,nCellsSolve

--- a/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
@@ -559,8 +559,7 @@ module isobaric_diagnostics
             do k = 1,nVertLevels
                 temperature(k,iCell) = (theta_m(k,iCell)/(1._RKIND+rvord*scalars(index_qv,k,iCell)))*exner(k,iCell) 
                 tempC = temperature(k,iCell) - 273.15
-                relhum(k,iCell) = max(1.e-08,min(1.,relhum(k,iCell)))
-                logrelhum = log(relhum(k,iCell))
+                logrelhum = log(max(1.e-08,min(100.,relhum(k,iCell)))*0.01)
                 dewpoint(k,iCell) = 243.04*(logrelhum+(17.625*tempC/(243.04+tempC))) & 
                                     /(17.625-logrelhum-((17.625*tempC)/(243.04+tempC))) 
             enddo


### PR DESCRIPTION
This merge corrects errors in the 'cape', 'cin', 'relhum', and isobaric 'dewpoint' fields arising from an assumption in diagnostic computations that the relative humidity field was given as a fraction, when in fact it is given as a percent.

In both the  isobaric_diagnostics and convective_diagnostics modules, an upper bound of 1.0 was being placed on the 'relhum' field, which lead to bad values for relative humidity as well as dewpoint temperature. Rather than modifying the 'relhum' field by placing an upper bound, a temporary, fractional relative humidity value is computed for use specifically in the computation of the 'dewpoint' field, which is in turn used by the routines for computing CAPE and CIN.