### PR TITLE
Bug fix to MPAS forcing

### DIFF
--- a/src/framework/mpas_forcing.F
+++ b/src/framework/mpas_forcing.F
@@ -1265,6 +1265,9 @@ contains
     type(mpas_forcing_stream_type), pointer :: &
          forcingStream
 
+    type (MPAS_Alarm_type), pointer :: &
+         alarmPtr
+
     ! check if cycling alarm is ringing
     if (mpas_is_alarm_ringing(forcingGroup % forcingClock, forcingGroup % forcingCycleAlarmID)) then
 
@@ -1273,7 +1276,7 @@ contains
        ! if ringing cycle the clock
        oldForingClockTime = mpas_get_clock_time(forcingGroup % forcingClock, MPAS_NOW)
        newForcingClockTime = oldForingClockTime - forcingGroup % forcingCycleDuration
-       call mpas_set_clock_time(forcingGroup % forcingClock, newForcingClockTime, MPAS_NOW)
+       call mpas_set_clock_time(forcingGroup % forcingClock, newForcingClockTime, MPAS_NOW, calibrateAlarms=.false.)
 
        ! if ringing cycle the forcing times
        forcingStream => forcingGroup % stream
@@ -1286,6 +1289,17 @@ contains
 
           forcingStream => forcingStream % next
        enddo
+
+       ! cycle alarms
+       alarmPtr => forcingGroup % forcingClock % alarmListHead
+       do while (associated(alarmPtr))
+
+          if (alarmPtr % isSet) then
+             alarmPtr % prevRingTime = alarmPtr % prevRingTime - forcingGroup % forcingCycleDuration
+          endif
+
+          alarmPtr => alarmPtr % next
+       end do
 
     endif ! forcingCycleAlarmID ringing
 
@@ -1582,6 +1596,10 @@ contains
 
     interpolants(1) = diffr2 / diffr
     interpolants(2) = 1.0_RKIND - interpolants(1) !diffr1 / diffr
+
+    if (interpolants(1) < 0.0_RKIND .or. interpolants(1) > 1.0_RKIND) then
+       call MPAS_dmpar_global_abort('Forcing: Error: get_interpolants_linear: Interpolant not in range [0,1]')
+    endif
 
   end subroutine get_interpolants_linear!}}}
 

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -410,7 +410,7 @@ module mpas_timekeeping
    end subroutine mpas_advance_clock
 
 
-   subroutine mpas_set_clock_time(clock, clock_time, whichTime, ierr)
+   subroutine mpas_set_clock_time(clock, clock_time, whichTime, ierr, calibrateAlarms)
 
       implicit none
 
@@ -418,14 +418,20 @@ module mpas_timekeeping
       type (MPAS_Time_type), intent(in) :: clock_time
       integer, intent(in) :: whichTime
       integer, intent(out), optional :: ierr
+      logical, intent(in), optional :: calibrateAlarms
       integer :: threadNum
+
+      logical :: calibrateAlarmsUse
+
+      calibrateAlarmsUse = .true.
+      if (present(calibrateAlarms)) calibrateAlarmsUse = calibrateAlarms
 
       threadNum = mpas_threading_get_thread_num()
 
       if ( threadNum == 0 ) then
          if (whichTime == MPAS_NOW) then
             call ESMF_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
-            call mpas_calibrate_alarms(clock, ierr);
+            if (calibrateAlarmsUse) call mpas_calibrate_alarms(clock, ierr);
          else if (whichTime == MPAS_START_TIME) then
             call ESMF_ClockSet(clock % c, StartTime=clock_time%t, rc=ierr)
          else if (whichTime == MPAS_STOP_TIME) then


### PR DESCRIPTION
Bug fix to correct the alarms when the forcing clock is cycled.
The forcing clock time is manually set back by the forcing cycle duration. The call to calibrate alarms in mpas_set_clock_time does not set the forcing clock alarms back correctly (I'm not sure you would expect it to). This solution the alarm time is also manually set back by the forcing alarm duration. This has been tested in the sea ice model and seems to give correct answers, but I'm not sure this is the correct solution.

