### PR TITLE
Fix restartability of the new Tiedtke scheme

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -395,11 +395,12 @@
  logical:: log_convection
 
  integer:: i,j
- integer:: icount
+ integer:: icount,initflag
 
  real(kind=RKIND):: dx
 
 !local pointers:
+ logical,pointer:: config_do_restart
  integer,pointer:: gfconv_closure_deep,gfconv_closure_shallow
  real(kind=RKIND),pointer:: len_disp
 
@@ -417,6 +418,7 @@
  call mpas_pool_get_config(configs,'config_gfconv_closure_deep',gfconv_closure_deep)
  call mpas_pool_get_config(configs,'config_gfconv_closure_shallow',gfconv_closure_shallow)
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
+ call mpas_pool_get_config(configs,'config_do_restart',config_do_restart)
 
 !initialize instantaneous precipitation, and copy convective tendencies from the dynamics to
 !the physics grid:
@@ -434,6 +436,10 @@
     cu_act_flag(i,j) = .false.
  enddo
  enddo
+
+!... initialization of initflag needed in the calls cu_tiedtke and cu_ntiedtke:
+ initflag = 1
+ if(config_do_restart .or. itimestep > 1) initflag = 0
 
  convection_select: select case(convection_scheme)
 
@@ -511,7 +517,7 @@
        call cu_tiedtke( &
              pcps        = pres_hyd_p    , p8w       = pres2_hyd_p   ,               &
              znu         = znu_hyd_p     , t3d       = t_p           ,               &
-             dt          = dt_dyn        , itimestep = itimestep     ,               &
+             dt          = dt_dyn        , itimestep = initflag      ,               &
              stepcu      = n_cu          , raincv    = raincv_p      ,               &
              pratec      = pratec_p      , qfx       = qfx_p         ,               &
              u3d         = u_p           , v3d       = v_p           ,               &
@@ -535,7 +541,7 @@
        call cu_ntiedtke( &
              pcps      = pres_hyd_p  , p8w         = pres2_hyd_p ,                   &
              t3d       = t_p         , dz8w        = dz_p        ,                   &
-             dt        = dt_dyn      , itimestep   = itimestep   ,                   &
+             dt        = dt_dyn      , itimestep   = initflag    ,                   &
              stepcu    = n_cu        , raincv      = raincv_p    ,                   & 
              pratec    = pratec_p    , qfx         = qfx_p       ,                   &
              hfx       = hfx_p       , xland       = xland_p     ,                   &

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
@@ -381,24 +381,6 @@ contains
         enddo
       enddo
 
-#if defined(mpas)
-      do k=kts,kte
-        zz = kte+1-k        
-        do i=its,ite
-          u1(i,zz)=u3d(i,k,j)
-          v1(i,zz)=v3d(i,k,j)
-          t1(i,zz)=t3d(i,k,j)
-          q1(i,zz)= qv3d(i,k,j)
-          q1b(i,zz)=qvften(i,k,j)
-          q1bl(i,zz)=qvpblten(i,k,j)
-          q2(i,zz)=qc3d(i,k,j)
-          q3(i,zz)=qi3d(i,k,j)
-          omg(i,zz)=dot(i,k)
-          ght(i,zz)=zl(i,k)
-          prsl(i,zz) = pcps(i,k,j)
-        enddo
-      enddo
-#else
       do k=kts,kte
         zz = kte+1-k        
         do i=its,ite
@@ -420,7 +402,6 @@ contains
           prsl(i,zz) = pcps(i,k,j)
         enddo
       enddo
-#endif
 
       do k=kts,kte+1
         zz = kte+2-k


### PR DESCRIPTION
This merge fixes a restartability error in the new Tiedtke scheme.

The new Tiedtke scheme relied on the value of 'itimestep' -- the time step
counter -- to initialize the variables 'q1b' and 't1b' to either zero or to
the values of 'qvften' and 'thften', respectively. Because the time step counter
begins at 1 even for restart runs, this caused the 'q1b' and 't1b' fields to be
set to zero in the first call after a restart, breaking bit-identical restarts
with the scheme.

Now, the dummy argument 'itimestep' in both Tiedtke schemes is passed a flag that 
is set to either 0 or 1 in the convection driver depending on whether
itimestep == 1 and config_do_restart == false.