### PR TITLE
Fix slow compilation of threaded MPAS-O on Mira

### DIFF
--- a/src/core_ocean/driver/Makefile
+++ b/src/core_ocean/driver/Makefile
@@ -14,11 +14,17 @@ mpas_ocn_core_interface.o: mpas_ocn_core.o
 clean:
 	$(RM) *.o *.mod *.f90
 
+ifneq (,$(findstring CPRIBM,$(CPPFLAGS)))
+FFLAGS_noSMP := $(filter-out -qsmp%,$(FFLAGS))
+else
+FFLAGS_noSMP := $(FFLAGS)
+endif
+
 .F.o:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES)
+	$(FC) $(FFLAGS_noSMP) -c $*.f90 $(FCINCLUDES)
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES)
+	$(FC) $(CPPFLAGS) $(FFLAGS_noSMP) -c $*.F $(CPPINCLUDES) $(FCINCLUDES)
 endif


### PR DESCRIPTION
This removes -qsmp* from compilation flags of MPAS-O to speedup
compilation of threaded MPAS-O on Mira.

The two files affected by this change

mpas_ocn_core.F
mpas_ocn_core_interface.F
do not need to be threaded. Pre-processed file mpas_ocn_core_interface.f90 contains ~81,000 source lines of code and takes most of the total OCN compilation time. When -qsmp* is present, compilation time grows from O(minutes) to O(hours).

Fixes ACME-Climate/ACME#579

This PR was originally posted at
https://github.com/ACME-Climate/MPAS/pull/7

