### PR TITLE
Release 5.0 bugfix init ecmwf pressure variable name

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3374,8 +3374,8 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
                 trim(field % field) == 'SKINTEMP') then
                k = 1
             else if (trim(field % field) /= 'PMSL' .and. &
-                     trim(field % field) /='PSFC' .and. &
-                     trim(field % field) /= 'SOILHGT')  then
+                     trim(field % field) /= 'PSFC' .and. &
+                     trim(field % field) /= 'SOILHGT') then
 
                ! Since the hash table can only store integers, transfer the bit pattern from 
                ! the real-valued xlvl into an integer; that the result is not an integer version


### PR DESCRIPTION
This PR fixes an issue with initialising the MPAS-A with ECMWF data on model levels. When preprocessed through WPS's calc_ecmwf_p.exe, the pressure variable is called "PRESSURE", but init_atmosphere is only looking for a variable "PRES" (which worked previously due to substring matching, but in v5.0 that was replaced by matching exact strings to avoid problems with snow fields SNOW, SNOWH etc. as @mgduda said).

In a second commit, two minor formatting corrections are made along the way for which a separate PR would be way over the top. This PR addresses parts of PR1197 as requested. Once the remaining parts of PR1197 have been separated out, PR1197 will be deleted.