### PR TITLE
Bug fix to area variables AM

### DIFF
--- a/src/core_cice/analysis_members/mpas_cice_deactivate_unneeded_fields.F
+++ b/src/core_cice/analysis_members/mpas_cice_deactivate_unneeded_fields.F
@@ -103,7 +103,7 @@ contains
 
                    ! see if area field is in stream
                    if (trim(fieldName) == trim(poolItr % memberName) .or. &
-                      index(trim(fieldName), "_"//trim(poolItr % memberName)//"_") /= 0) then
+                      index(trim(fieldName), "_"//trim(poolItr % memberName)) /= 0) then
 
                       fieldInStream = .true.
 


### PR DESCRIPTION
Fixed code that switches off unused variables. Changes to time series stats names caused issues.
