### PR TITLE
Fix MPAS fillvalue usage when using PIO2

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -24,14 +24,28 @@ module mpas_io
    integer, parameter :: PIO_REALKIND = PIO_DOUBLE
 #endif
 
+#ifdef USE_PIO2
+   integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)  ! TODO: To be replaced with PIO_FILL_CHAR once PIO2 provides this variable
+#else
    integer, parameter :: MPAS_INT_FILLVAL = NF_FILL_INT
    character, parameter :: MPAS_CHAR_FILLVAL = achar(NF_FILL_CHAR)
+#endif
+
+#ifdef USE_PIO2
+#ifdef SINGLE_PRECISION
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = PIO_FILL_FLOAT
+#else
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = PIO_FILL_DOUBLE
+#endif
+#else
 #ifdef SINGLE_PRECISION
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_FLOAT
 #else
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_DOUBLE
 #endif
-   
+#endif
+
    interface MPAS_io_get_var
       module procedure MPAS_io_get_var_int0d
       module procedure MPAS_io_get_var_int1d


### PR DESCRIPTION
The MPAS code currently relies on the availability of netcdf fillvalues
in the code. With PIO1 these fillvalues are available indirectly by
"use"ing the pio module (that "use"s the fortran netcdf module). With
PIO2 these netcdf fillvalues will no longer be available.

The solution is to use the new (currently only available in pio2) PIO*
fillvalues for int/float/double and explicitly specify the fillvalue for
char (pio2 does not support any fillvalues for chars).

PIO2 does not currently provide a PIO_FILL_CHAR variable, so this merge
specifies a character fill value of achar(0) (ASCII Null and what NetCDF
presently uses) if PIO2 is being used.  In the future, once PIO2 has been
modified to provide PIO_FILL_CHAR, this can be updated.
