### PR TITLE
Add use statements to top of core interface file

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -9,6 +9,10 @@ module atm_core_interface
 
    use mpas_attlist
    use mpas_abort, only : mpas_dmpar_global_abort
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_io_units
 
    contains
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -8,6 +8,10 @@
 module init_atm_core_interface
 
    use mpas_attlist
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_io_units
 
    contains
 


### PR DESCRIPTION
This commit is needed after PR #1208, which removes use statements from
the autogenerated code inserted using
   include "inc/namelist_defines.inc"
at the bottom of
   mpas_init_atm_core_interface.F
This reduces four use statements from nine each to one.