### PR TITLE
Move open_streams outside of mpas_dmpar_init

### DIFF
--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -259,13 +259,6 @@ include 'mpif.h'
       dminfo % nprocs = mpi_size
       dminfo % my_proc_id = mpi_rank
 
-      if ( dminfo % initialized_mpi ) then
-         write(stderrUnit,'(a,i5,a,i5,a)') 'task ', mpi_rank, ' of ', mpi_size, &
-           ' is running'
-
-         call open_streams(dminfo % my_proc_id)
-      end if
-
       dminfo % info = MPI_INFO_NULL
 #else
       dminfo % comm = 0

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -52,8 +52,12 @@ module mpas_framework
       integer, intent(in), optional :: stdoutUnit_in, stderrUnit_in
 
       allocate(dminfo)
-      call mpas_io_units_init(stdoutUnit_in, stderrUnit_in)
       call mpas_dmpar_init(dminfo, mpi_comm)
+      call mpas_io_units_init(stdoutUnit_in, stderrUnit_in)
+
+      write(stderrUnit,'(a,i5,a,i5,a)') 'task ', dminfo % my_proc_id, ' of ', dminfo % nprocs, &
+           ' is running'
+      call open_streams(dminfo % my_proc_id)
 
    end subroutine mpas_framework_init_phase1!}}}
 


### PR DESCRIPTION
This merge changes the location from where open_streams is called.

Currently, the C function open_streams (which opens up the stderr and
stdout log files, if necessary) is called from within mpas_dmpar_init.
This necessitated certain logic in mpas_dmpar_init to either call
open_streams or not based on if an external communicator was not
supplied or was supplied, respectively.  This was done so that when
the model starts up (via mpas_framework_init_phase1 where no external
communicator is supplied in standalone MPAS) the standard streams
(out and err) would be opened, but if mpas_dmpar_init is called later
in the model to initialize a new communicator (the only current
example is MPAS_stream_mgr_block_write) those standard streams will
not be opened again, which would clobber them.

Basing this logic on dminfo%initialized_mpi creates a problem for
running MPAS in a coupled model framework (e.g. ACME).  In that
situation the coupled model supplies the external communicator, but
the standard streams still need to be opened on model init.

This merge changes the logic for when open_streams is called.  The
call has been moved out of mpas_dmpar_init to
mpas_framework_init_phase1, and the conditional logic around the call
has been removed.  In other words, open_streams is always called when
MPAS starts up (whether in standalone mode or in a coupled model
framework), and it is never called after model initialization (even
if additional calls to mpas_dmpar_init occur).

Fixes #1194 (issue) and replaces #1119 (PR).