### PR TITLE
Fix issue with 'dzs' when running r8 model with r4 initial conditions

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -349,12 +349,10 @@
        case("noah")
        !initialize the thickness of the soil layers for the Noah scheme:
           do iCell = 1, nCells
-             if(landmask(iCell) == 1) then  
-                dzs(1,iCell) = 0.10_RKIND
-                dzs(2,iCell) = 0.30_RKIND
-                dzs(3,iCell) = 0.60_RKIND
-                dzs(4,iCell) = 1.00_RKIND
-             endif
+             dzs(1,iCell) = 0.10_RKIND
+             dzs(2,iCell) = 0.30_RKIND
+             dzs(3,iCell) = 0.60_RKIND
+             dzs(4,iCell) = 1.00_RKIND
           enddo
 
        case default


### PR DESCRIPTION
This merge corrects an issue with the 'dzs' field when running MPAS-Atmosphere
in double-precision using single-precision initial conditions files.

The initial conditions file provides values for 'dzs', and for the Noah
LSM, we were previously reinitializing the 'dzs' field only for land cells.
However, the Noah scheme takes as input a single column of soil layer
thicknesses, and this column is taken from the first column of 'dzs' owned
by each task.

If the initial conditions file is in single precision, and the first column
owned by an MPI task is a water column, then the Noah scheme will see soil
layer thickness values that represent 32-bit values converted to 64-bit values,
which are not the same as 64-bit values initialized directly (as we do for
land columns) for any values that are not exactly representable in floating
point (e.g., 0.1). This causes bitwise differences in runs with different
MPI task counts.

Now, we reinitialize 'dzs' for all columns, both land and water.