### PR TITLE
Correct initialisation of pointers in mpas_timekeeping_types

### DIFF
--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -26,13 +26,13 @@
       type (MPAS_Time_type) :: ringTime
       type (MPAS_Time_type) :: prevRingTime
       type (MPAS_TimeInterval_type) :: ringTimeInterval
-      type (MPAS_Alarm_type), pointer :: next
+      type (MPAS_Alarm_type), pointer :: next => null()
    end type
    
    type MPAS_Clock_type
       integer :: direction
       integer :: nAlarms
       type (ESMF_Clock) :: c
-      type (MPAS_Alarm_type), pointer :: alarmListHead
+      type (MPAS_Alarm_type), pointer :: alarmListHead => null()
    end type
 


### PR DESCRIPTION
The pointers in mpas_timekeeping_types should be initialised correctly to null(). While the initialization of the next pointer in the MPAS_Alarm_type and MPAS_Clock_type types is not needed for correct behavior, it silences a large volume of complaints when using Allinea DDT (parallel debugger) with MPAS.