### PR TITLE
Modify Makefiles in core_atmosphere to enable parallel builds

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -34,7 +34,7 @@ physcore: mpas_atm_dimensions.o
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*TBL .)
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*DATA* .)
 
-dycore: mpas_atm_dimensions.o
+dycore: mpas_atm_dimensions.o physcore
 	( cd dynamics; $(MAKE) all PHYSICS="$(PHYSICS)" )
 
 diagcore: physcore dycore
@@ -48,7 +48,7 @@ atmcore: physcore dycore diagcore $(OBJS)
 
 mpas_atm_core_interface.o: mpas_atm_core.o
 
-mpas_atm_core.o: dycore mpas_atm_threading.o
+mpas_atm_core.o: dycore diagcore mpas_atm_threading.o
 
 mpas_atm_dimensions.o:
 

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -49,13 +49,16 @@ lookup_tables:
 	./checkout_data_files.sh
 
 core_physics_wrf:
-	(cd physics_wrf; make all COREDEF="$(COREDEF)")
+	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)
 
-core_physics: $(OBJS)
+core_physics: core_physics_wrf
+	($(MAKE) phys_interface COREDEF="$(COREDEF)")
 	ar -ru libphys.a $(OBJS)
+
+phys_interface: $(OBJS)
 
 # DEPENDENCIES:
 mpas_atmphys_camrad_init.o: \
@@ -107,6 +110,7 @@ mpas_atmphys_driver_microphysics.o: \
 
 mpas_atmphys_driver_oml.o: \
 	mpas_atmphys_constants.o \
+	mpas_atmphys_landuse.o \
 	mpas_atmphys_vars.o
 
 mpas_atmphys_driver_pbl.o: \
@@ -190,7 +194,7 @@ mpas_atmphys_update.o: \
 
 clean:
 	$(RM) *.o *.mod *.f90 libphys.a
-	( cd physics_wrf; make clean )
+	( cd physics_wrf; $(MAKE) clean )
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i


### PR DESCRIPTION
This merge provides several modifications to Makefiles within the core_atmosphere
directory to enable parallel builds of MPAS-Atmosphere.

