### PR TITLE
Add mpas_abort Makefile dependencies

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -54,6 +54,8 @@ mpas_framework.o: mpas_dmpar.o \
                   mpas_stream_manager.o \
                   mpas_c_interfacing.o
 
+mpas_abort.o: mpas_kind_types.o mpas_io_units.o mpas_threading.o
+
 mpas_constants.o: mpas_kind_types.o
 
 mpas_attlist.o: mpas_kind_types.o mpas_io_units.o mpas_derived_types.o


### PR DESCRIPTION
When the mpas_abort module was added recently, no explicit dependencies
were added to the framework Makefile.  This caused parallel builds to
fail on some processor counts (in my experience, 3).

This commits adds the dependencies for the mpas_abort module to the
framework Makefile.  This fixes the -j 3 parallel build.