### PR TITLE
Automatic adjustment of number of digits for log.xxxx.err and log.xxxx.out

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -57,7 +57,7 @@ module mpas_framework
 
       write(stderrUnit,'(a,i5,a,i5,a)') 'task ', dminfo % my_proc_id, ' of ', dminfo % nprocs, &
            ' is running'
-      call open_streams(dminfo % my_proc_id)
+      call open_streams(dminfo % my_proc_id, dminfo % nprocs)
 
    end subroutine mpas_framework_init_phase1!}}}
 

--- a/src/framework/streams.c
+++ b/src/framework/streams.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <string.h>
 
 #ifdef MPAS_DEBUG
 #ifndef MPAS_ALL_TASKS_PRINT
@@ -27,22 +28,60 @@
 
 int fd_out, fd_err;
 
-void open_streams(int * id)
+void open_streams(int * id, int * tasks)
 {
    char fname[128];
+   char eformat[128];
+   char oformat[128];
+
+   strcpy(eformat, "log.");
+   strcpy(oformat, "log.");
+
+   if(*tasks < 1E4) {
+       strcat(eformat, "%4.4i");
+       strcat(oformat, "%4.4i");
+   }
+   else if (*tasks < 1E5) {
+       strcat(eformat, "%5.5i");
+       strcat(oformat, "%5.5i");
+   }
+   else if (*tasks < 1E6) {
+       strcat(eformat, "%6.6i");
+       strcat(oformat, "%6.6i");
+   }
+   else if (*tasks < 1E7) {
+       strcat(eformat, "%7.7i");
+       strcat(oformat, "%7.7i");;
+   }
+   else if (*tasks < 1E8) {
+       strcat(eformat, "%8.8i");
+       strcat(oformat, "%8.8i");
+   }
+   else if (*tasks < 1E9) {
+       strcat(eformat, "%9.9i");
+       strcat(oformat, "%9.9i");
+   }
+   else {
+       if(*id == 0){
+           fprintf(stderr, "Error opening streams for 1E9 tasks or more\n");
+       }
+       return;
+   }
+   strcat(eformat, ".err");
+   strcat(oformat, ".out");
 
 #ifndef MPAS_NO_LOG_REDIRECT
 
 #ifndef MPAS_ALL_TASKS_PRINT
    if(*id == 0){
-	   sprintf(fname, "log.%4.4i.err", *id);
+	   sprintf(fname, eformat, *id);
 	   fd_err = open(fname,O_CREAT|O_WRONLY|O_TRUNC,0644);
 	   if (dup2(fd_err, 2) < 0) {
 		   printf("Error duplicating STDERR\n");
 		   return;
 	   }
 
-	   sprintf(fname, "log.%4.4i.out", *id);
+	   sprintf(fname, oformat, *id);
 	   fd_out = open(fname,O_CREAT|O_WRONLY|O_TRUNC,0644);
 	   if (dup2(fd_out, 1) < 0) {
 		   printf("Error duplicating STDOUT\n");
@@ -64,14 +103,14 @@ void open_streams(int * id)
 	   }
    }
 #else // MPAS_ALL_TASKS_PRINT
-   sprintf(fname, "log.%4.4i.err", *id);
+   sprintf(fname, eformat, *id);
    fd_err = open(fname,O_CREAT|O_WRONLY|O_TRUNC,0644);
    if (dup2(fd_err, 2) < 0) {
       printf("Error duplicating STDERR\n");
       return;
    }
 
-   sprintf(fname, "log.%4.4i.out", *id);
+   sprintf(fname, oformat, *id);
    fd_out = open(fname,O_CREAT|O_WRONLY|O_TRUNC,0644);
    if (dup2(fd_out, 1) < 0) {
       printf("Error duplicating STDOUT\n");


### PR DESCRIPTION
Just as for the new log.xxxx.abort, this patch modifies streams.c such that xxxx is 4 digits for total number of tasks < 1E4, 5 digits for <1E5 etc. all the way up to 9 digits for <1E9 tasks. @mgduda unfortunately I still can't edit pull request to add tags etc.

I tested this code on Mac OS X Sierra (clang/gfortran), Scientific Linux 7.2 (icc/ifort) and SUSE Enterprise Linux (icc/ifort) for 1 to MPI 16384 tasks.