### PR TITLE
Threading optimization: bfb ocean changes by Abhinav

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -557,11 +557,11 @@ module ocn_forward_mode
 
          call mpas_timer_start("time integration")
 
-         !$omp parallel default(firstprivate) shared(domain, dt, timeStamp)
-
 #ifdef MPAS_DEBUG
          write(stderrUnit,*) '   Computing forward time step'
 #endif
+         !$omp parallel default(firstprivate) shared(domain, dt, timeStamp)
+
          call ocn_timestep(domain, dt, timeStamp)
 
          !$omp end parallel

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -126,7 +126,10 @@ module ocn_time_integration
         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+
+        !$omp single
         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+        !$omp end single
 
         block => block % next
      end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -205,6 +205,8 @@ module ocn_time_integration_split
       character (len=StrKIND) :: configName
       integer :: threadNum
 
+      integer :: temp_mask
+
       call mpas_timer_start("se timestep")
 
       call mpas_pool_get_config(domain % configs, 'config_n_bcl_iter_beg', config_n_bcl_iter_beg)
@@ -317,9 +319,6 @@ module ocn_time_integration_split
             end do
          end do
          !$omp end do
-
-
-         threadnum = mpas_threading_get_thread_num()
 
          call mpas_pool_begin_iteration(tracersPool)
          do while ( mpas_pool_get_next_member(tracersPool, groupItr))
@@ -779,24 +778,26 @@ module ocn_time_integration_split
                      !$omp do schedule(runtime) private(cell1, cell2, CoriolisTerm, i, eoe)
                      do iEdge = 1, nEdges
 
-                        cell1 = cellsOnEdge(1,iEdge)
-                        cell2 = cellsOnEdge(2,iEdge)
+                        temp_mask = edgeMask(1, iEdge)
 
-                        ! Compute the barotropic Coriolis term, -f*uPerp
-                        CoriolisTerm = 0.0_RKIND
-                        do i = 1, nEdgesOnEdge(iEdge)
-                           eoe = edgesOnEdge(i,iEdge)
-                           CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge) &
-                                        * normalBarotropicVelocitySubcycleCur(eoe) * fEdge(eoe)
-                        end do
+                          cell1 = cellsOnEdge(1,iEdge)
+                          cell2 = cellsOnEdge(2,iEdge)
 
-                        ! normalBarotropicVelocityNew = normalBarotropicVelocityOld + dt/J*(-f*normalBarotropicVelocityoldPerp
-                        !                             - g*grad(SSH) + G)
-                        normalBarotropicVelocitySubcycleNew(iEdge) &
-                          = (normalBarotropicVelocitySubcycleCur(iEdge) &
-                          + dt / nBtrSubcycles * (CoriolisTerm - gravity &
-                          * (sshSubcycleCur(cell2) - sshSubcycleCur(cell1) ) &
-                          / dcEdge(iEdge) + barotropicForcing(iEdge))) * edgeMask(1, iEdge)
+                          ! Compute the barotropic Coriolis term, -f*uPerp
+                          CoriolisTerm = 0.0_RKIND
+                          do i = 1, nEdgesOnEdge(iEdge)
+                             eoe = edgesOnEdge(i,iEdge)
+                             CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge) &
+                                          * normalBarotropicVelocitySubcycleCur(eoe) * fEdge(eoe)
+                          end do
+
+                          normalBarotropicVelocitySubcycleNew(iEdge) &
+                            = temp_mask &
+                            * (normalBarotropicVelocitySubcycleCur(iEdge) &
+                            + dt / nBtrSubcycles * (CoriolisTerm - gravity &
+                            * (sshSubcycleCur(cell2) - sshSubcycleCur(cell1) ) &
+                            / dcEdge(iEdge) + barotropicForcing(iEdge)))
+
                      end do
                      !$omp end do
 
@@ -851,15 +852,6 @@ module ocn_time_integration_split
                 nCells = nCellsArray( cellHaloComputeCounter )
                 nEdges = nEdgesArray( edgeHaloComputeCounter )
 
-                if (config_btr_solve_SSH2) then
-                   ! If config_btr_solve_SSH2=.true., then do NOT accumulate barotropicThicknessFlux in this SSH predictor
-                   ! section, because it will be accumulated in the SSH corrector section.
-                   barotropicThicknessFlux_coeff = 0.0_RKIND
-                else
-                   ! otherwise, DO accumulate barotropicThicknessFlux in this SSH predictor section
-                   barotropicThicknessFlux_coeff = 1.0_RKIND
-                endif
-
                 ! config_btr_gam1_velWt1 sets the forward weighting of velocity in the SSH computation
                 ! config_btr_gam1_velWt1=  1     flux = normalBarotropicVelocityNew*H
                 ! config_btr_gam1_velWt1=0.5     flux = 1/2*(normalBarotropicVelocityNew+normalBarotropicVelocityOld)*H
@@ -891,42 +883,51 @@ module ocn_time_integration_split
                            + config_btr_gam1_velWt1 * normalBarotropicVelocitySubcycleNew(iEdge)) &
                            * thicknessSum
 
-                    sshTend(iCell) = sshTend(iCell) + edgeSignOncell(i, iCell) * flux &
-                           * dvEdge(iEdge)
+                    sshTend(iCell) = sshTend(iCell) + edgeSignOncell(i, iCell) * flux * dvEdge(iEdge)
 
                   end do
 
                   ! SSHnew = SSHold + dt/J*(-div(Flux))
-                  sshSubcycleNew(iCell) = sshSubcycleCur(iCell) + dt / nBtrSubcycles * sshTend(iCell) / areaCell(iCell)
+                  sshSubcycleNew(iCell) = sshSubcycleCur(iCell) &
+                                          + dt / nBtrSubcycles * sshTend(iCell) / areaCell(iCell)
                 end do
                 !$omp end do
 
-                !$omp do schedule(runtime) private(cell1, cell2, sshEdge, thicknessSum, flux)
-                do iEdge = 1, nEdges
-                   cell1 = cellsOnEdge(1,iEdge)
-                   cell2 = cellsOnEdge(2,iEdge)
+                !! asarje: changed to avoid redundant computations when config_btr_solve_SSH2 is true
 
-                   sshEdge = 0.5_RKIND * (sshSubcycleCur(cell1) &
-                             + sshSubcycleCur(cell2) )
+                if (config_btr_solve_SSH2) then
 
-                   ! method 0: orig, works only without pbc:
-                   !thicknessSum = sshEdge + refBottomDepthTopOfCell(maxLevelEdgeTop(iEdge)+1)
+                  ! If config_btr_solve_SSH2=.true.,
+                  ! then do NOT accumulate barotropicThicknessFlux in this SSH predictor
+                  ! section, because it will be accumulated in the SSH corrector section.
+                  barotropicThicknessFlux_coeff = 0.0_RKIND
 
-                   ! method 1, matches method 0 without pbcs, works with pbcs.
-                   thicknessSum = sshEdge + min(bottomDepth(cell1), bottomDepth(cell2))
+                  ! othing else to do
 
-                   ! method 2: may be better than method 1.
-                   ! take average  of full thickness at two neighboring cells
-                   !thicknessSum = sshEdge + 0.5 *(  bottomDepth(cell1) &
-                   !                       + bottomDepth(cell2) )
+                else
 
-                   flux = ((1.0-config_btr_gam1_velWt1) * normalBarotropicVelocitySubcycleCur(iEdge) &
-                          + config_btr_gam1_velWt1 * normalBarotropicVelocitySubcycleNew(iEdge)) &
-                          * thicknessSum
+                  ! otherwise, DO accumulate barotropicThicknessFlux in this SSH predictor section
+                  barotropicThicknessFlux_coeff = 1.0_RKIND
 
-                   barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) + barotropicThicknessFlux_coeff * flux
-                end do
-                !$omp end do
+                  !$omp do schedule(runtime)
+                  do iEdge = 1, nEdges
+                     cell1 = cellsOnEdge(1,iEdge)
+                     cell2 = cellsOnEdge(2,iEdge)
+
+                     sshEdge = 0.5_RKIND * (sshSubcycleCur(cell1) + sshSubcycleCur(cell2))
+
+                     ! method 1, matches method 0 without pbcs, works with pbcs.
+                     thicknessSum = sshEdge + min(bottomDepth(cell1), bottomDepth(cell2))
+
+                     flux = ((1.0-config_btr_gam1_velWt1) * normalBarotropicVelocitySubcycleCur(iEdge) &
+                            + config_btr_gam1_velWt1 * normalBarotropicVelocitySubcycleNew(iEdge)) &
+                            * thicknessSum
+
+                     barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) + flux
+                  end do
+                  !$omp end do
+
+                endif
 
                 block => block % next
               end do  ! block
@@ -988,28 +989,36 @@ module ocn_time_integration_split
 
                    !$omp do schedule(runtime) private(cell1, cell2, eoe, CoriolisTerm, i, sshCell1, sshCell2)
                    do iEdge = 1, nEdges
-                     cell1 = cellsOnEdge(1,iEdge)
-                     cell2 = cellsOnEdge(2,iEdge)
 
-                     ! Compute the barotropic Coriolis term, -f*uPerp
-                     CoriolisTerm = 0.0_RKIND
-                     do i = 1, nEdgesOnEdge(iEdge)
-                        eoe = edgesOnEdge(i,iEdge)
-                        CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge) &
-                             !* normalBarotropicVelocitySubcycleNew(eoe) &
-                             * btrvel_temp(eoe) * fEdge(eoe)
-                     end do
+                     ! asarje: added to avoid redundant computations based on mask
+                     temp_mask = edgeMask(1,iEdge)
 
-                     ! In this final solve for velocity, SSH is a linear
-                     ! combination of SSHold and SSHnew.
-                     sshCell1 = (1-config_btr_gam2_SSHWt1) * sshSubcycleCur(cell1) + config_btr_gam2_SSHWt1 * sshSubcycleNew(cell1)
-                     sshCell2 = (1-config_btr_gam2_SSHWt1) * sshSubcycleCur(cell2) + config_btr_gam2_SSHWt1 * sshSubcycleNew(cell2)
+                       cell1 = cellsOnEdge(1,iEdge)
+                       cell2 = cellsOnEdge(2,iEdge)
 
-                     ! normalBarotropicVelocityNew = normalBarotropicVelocityOld + dt/J*(-f*normalBarotropicVelocityoldPerp
-                     !                             - g*grad(SSH) + G)
-                     normalBarotropicVelocitySubcycleNew(iEdge) = (normalBarotropicVelocitySubcycleCur(iEdge) &
-                         + dt / nBtrSubcycles *(CoriolisTerm - gravity *(sshCell2 - sshCell1) / dcEdge(iEdge) &
-                         + barotropicForcing(iEdge))) * edgeMask(1,iEdge)
+                       ! Compute the barotropic Coriolis term, -f*uPerp
+                       CoriolisTerm = 0.0_RKIND
+                       do i = 1, nEdgesOnEdge(iEdge)
+                         eoe = edgesOnEdge(i,iEdge)
+                         CoriolisTerm = CoriolisTerm &
+                                        + weightsOnEdge(i,iEdge) * btrvel_temp(eoe) * fEdge(eoe)
+                       end do
+
+                       ! In this final solve for velocity, SSH is a linear
+                       ! combination of SSHold and SSHnew.
+                       sshCell1 = (1 - config_btr_gam2_SSHWt1) * sshSubcycleCur(cell1) &
+                                  + config_btr_gam2_SSHWt1 * sshSubcycleNew(cell1)
+                       sshCell2 = (1 - config_btr_gam2_SSHWt1) * sshSubcycleCur(cell2) &
+                                  + config_btr_gam2_SSHWt1 * sshSubcycleNew(cell2)
+
+                       ! normalBarotropicVelocityNew = normalBarotropicVelocityOld + dt/J*(-f*normalBarotropicVelocityoldPerp
+                       !                             - g*grad(SSH) + G)
+                       normalBarotropicVelocitySubcycleNew(iEdge) = temp_mask &
+                            * (normalBarotropicVelocitySubcycleCur(iEdge) &
+                            + dt / nBtrSubcycles &
+                            * (CoriolisTerm - gravity * (sshCell2 - sshCell1) / dcEdge(iEdge) &
+                            + barotropicForcing(iEdge)))
+
                    end do
                    !$omp end do
 
@@ -1795,8 +1804,6 @@ module ocn_time_integration_split
          end if
 
          call mpas_timer_start('se final mpas reconstruct', .false.)
-         call mpas_threading_barrier()
-         !$omp master
          call mpas_reconstruct(meshPool, normalVelocityNew,  &
                           velocityX, velocityY, velocityZ,   &
                           velocityZonal, velocityMeridional, &
@@ -1806,8 +1813,6 @@ module ocn_time_integration_split
                           gradSSHX, gradSSHY, gradSSHZ,    &
                           gradSSHZonal, gradSSHMeridional, &
                           includeHalos = .true.)
-         !$omp end master
-         call mpas_threading_barrier()
          call mpas_timer_stop('se final mpas reconstruct')
 
          !$omp do schedule(runtime)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -152,6 +152,10 @@ contains
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
 
+      real (kind=RKIND) :: areaTri1, layerThicknessVertexInv, tempRiVal, dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
+      real (kind=RKIND), dimension(:), allocatable:: layerThicknessVertexVec
+      integer :: edgeSignOnCell_temp
+
       call mpas_timer_start('diagnostic solve')
 
       if (present(timeLevelIn)) then
@@ -259,16 +263,11 @@ contains
       nCells = nCellsArray( size(nCellsArray) )
       nVertices = nVerticesArray( size(nVerticesArray) )
 
-      ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
-      end do
-      !$omp end do
-      coef_3rd_order = config_coef_3rd_order
 
       !$omp do schedule(runtime) private(cell1, cell2, k)
       do iEdge = 1, nEdges
+         ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
+         layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          do k = 1, maxLevelEdgeTop(iEdge)
@@ -276,6 +275,8 @@ contains
          end do
       end do
       !$omp end do
+
+      coef_3rd_order = config_coef_3rd_order
 
       !
       ! set the velocity and height at dummy address
@@ -289,25 +290,7 @@ contains
       activeTracers(indexSalinity,:,nCells+1) = -1e34
       !$omp end single
 
-      !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         divergence(:, iCell) = 0.0_RKIND
-         vertVelocityTop(:, iCell) = 0.0_RKIND
-         kineticEnergyCell(:, iCell) = 0.0_RKIND
-      end do
-      !$omp end do
-
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         tangentialVelocity(:, iEdge) = 0.0_RKIND
-      end do
-      !$omp end do
-
-      call mpas_threading_barrier()
-
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
-
-      call mpas_threading_barrier()
 
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsArray( 1 )
@@ -337,28 +320,36 @@ contains
 
       !$omp do schedule(runtime) private(invAreaCell1, iEdge, r_tmp, i, k)
       do iCell = 1, nCells
+         divergence(:, iCell) = 0.0_RKIND
+         kineticEnergyCell(:, iCell) = 0.0_RKIND
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
          div_huGMBolus(:) = 0.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dcEdge_temp = dcEdge(iEdge)
+            dvEdge_temp = dvEdge(iEdge)
             do k = 1, maxLevelCell(iCell)
-               r_tmp = dvEdge(iEdge) * normalVelocity(k, iEdge) * invAreaCell1
+               r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
 
-               divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell(i, iCell) * r_tmp
-               div_hu(k)    = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell(i, iCell) * r_tmp
-               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) + 0.25 * r_tmp * dcEdge(iEdge) * normalVelocity(k,iEdge)
-
+               divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
+               div_hu(k) = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * r_tmp
+               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
+                                              + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
                ! Compute vertical velocity from the horizontal total transport
-               div_huTransport(k) = div_huTransport(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell(i, iCell) &
-                                  * dvEdge(iEdge) * normalTransportVelocity(k, iEdge) * invAreaCell1
+               div_huTransport(k) = div_huTransport(k) &
+                                    - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp &
+                                    * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
                ! Compute vertical velocity from the horizontal GM Bolus velocity
-               div_huGMBolus(k) = div_huGMBolus(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell(i, iCell) * dvEdge(iEdge) &
-                                * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+               div_huGMBolus(k) = div_huGMBolus(k) &
+                                  - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
             end do
          end do
          ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+         vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
          do k=maxLevelCell(iCell),1,-1
             vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
             vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
@@ -373,11 +364,14 @@ contains
 
       !$omp do schedule(runtime) private(eoe, i, k)
       do iEdge = 1, nEdges
+         tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
          do i = 1, nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(i,iEdge)
+            weightsOnEdge_temp = weightsOnEdge(i, iEdge)
             do k = 1, maxLevelEdgeTop(iEdge)
-               tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) + weightsOnEdge(i,iEdge) * normalVelocity(k, eoe)
+               tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) &
+                                              + weightsOnEdge_temp * normalVelocity(k, eoe)
             end do
          end do
       end do
@@ -773,14 +767,14 @@ contains
              exit
            endif
           end do
+          tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
           do k=1,int(rSurfaceLayer)
             tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
                                               * layerThickness(k,iCell)
           enddo
           k=min( int(rSurfaceLayer)+1, maxLevelCell(iCell) )
-          tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
-                                            * activeTracers(:,k,iCell) * layerThickness(k,iCell)
-          tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) / surfaceLayerDepth
+          tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
+                                            * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
         enddo
         !$omp end do
 
@@ -808,15 +802,15 @@ contains
              exit
            endif
           end do
+          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
           do k=1,int(rSurfaceLayer)
             normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + normalVelocity(k,iEdge) &
                                               * layerThicknessEdge(k,iEdge)
           enddo
           k=int(rSurfaceLayer)+1
           if(k.le.maxLevelEdgeTop(iEdge)) then
-            normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &
-                                              * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
-            normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) / surfaceLayerDepth
+            normalVelocitySurfaceLayer(iEdge) = (normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &
+                                              * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
           end if
         enddo
         !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -411,8 +411,6 @@ contains
       end do
       !$omp end do
 
-      call mpas_threading_barrier()
-
       deallocate(pRefEOS,p,p2)
       deallocate(tracerTemp)
       deallocate(tracerSalt)


### PR DESCRIPTION
This PR replaces #1151, and includes only bfb changes to the ocean core.  This includes:

1. Statements reorganization in 'btr se subcycle loop' to avoid redundant computations, loop fusions to fuse initialization loops with the main loops.
2. Removal of unnecessary threading barriers.
3. Implementation of threading into the mpas reconstruct routine.
4. Reorganization of statements in 'diagnostic solve' to merge initializations with main loops, removal of extra barriers, vectorization and reorders.
5. Changing MPI threading level from multiple to funneled.
6. Reorganization in buffer pack and unpack in halo exchanges to minimize use of barriers.
7. Implementation of threaded memory buffer initializations.