### PR TITLE
Avoid bit-reproducibility errors in GWDO scheme due to 'kpblmin' and 'kpblmax'

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
@@ -455,14 +455,14 @@ contains
      ol(i) = ol4(i,mod(nwd-1,4)+1)
    enddo
 !
+   kpblmax = 2
    kpblmin = kte
    do i = its,ite
+     if (oa(i).le.0.0) kbl(i) = kpbl(i) + 1
+     kpblmax = max(kpblmax,kbl(i))
      kpblmin = min(kpblmin, kbl(i))
    enddo
-!
-   do i = its,ite
-     if (oa(i).le.0.0) kbl(i) = kpbl(i) + 1
-   enddo
+   kpblmax = min(kpblmax+1,kte-1)
 !
    do i = its,ite
      delks(i) = 1.0 / (prsi(i,1) - prsi(i,kbl(i)))


### PR DESCRIPTION
This merge corrects bit-reproducibility errors in the YSU GWDO scheme caused by 
the incorrect computation of values for 'kpblmin' and 'kpblmax'.

The 'kpblmin' and 'kpblmax' values in the GWDO scheme are computed based on values
of 'kbl' for each column that is owned by an MPI rank. Because the PBL structure
is necessarily different for distinct groups of columns, the values of 'kpblmin'
and 'kpblmax' differ among MPI ranks; furthermore, the value of 'kbl' may be modified
after 'kpblmax' and 'kpblmin' are computed. To ensure identical results across
different MPI task counts, we need to recompute final values for 'kpblmin' and 'kpblmax'
after the last modification of 'kbl'.