### PR TITLE
Release 5.0 hotfix compatibility with WPS output of ECMWF soil levels

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3336,6 +3336,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
              trim(field % field) == 'SM007028' .or. &
              trim(field % field) == 'SM028100' .or. &
              trim(field % field) == 'SM100255' .or. &
+             trim(field % field) == 'SM100289' .or. &
              trim(field % field) == 'ST000010' .or. &
              trim(field % field) == 'ST010040' .or. &
              trim(field % field) == 'ST040100' .or. &
@@ -3345,6 +3346,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
              trim(field % field) == 'ST007028' .or. &
              trim(field % field) == 'ST028100' .or. &
              trim(field % field) == 'ST100255' .or. &
+             trim(field % field) == 'ST100289' .or. &
              trim(field % field) == 'PRES' .or. &
              trim(field % field) == 'SNOW' .or. &
              trim(field % field) == 'SEAICE' .or. &
@@ -3359,6 +3361,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
                 trim(field % field) == 'SM007028' .or. &
                 trim(field % field) == 'SM028100' .or. &
                 trim(field % field) == 'SM100255' .or. &
+                trim(field % field) == 'SM100289' .or. &
                 trim(field % field) == 'ST000010' .or. &
                 trim(field % field) == 'ST010040' .or. &
                 trim(field % field) == 'ST040100' .or. &
@@ -3368,6 +3371,7 @@ write(0,*) 'minval, maxval of LANDSEA = ', minval(maskslab), maxval(maskslab)
                 trim(field % field) == 'ST007028' .or. &
                 trim(field % field) == 'ST028100' .or. &
                 trim(field % field) == 'ST100255' .or. &
+                trim(field % field) == 'ST100289' .or. &
                 trim(field % field) == 'SNOW' .or. &
                 trim(field % field) == 'SEAICE' .or. &
                 trim(field % field) == 'SKINTEMP') then
@@ -3711,6 +3715,26 @@ write(0,*) 'Interpolating SM100255'
                ndims = 2
                dzs_fg(k,:) = 255.-100.
                zs_fg(k,:) = 255.
+            else if (trim(field % field) == 'SM100289') then
+write(0,*) 'Interpolating SM100289'
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 4
+               ndims = 2
+               dzs_fg(k,:) = 289.-100.
+               zs_fg(k,:) = 289.
             else if (trim(field % field) == 'ST000010') then
 write(0,*) 'Interpolating ST000010'
 
@@ -3900,6 +3924,27 @@ write(0,*) 'Interpolating ST100255'
                ndims = 2
                dzs_fg(k,:) = 255.-100.
                zs_fg(k,:) = 255.
+            else if (trim(field % field) == 'ST100289') then
+write(0,*) 'Interpolating ST100289'
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 4
+               ndims = 2
+               dzs_fg(k,:) = 289.-100.
+               zs_fg(k,:) = 289.
             else if (trim(field % field) == 'SNOW') then
 write(0,*) 'Interpolating SNOW'
 


### PR DESCRIPTION
ECMWF soil levels are 0-7cm, 7-28cm, 28-100cm and 100-255cm (see http://rda.ucar.edu/datasets/ds627.0/docs/era_interim_grib_table.html). WPS/ungrib labels the top three levels correctly SM000007, SM007028, SM028100 (similar for ST). However, the lowest level is labelled SM100289 (ST100289), presumably for historic reasons.

MPAS is looking for SM100255 and ST100255 instead and thus does not read the lowermost level from the intermediate files. This PR adds support to account for the incorrect behaviour of WPS by treating SM100289 as SM100255 (similar for ST). While the problem should be solved in WPS, we don't know if/when this will happen, and also many users are having large sets of intermediate data for ERA-Interim in their archives.

@mgduda I would like to ask for your comment on the message to be printed when reading those fields; currently I am using "Interpolating ST100289 as ST100255 (compatibility with WPS output of ECMWF soil levels)" but I am happy to change this to a better wording.