### PR TITLE
Fix initialization of effective radii in lw and sw radiation drivers

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -82,6 +82,10 @@
 ! * in the call to rrtmg_lwrad, substituted the variables qv_p, qc_p, qi_p, and qs_p with qvrad_p, qcrad_p,
 !   qirad_p, and qsrad_p initialized in subroutine cloudiness_from_MPAS.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-07-09.
+! * in subroutines radiation_lw_from_MPAS and radiation_lw_to_MPAS, revised the initialization of re_cloud,
+!   re_ice, re_snow, and rre_cloud, rre_ice, and rre_snow to handle the case when the cloud microphysics
+!   parameterization is turned off, i.e. config_microp_scheme='off'.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-10.
 
 
  contains
@@ -292,6 +296,7 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_microp_re
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: skintemp,snow,xice,xland
@@ -309,6 +314,7 @@
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_o3climatology',config_o3climatology)
+ call mpas_pool_get_config(configs,'config_microp_re'    ,config_microp_re    )
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -383,22 +389,48 @@
  radiation_lw_select: select case (trim(radt_lw_scheme))
 
     case("rrtmg_lw")
-       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
-       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
-       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
+       microp_select: select case(microp_scheme)
+          case("mp_thompson","mp_wsm6")
+             if(config_microp_re) then
+                call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
+                call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
+                call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
 
-       do j = jts,jte
-       do k = kts,kte
-       do i = its,ite
-          recloud_p(i,k,j)  = re_cloud(k,i)
-          reice_p(i,k,j)    = re_ice(k,i)
-          resnow_p(i,k,j)   = re_snow(k,i)
-          rrecloud_p(i,k,j) = 0._RKIND
-          rreice_p(i,k,j)   = 0._RKIND
-          rresnow_p(i,k,j)  = 0._RKIND
-       enddo
-       enddo
-       enddo
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   recloud_p(i,k,j) = re_cloud(k,i)
+                   reice_p(i,k,j)   = re_ice(k,i)
+                   resnow_p(i,k,j)  = re_snow(k,i)
+                enddo
+                enddo
+                enddo
+             else
+                has_reqc = 0
+                has_reqi = 0
+                has_reqs = 0
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   recloud_p(i,k,j) = 0._RKIND
+                   reice_p(i,k,j)   = 0._RKIND
+                   resnow_p(i,k,j)  = 0._RKIND
+                enddo
+                enddo
+                enddo
+             endif
+             do j = jts,jte
+             do k = kts,kte
+             do i = its,ite
+                rrecloud_p(i,k,j) = 0._RKIND
+                rreice_p(i,k,j)   = 0._RKIND
+                rresnow_p(i,k,j)  = 0._RKIND
+             enddo
+             enddo
+             enddo
+
+          case default
+       end select microp_select
 
        do j = jts,jte
        do k = kts,kte+2
@@ -559,16 +591,21 @@
  end subroutine radiation_lw_from_MPAS
 
 !=================================================================================================================
- subroutine radiation_lw_to_MPAS(diag_physics,tend_physics,its,ite)
+ subroutine radiation_lw_to_MPAS(configs,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
+ type(mpas_pool_type),intent(in):: configs
+
+!inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
  type(mpas_pool_type),intent(inout):: tend_physics
 
  integer,intent(in):: its,ite
 
 !local pointers:
+ logical,pointer:: config_microp_re
+
  real(kind=RKIND),dimension(:),pointer :: glw,lwcf,lwdnb,lwdnbc,lwdnt,lwdntc,lwupb,lwupbc, &
                                           lwupt,lwuptc,olrtoa
  real(kind=RKIND),dimension(:,:),pointer:: rthratenlw
@@ -580,6 +617,8 @@
  real(kind=RKIND),dimension(:,:),allocatable:: p1d
 
 !-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_microp_re',config_microp_re)
 
  call mpas_pool_get_array(diag_physics,'glw'   ,glw   )
  call mpas_pool_get_array(diag_physics,'lwcf'  ,lwcf  )
@@ -620,21 +659,36 @@
  radiation_lw_select: select case (trim(radt_lw_scheme))
 
     case("rrtmg_lw")
-       call mpas_pool_get_array(diag_physics,'rre_cloud',rre_cloud)
-       call mpas_pool_get_array(diag_physics,'rre_ice'  ,rre_ice  )
-       call mpas_pool_get_array(diag_physics,'rre_snow' ,rre_snow )
 
-       do j = jts,jte
-       do k = kts,kte
-       do i = its,ite
-          rre_cloud(k,i) = rrecloud_p(i,k,j)
-          rre_ice(k,i)   = rreice_p(i,k,j)
-          rre_snow(k,i)  = rresnow_p(i,k,j)
-       enddo
-       enddo
-       enddo
+       microp_select: select case(microp_scheme)
+          case("mp_thompson","mp_wsm6")
+             call mpas_pool_get_array(diag_physics,'rre_cloud',rre_cloud)
+             call mpas_pool_get_array(diag_physics,'rre_ice'  ,rre_ice  )
+             call mpas_pool_get_array(diag_physics,'rre_snow' ,rre_snow )
+             if(config_microp_re) then
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   rre_cloud(k,i) = rrecloud_p(i,k,j)
+                   rre_ice(k,i)   = rreice_p(i,k,j)
+                   rre_snow(k,i)  = rresnow_p(i,k,j)
+                enddo
+                enddo
+                enddo
+             else
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   rre_cloud(k,i) = 0._RKIND
+                   rre_ice(k,i)   = 0._RKIND
+                   rre_snow(k,i)  = 0._RKIND
+                enddo
+                enddo
+                enddo
+             endif
 
-    case default
+          case default
+       end select microp_select
 
  end select radiation_lw_select
 
@@ -785,6 +839,7 @@
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &
                        )
+
     case ("cam_lw")
        xtime_m = xtime_s/60.
 
@@ -849,7 +904,7 @@
  end select radiation_lw_select
 
 !copy local arrays to MPAS grid:
- call radiation_lw_to_MPAS(diag_physics,tend_physics,its,ite)
+ call radiation_lw_to_MPAS(configs,diag_physics,tend_physics,its,ite)
 
 !write(0,*) '--- end subroutine driver_radiation_lw.'
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -77,6 +77,9 @@
 ! * in the call to rrtmg_swrad, substituted the variables qv_p, qc_p, qi_p, and qs_p with qvrad_p, qcrad_p,
 !   qirad_p, and qsrad_p initialized in subroutine cloudiness_from_MPAS.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-07-09.
+! * in subroutines radiation_sw_from_MPAS, revised the initialization of re_cloud, re_ice, re_snow, to
+!   handle the case when the cloud microphysics parameterization is turned off, i.e. config_microp_scheme='off'.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-10.
 
 
  contains
@@ -296,6 +299,7 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_microp_re
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: skintemp,snow,xice,xland
@@ -308,6 +312,7 @@
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_o3climatology',config_o3climatology)
+ call mpas_pool_get_config(configs,'config_microp_re'    ,config_microp_re    )
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -384,19 +389,40 @@
  radiation_sw_select: select case (trim(radt_sw_scheme))
 
     case("rrtmg_sw")
-       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
-       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
-       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
 
-       do j = jts,jte
-       do k = kts,kte
-       do i = its,ite
-          recloud_p(i,k,j) = re_cloud(k,i)
-          reice_p(i,k,j)   = re_ice(k,i)
-          resnow_p(i,k,j)  = re_snow(k,i)
-       enddo
-       enddo
-       enddo
+       microp_select: select case(microp_scheme)
+          case("mp_thompson","mp_wsm6")
+             if(config_microp_re) then
+                call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
+                call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
+                call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
+
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   recloud_p(i,k,j) = re_cloud(k,i)
+                   reice_p(i,k,j)   = re_ice(k,i)
+                   resnow_p(i,k,j)  = re_snow(k,i)
+                enddo
+                enddo
+                enddo
+             else
+                has_reqc = 0
+                has_reqi = 0
+                has_reqs = 0
+                do j = jts,jte
+                do k = kts,kte
+                do i = its,ite
+                   recloud_p(i,k,j) = 0._RKIND
+                   reice_p(i,k,j)   = 0._RKIND
+                   resnow_p(i,k,j)  = 0._RKIND
+                enddo
+                enddo
+                enddo
+             endif
+
+          case default          
+       end select microp_select
 
        do j = jts,jte
        do k = kts,kte+2
@@ -409,7 +435,7 @@
        enddo
        enddo
 
-       !ozone volum mixing ratio:
+       !ozone volume mixing ratio:
        if(config_o3climatology) then
           do k = 1, num_oznLevels
              pin_p(k) = pin(k)
@@ -544,7 +570,6 @@
 !local pointers:
  real(kind=RKIND),dimension(:),pointer  :: coszr,gsw,swcf,swdnb,swdnbc,swdnt,swdntc, &
                                            swupb,swupbc,swupt,swuptc
-!real(kind=RKIND),dimension(:,:),pointer:: swdnflx,swdnflxc,swupflx,swupflxc
  real(kind=RKIND),dimension(:,:),pointer:: rthratensw
 
 !-----------------------------------------------------------------------------------------------------------------
@@ -560,10 +585,6 @@
  call mpas_pool_get_array(diag_physics,'swupbc'    , swupbc   )
  call mpas_pool_get_array(diag_physics,'swupt'     ,swupt     )
  call mpas_pool_get_array(diag_physics,'swuptc'    ,swuptc    )
-!call mpas_pool_get_array(diag_physics,'swdnflx'   ,swdnflx   )
-!call mpas_pool_get_array(diag_physics,'swdnflxc'  ,swdnflxc  )
-!call mpas_pool_get_array(diag_physics,'swupflx'   ,swupflx   )
-!call mpas_pool_get_array(diag_physics,'swupflxc'  ,swupflxc  )
  call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
  do j = jts,jte
@@ -581,15 +602,6 @@
     swupt(i)  = swupt_p(i,j)
     swuptc(i) = swuptc_p(i,j)
  enddo
-!not needed:
-!do k = kts,kte+2
-!do i = its,ite
-!   swdnflx(k,i)  = swdnflx_p(i,k,j)
-!   swdnflxc(k,i) = swdnflxc_p(i,k,j)
-!   swupflx(k,i)  = swupflx_p(i,k,j)
-!   swupflxc(k,i) = swupflxc_p(i,k,j)
-!enddo
-!enddo
 
  do k = kts,kte
  do i = its,ite


### PR DESCRIPTION
This PR fixes the initialization of the effective radius of cloud water, cloud ice, and snow in the longwave and shortwave RRTMG radiation codes. Without this fix, runs would crash with segmentation fault because these arrays were not properly allocated when cloud microphysics parameterizations were turned off (i.e. when config_microp_scheme='off').
