### PR TITLE
Minor typographical fixes to print statements in 'build_tables'

### DIFF
--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -110,7 +110,7 @@
  write(0,*)
  write(0,*) '*******************************************************************************'
  write(0,*) 'To preserve these tables when running ''make clean'', please copy the following'
- write(0,*) 'files to the src/core_atmosphere/physics/physics_wrf/files/ '
+ write(0,*) 'files to the src/core_atmosphere/physics/physics_wrf/files/ directory:'
  write(0,*)
  write(0,*) '  MP_THOMPSON_QRacrQG_DATA.DBL'
  write(0,*) '  MP_THOMPSON_QRacrQS_DATA.DBL'

--- a/src/core_atmosphere/utils/build_tables.F
+++ b/src/core_atmosphere/utils/build_tables.F
@@ -12,7 +12,7 @@
  implicit none
 
  write(0,*) ' '
- write(0,*) 'Constructing tables for Thompson cloud microphysics scheme'
+ write(0,*) 'Constructing tables for Thompson cloud microphysics scheme.'
  write(0,*) 'This may take as much as 15-20 minutes with an optimized build...'
 
  call build_tables_thompson


### PR DESCRIPTION
This merge makes two minor changes to the print statements in
the build_tables utility. No change to results.