### PR TITLE
Avoid setting invalid pointers to scalar constituents in mpas_atmphys_interface module

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -508,11 +508,6 @@
  qv   => scalars(index_qv,:,:)
  qc   => scalars(index_qc,:,:)
  qr   => scalars(index_qr,:,:)
- qi   => scalars(index_qi,:,:)
- qs   => scalars(index_qs,:,:)
- qg   => scalars(index_qg,:,:)
- ni   => scalars(index_ni,:,:)
- nr   => scalars(index_nr,:,:)
 
 !initialize variables needed in the cloud microphysics schemes:
  do j = jts, jte
@@ -539,6 +534,10 @@
  microp_select_init: select case(microp_scheme)
 
     case ("mp_thompson","mp_wsm6")
+       qi   => scalars(index_qi,:,:)
+       qs   => scalars(index_qs,:,:)
+       qg   => scalars(index_qg,:,:)
+
        do j = jts, jte
        do k = kts, kte
        do i = its, ite
@@ -552,6 +551,9 @@
     microp2_select: select case(microp_scheme)
 
        case("mp_thompson")
+          ni   => scalars(index_ni,:,:)
+          nr   => scalars(index_nr,:,:)
+
           do j = jts,jte
           do i = its,ite
              muc_p(i,j) = mu_c(i)
@@ -654,11 +656,6 @@
  qv   => scalars(index_qv,:,:)
  qc   => scalars(index_qc,:,:)
  qr   => scalars(index_qr,:,:)
- qi   => scalars(index_qi,:,:)
- qs   => scalars(index_qs,:,:)
- qg   => scalars(index_qg,:,:)
- ni   => scalars(index_ni,:,:)
- nr   => scalars(index_nr,:,:)
 
  call mpas_pool_get_array(tend,'rt_diabatic_tend',rt_diabatic_tend)
 
@@ -711,6 +708,10 @@
  microp_select_init: select case(microp_scheme)
 
     case ("mp_thompson","mp_wsm6")
+       qi   => scalars(index_qi,:,:)
+       qs   => scalars(index_qs,:,:)
+       qg   => scalars(index_qg,:,:)
+
        do j = jts, jte
        do k = kts, kte
        do i = its, ite
@@ -724,6 +725,9 @@
     microp2_select: select case(microp_scheme)
 
        case("mp_thompson")
+          ni   => scalars(index_ni,:,:)
+          nr   => scalars(index_nr,:,:)
+
           do j = jts, jte
           do k = kts, kte
           do i = its, ite


### PR DESCRIPTION
This merge introduces a fix to ensure that we do not set invalid pointers to scalar constituents
in the mpas_atmphys_interface module.

Several scalar constituents, e.g., 'ni' and 'nr', are only allocated by specific
microphysics schemes through the use of packages. In the routines microphysics_to_MPAS
and microphysics_from_MPAS, we should only set pointers to sub-arrays of the scalars
var_array for constituents that are guaranteed to be allocated based on the choice
of microphysics scheme.