### PR TITLE
Changes to Make file for the MPAS-Seaice model_forward directory

### DIFF
--- a/src/core_cice/model_forward/Makefile
+++ b/src/core_cice/model_forward/Makefile
@@ -12,12 +12,18 @@ mpas_cice_core_interface.o: mpas_cice_core.o
 clean:
 	$(RM) *.o *.i *.mod *.f90
 
+ifneq (,$(findstring CPRIBM,$(CPPFLAGS)))
+FFLAGS_noSMP := $(filter-out -qsmp%,$(FFLAGS))
+else
+FFLAGS_noSMP := $(FFLAGS)
+endif
+
 .F.o:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I../../external/esmf_time_f90 -I../column -I../shared
+	$(FC) $(FFLAGS_noSMP) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I../../external/esmf_time_f90 -I../column -I../shared
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I../../external/esmf_time_f90 -I../column -I../shared
+	$(FC) $(CPPFLAGS) $(FFLAGS_noSMP) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I../../external/esmf_time_f90 -I../column -I../shared
 endif


### PR DESCRIPTION
This allows the openMP flags to be removed for a particular compiler for the model_forward directory. This satisfies issue:
https://github.com/ACME-Climate/MPAS/pull/6