### PR TITLE
Add print statements to identify default real precision in log files

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -53,6 +53,14 @@ module atm_core_interface
 
 #include "inc/core_variables.inc"
 
+write(0,*) ''
+#ifdef SINGLE_PRECISION
+write(0,'(a)') 'Using default single-precision reals'
+#else
+write(0,'(a)') 'Using default double-precision reals'
+#endif
+write(0,*) ''
+
    end subroutine atm_setup_core
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -52,6 +52,14 @@ module init_atm_core_interface
 
 #include "inc/core_variables.inc"
 
+write(0,*) ''
+#ifdef SINGLE_PRECISION
+write(0,'(a)') 'Using default single-precision reals'
+#else
+write(0,'(a)') 'Using default double-precision reals'
+#endif
+write(0,*) ''
+
    end subroutine init_atm_setup_core
 
 


### PR DESCRIPTION
This merge adds print statements in the atm_setup_core() and init_atm_setup_core()
routines to identify the default real precision that was used when the core was
built. These routines are called early on in the model startup sequence, and will
result one of the two print statements

 Using default single-precision reals

or

 Using default double-precision reals

showing up at the top of the log.*.err files.