### PR TITLE
Initialize t_oml_200m_initial field when climatological OML depth is used

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -307,6 +307,14 @@
           hv_oml(iCell) = 0.
           t_oml_200m_initial(iCell) = sst(iCell) - 5.
         end do
+      else if (config_oml_hml0 .eq. 0) then
+! initializing with climatological mixed layer depth only
+        do iCell = 1, nCellsSolve
+          h_oml(iCell) = h_oml_initial(iCell)
+          hu_oml(iCell) = 0.
+          hv_oml(iCell) = 0.
+          t_oml_200m_initial(iCell) = sst(iCell) - 5.
+        end do
       else
         do iCell = 1, nCellsSolve
           h_oml(iCell) = h_oml_initial(iCell)


### PR DESCRIPTION
This merge corrects a bug wherein the top 200 m layer mean temperature used by the
1-d OML model was not properly initialized in some cases.

When the namelist option 'config_oml_hml0' is zero, the ocean mixed-layer depth
was initialized from a climatological field, but the top 200 m layer mean temperature,
as well as the zonal and meridional velocities, were not initialized.

Now, the initial top 200 m layer mean temperature (t_oml_200m_initial) is set to
(SST - 5) when config_oml_hml0 == 0. Also, hu_oml and hv_oml are initialized to zero.

The t_oml_200m_initial field has a small function in OML: it acts to limit the mixing
if the skin temperature is cooler than the value in this field. Without it being
properly defined, the OML model may keep cooling the ocean.