### PR TITLE
Add exit messages at the end of core_finalize routines

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -880,6 +880,7 @@ module atm_core
       use mpas_timekeeping
       use mpas_atm_diagnostics_manager, only : mpas_atm_diag_cleanup
       use mpas_atm_threading, only : mpas_atm_threading_finalize
+      use mpas_io_units, only : stderrUnit
    
 #ifdef DO_PHYSICS
       use mpas_atmphys_finalize
@@ -911,6 +912,11 @@ module atm_core
       ! Finalize threading
       !
       call mpas_atm_threading_finalize(domain % blocklist)
+
+      write(stderrUnit,'(a)') ''
+      write(stderrUnit,'(a)') '********************************************************'
+      write(stderrUnit,'(a)') '   Finished running the atmosphere core'
+      write(stderrUnit,'(a)') '********************************************************'
    
    end function atm_core_finalize
 

--- a/src/core_init_atmosphere/mpas_init_atm_core.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core.F
@@ -98,6 +98,7 @@ module init_atm_core
       use mpas_derived_types
       use mpas_decomp
       use mpas_stream_manager
+      use mpas_io_units, only : stderrUnit
    
       implicit none
    
@@ -108,6 +109,11 @@ module init_atm_core
       ierr = 0
 
       call mpas_decomp_destroy_decomp_list(domain % decompositions)
+
+      write(stderrUnit,'(a)') ''
+      write(stderrUnit,'(a)') '********************************************************'
+      write(stderrUnit,'(a)') '   Finished running the init_atmosphere core'
+      write(stderrUnit,'(a)') '********************************************************'
    
    end function init_atm_core_finalize
    


### PR DESCRIPTION
This merge adds print statements to the end of the init_atm_core_finalize and atm_core_finalize
routines in order to give some indication of whether execution of the init_atmosphere
or atmosphere cores reached the end of the core's code without any fatal errors. Without this
printout, it may not always be obvious that a core reached the end of its expected execution.