### PR TITLE
move salinity limiting to its own loop

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1614,11 +1614,21 @@ module ocn_time_integration_split
                            do k = 1, maxLevelCell(iCell)
                               tracersGroupNew(:,k,iCell) = (tracersGroupCur(:,k,iCell) * layerThicknessCur(k,iCell) + dt &
                                                          * tracersGroupTend(:,k,iCell) ) / layerThicknessNew(k,iCell)
-!mrp limit Salinity
-                              tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
                            end do
                         end do
                         !$omp end do
+
+!mrp limit Salinity in separate loop
+                        if ( trim(groupItr % memberName) == 'activeTracers' ) then
+                           !$omp do schedule(runtime) private(k)
+                           do iCell = 1, nCells
+                              do k = 1, maxLevelCell(iCell)
+                                 tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
+                              end do
+                           end do
+                           !$omp end do
+                        end if
+
                      end if
                   end if
                end do


### PR DESCRIPTION
in order to ensure that salinity doesn't go negative, a cutoff limit of 0.001 was introduced after updating from the tendency.  this was done with no check to make sure that it was acting on the "activeTracers", so it was also limiting the second member of all tracer structures.  this has been fixed by moving the limiter out of the main tracer update loop, wrapped by a check that the tracer group is activeTracers.