### PR TITLE
Remove unused routine wrf_error_fatal from mpas_timekeeping module

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -2117,19 +2117,4 @@ module mpas_timekeeping
     end subroutine mpas_expand_string!}}}
  
 
-
-
 end module mpas_timekeeping
-
-
-subroutine wrf_error_fatal(msg)
-
-   use mpas_abort, only : mpas_dmpar_global_abort
-
-   implicit none
-
-   character (len=*) :: msg
-
-   call mpas_dmpar_global_abort('ERROR: mpas_timekeeping: '//trim(msg))
-
-end subroutine wrf_error_fatal


### PR DESCRIPTION
This merge removes the unused routine wrf_error_fatal from the mpas_timekeeping
module. The routine wrf_error_fatal is not called directly from this module, and the ESMF
time manager code supplies its own version of this routine.