### PR TITLE
changes to fix irreproducibility when threading is turned on

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -710,9 +710,10 @@ contains
       !
       ! Gradient Richardson number
       !
-      RiTopOfCell = 100.0_RKIND
+
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, factor, delU2, shearMean)
       do iCell=1,nCells
+         RiTopOfCell(:,iCell) = 100.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
          do k=2,maxLevelCell(iCell)
            shearSquared = 0.0_RKIND
@@ -756,17 +757,12 @@ contains
 
         nCells = nCellsArray( 1 )
 
-        !$omp do schedule(runtime)
-        do iCell = 1, nCells
-           tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
-           indexSurfaceLayerDepth( iCell) = -9.e30
-        end do
-        !$omp end do
-
         !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
         do iCell=1,nCells
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
+          tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
+          indexSurfaceLayerDepth(iCell) = -9.e30
           do k=1,maxLevelCell(iCell)
            sumSurfaceLayer = sumSurfaceLayer + layerThickness(k,iCell)
            rSurfaceLayer = maxLevelCell(iCell)
@@ -794,14 +790,10 @@ contains
         ! average normal velocity values over the ocean surface layer
         ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
         !
-        !$omp do schedule(runtime)
-        do iEdge = 1, nEdges
-           normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
-        end do
-        !$omp end do
-
+ 
         !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
         do iEdge=1,nEdges
+          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
           cell1=cellsOnEdge(1,iEdge)
           cell2=cellsOnEdge(2,iEdge)
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -169,7 +169,13 @@ module ocn_time_average_coupled
            !$omp end do
         endif
 
+        call mpas_threading_barrier()
+        !$omp master
+
         nAccumulatedCoupled = 0
+
+        !$omp end master
+        call mpas_threading_barrier()
 
     end subroutine ocn_time_average_coupled_init!}}}
 
@@ -376,7 +382,13 @@ module ocn_time_average_coupled
            !$omp end do
         endif
 
+        call mpas_threading_barrier()
+        !$omp master
+
         nAccumulatedCoupled = nAccumulatedCoupled + 1
+
+        !$omp end master
+        call mpas_threading_barrier()
 
     end subroutine ocn_time_average_coupled_accumulate!}}}
 


### PR DESCRIPTION
These changes provide bug fixes for reproducibility in a threaded configuration. It includes a correction to time average counters being incorrectly updated by all threads and it fuses three initialization loops with computational loops to avoid race conditions in threaded mode.

This is a critical bug fix for ACME github issue 1137. 

It is not BFB  in threaded mode as older algorithm was broken. It has been tested in an ACME configurations where the issue was discovered.

