### PR TITLE
Fix incorrect assignment of 'xlamdd', 'frh', and 'mentrd_rate' in Grell-Freitas scheme

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_cu_gf.mpas.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_gf.mpas.F
@@ -812,7 +812,7 @@ CONTAINS
         xz(i,k)=zo(i,k)
         cupclw(i,k)=0.
         cd(i,k)=1.*entr_rate
-        cdd(i,k)=xlamdd
+        cdd(i,k)=xlamdd(i)
         hcdo(i,k)=0.
         qrcdo(i,k)=0.
         dellaqc(i,k)=0.
@@ -1093,7 +1093,7 @@ CONTAINS
             zuhe(i)=zustart
             do k=2,kbegzu 
               dz=z_cup(i,k+1)-z_cup(i,k)
-              frh=zuhe(i)
+              frh(i)=zuhe(i)
               zuhe(i)=zuhe(i)+entr_rate_2d(i,k)*dz*zuhe(i)-cd(i,k)*dz*zuhe(i)
             enddo
          ENDIF
@@ -1401,7 +1401,7 @@ CONTAINS
 ! calculate downdraft mass terms
 !
             do ki=jmin(i)-1,1,-1
-               mentrd_rate=mentrd_rate_2d(i,ki)
+               mentrd_rate(i)=mentrd_rate_2d(i,ki)
                dzo=zo_cup(i,ki+1)-zo_cup(i,ki)
                dd_massentro(i,ki)=mentrd_rate(i)*dzo*zdo(i,ki+1)
                dd_massdetro(i,ki)=cdd(i,ki)*dzo*zdo(i,ki+1)


### PR DESCRIPTION
This merge corrects variable assignment errors in the Grell-Freitas scheme that
caused bit-reproducibility errors for different MPI task counts.

The variables 'xlamdd', 'frh', and 'mentrd_rate' are dimensioned by (its:ite) in the MPAS 
version of the GF scheme, but were incorrectly used in several places as though they were
scalars (which they are in the WRF version of the scheme). This led to an inability
to get identical results from the GF scheme for different MPI task counts.