### PR TITLE
Ensure that temperature is computed if MSLP is needed in isobaric_diagnostics

### DIFF
--- a/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
@@ -553,7 +553,7 @@ module isobaric_diagnostics
            enddo
         enddo
        
-        if (NEED_TEMP .or. NEED_RELHUM .or. NEED_DEWPOINT) then
+        if (NEED_TEMP .or. NEED_RELHUM .or. NEED_DEWPOINT .or. need_mslp) then
            !calculation of temperature at cell centers:
             do iCell = 1,nCells
             do k = 1,nVertLevels


### PR DESCRIPTION
This merge corrects a bug that prevented a correct MSLP field from being
computed if no isobaric temperature, dewpoint, or relative humidity diagnostics
were also being computed.

In the isobaric_diagnostics module, we have logic that attempts to compute
fields only if they appear in an output stream, or if they are needed by
another diagnostic that appears in an output stream. The temperature field
was previously only computed if any of the isobaric temperature, dewpoint,
or relative humidity fields appeared in an output stream. This caused
problems if only MSLP was being written to a stream, since a valid temperature
field was not available for the computation of MSLP.

Now, the computation of temperature in the isobaric_diagnostics module also
depends on whether MSLP appears in an output stream.