### PR TITLE
Atmosphere develop: newer preprocessors on Mac OS X not substituting FATAL_ERROR macro

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
@@ -494,7 +494,7 @@ CONTAINS
          ELSE
             SNDENS = SNEQV / SNOWH
             IF(SNDENS > 1.0) THEN
-             FATAL_ERROR ( 'Physical snow depth is less than snow water equiv.' )
+             FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
             ENDIF
             CALL CSNOW (SNCOND,SNDENS)
          END IF
@@ -2421,7 +2421,7 @@ CONTAINS
                IF (NROOT .gt. NSOIL) THEN
                   WRITE (err_message,*) 'Error: too many root layers ',  &
                                                  NSOIL,NROOT
-                  FATAL_ERROR ( err_message )
+                  FATAL_ERROR( err_message )
 ! ----------------------------------------------------------------------
 ! CALCULATE ROOT DISTRIBUTION.  PRESENT VERSION ASSUMES UNIFORM
 ! DISTRIBUTION BASED ON SOIL LAYER DEPTHS.

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_urban.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_urban.F
@@ -510,7 +510,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
    if(ahoption==1) AH=AH*ahdiuprf(tloc)
 
    IF( ZDC+Z0C+2. >= ZA) THEN
-    FATAL_ERROR ("ZDC + Z0C + 2m is larger than the 1st WRF level - Stop in subroutine urban - change ZDC and Z0C" ) 
+    FATAL_ERROR("ZDC + Z0C + 2m is larger than the 1st WRF level - Stop in subroutine urban - change ZDC and Z0C" ) 
    END IF
 
    IF(.NOT.LSOLAR) THEN


### PR DESCRIPTION
This PR addresses problems with two source files in src/core_atmosphere/physics/physics_wrf/

In module_sf_urban.F and module_sf_noahslm.F, the substitution of the commands FATAL_ERROR using the preprocessor fails in a few places because of a whitespace between FATAL_ERROR and the opening parenthesis. Detected and fixed on Mac OS X with clang/gfortran, tested also on Linux with ifort after making the changes.