### PR TITLE
Ensures AM write/compute startup steps done once

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
@@ -604,6 +604,16 @@ contains
                     // poolItr % memberName(1:nameLength) // '.'
                end if
             end if
+
+            ! Reset configs to false, so we don't write or compute the state every coupling interval for use within ACME.
+            ! This ensures that these startup options are only done once.
+            if ( config_AM_compute_on_startup) then
+              config_AM_compute_on_startup = .false.
+            end if
+            if ( config_AM_write_on_startup ) then
+              config_AM_write_on_startup = .false.
+            end if
+
          end if
       end do
 


### PR DESCRIPTION
This is to fix a bug in the ACME where startup computation
and writing did not work for AMs.  This fix is needed to
ensure that these steps are not performed each coupling
interval

Addresses code changes on the MPAS-O side for https://github.com/ACME-Climate/ACME/issues/1185

cc @jonbob 