### PR TITLE
add block debug write to default stream

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1347,6 +1347,23 @@
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
 		</stream>
+		<stream name="block_debug_output"
+				type="output"
+				filename_template="output_debug_block_$B.nc"
+				filename_interval="1000-00-00_00:00:00"
+				reference_time="0001-01-01_00:00:00"
+				clobber_mode="truncate"
+				output_interval="1000-00-00_00:00:00"
+				runtime_format="single_file"
+				mode="forward">
+
+			<stream name="mesh"/>
+			<var name="xtime"/>
+			<var_struct name="tracers"/>
+			<var name="normalVelocity"/>
+			<var name="layerThickness"/>
+			<var name="ssh"/>
+		</stream>
 		<stream name="KPP_testing"
 				type="output"
 				filename_template="output/KPP_test.$Y-$M-$D_$h.$m.$s.nc"
@@ -1354,7 +1371,8 @@
 				reference_time="0001-01-01_00:00:00"
 				clobber_mode="truncate"
 				output_interval="0000_01:00:00"
-				runtime_format="single_file" >
+				runtime_format="single_file"
+				mode="forward">
 
 			<stream name="mesh"/>
 			<var name="xtime"/>

--- a/testing_and_setup/compass/ocean/templates/streams/output.xml
+++ b/testing_and_setup/compass/ocean/templates/streams/output.xml
@@ -34,5 +34,23 @@
 				<member name="CFLNumberGlobal" type="var"/>
 			</add_contents>
 		</stream>
+
+		<stream name="block_debug_output">
+			<attribute name="filename_template">output_debug_block_$B.nc</attribute>
+			<attribute name="name">block_debug_output</attribute>
+			<attribute name="filename_interval">1000-00-00_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0001-01-01_00:00:00</attribute>
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">1000-00-00_00:00:00</attribute>
+			<add_contents>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="layerThickness" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="ssh" type="var"/>
+			</add_contents>
+		</stream>
 	</streams>
 </template>


### PR DESCRIPTION
The block debug stream is only used upon failure.  It writes a block for
each processor.  See #1092.
