### PR TITLE
Ocean heat flux correction

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1897,6 +1897,9 @@
 		<var name="areaCell" type="real" dimensions="nCells" units="m^2"
 			 description="Area of each cell in the primary grid."
 		/>
+		<var name="areaCellTotal" type="real" dimensions="" units="m^2"
+			 description="Global sum of area cell"
+		/>
 		<var name="areaTriangle" type="real" dimensions="nVertices" units="m^2"
 			 description="Area of each cell (triangle) in the dual grid."
 		/>
@@ -2663,6 +2666,9 @@
 		<var name="shortWaveHeatFlux" type="real" dimensions="nCells Time" units="W m^{-2}"
 			 description="Short wave flux at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;ecosysTracersPKG"
+		/>
+		<var name="surfaceHeatFluxSums" type="real" dimensions="R3"  units="^\circ C m s^{-1}"
+			description="Sum of surface heat used for corrections, indices are: (1) rain and evaporation (2) runoff (3) sea ice"
 		/>
 
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -110,14 +110,14 @@ module ocn_forward_mode
       type (block_type), pointer :: block
 
       integer :: err_tmp
-      integer, pointer :: nVertLevels
-      real (kind=RKIND) :: maxDensity, maxDensity_global
-      real (kind=RKIND), dimension(:), pointer :: meshDensity
+      integer, pointer :: nVertLevels, nCellsSolve
+      real (kind=RKIND) :: maxDensity, maxDensity_global, areaCellLocalSum
+      real (kind=RKIND), dimension(:), pointer :: meshDensity, areaCell
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: diagnosticsPool
 
       character (len=StrKIND), pointer :: xtime, simulationStartTime
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
+      real (kind=RKIND), pointer :: daysSinceStartOfSim, areaCellTotal
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_Time_Type) :: startTime
       type (MPAS_TimeInterval_type) :: timeStep
@@ -305,6 +305,18 @@ module ocn_forward_mode
         call mpas_dmpar_max_real(domain % dminfo, maxDensity, maxDensity_global)
         config_maxMeshDensity = maxDensity_global
       endif
+
+      ! find the global sum of areaCell
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         areaCellLocalSum = sum(areaCell(1:nCellsSolve))
+         block => block % next
+      end do
+      call mpas_pool_get_array(meshPool,'areaCellTotal',areaCellTotal)
+      call mpas_dmpar_sum_real(domain % dminfo, areaCellLocalSum, areaCellTotal)
 
       !
       ! Initialize core

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -113,6 +113,7 @@ module ocn_time_integration_split
       type (block_type), pointer :: block
       real (kind=RKIND) :: normalThicknessFluxSum, thicknessSum, flux, sshEdge, hEdge1, &
                  CoriolisTerm, normalVelocityCorrection, temp, temp_h, coef, barotropicThicknessFlux_coeff, sshCell1, sshCell2
+      real (kind=RKIND), dimension(3) :: tempArray3
       integer :: useVelocityCorrection, err
       real (kind=RKIND), dimension(:,:), pointer :: &
                  vertViscTopOfEdge, vertDiffTopOfCell
@@ -171,7 +172,7 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupCur, tracersGroupNew
 
       ! Tend Array Pointers
-      real (kind=RKIND), dimension(:), pointer :: sshTend
+      real (kind=RKIND), dimension(:), pointer :: sshTend, surfaceHeatFluxSums
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessTend
       real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceTend
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocityTend, layerThicknessTend
@@ -1443,18 +1444,18 @@ module ocn_time_integration_split
          ! mrp warning: this mpi sum is within a block loop.  Will not work with
          ! threading, needs to be moved to outside the block loop for
          ! production.
-         sums(1) = surfaceHeatFluxSums
-         call mpas_dmpar_sum_real_array(dminfo,3,surfaceHeatFluxSums,surfaceHeatFluxSumsAll)
-
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+         call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
+         call mpas_dmpar_sum_real_array(dminfo,3,surfaceHeatFluxSums,tempArray3)
+         surfaceHeatFluxSums = tempArray3
 ! mrp added to correct tracers
          call mpas_timer_start('se tracer tend', .false.)
          block => domain % blocklist
          do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call ocn_correct_surface_heat_flux_tend(tracersTendPool, forcingPool, meshPool)
+            call ocn_tend_surface_correction(tendPool, statePool, forcingPool, meshPool)
 
             block => block % next
          end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1446,8 +1446,10 @@ module ocn_time_integration_split
          ! production.
          call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
          call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
+print *, 'surfaceHeatFluxSums 3: ',surfaceHeatFluxSums
          call mpas_dmpar_sum_real_array(dminfo,3,surfaceHeatFluxSums,tempArray3)
          surfaceHeatFluxSums = tempArray3
+print *, 'surfaceHeatFluxSums 4: ',surfaceHeatFluxSums
 ! mrp added to correct tracers
          call mpas_timer_start('se tracer tend', .false.)
          block => domain % blocklist
@@ -1455,11 +1457,14 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+print *, 'call ocn_tend_surface_correction'
             call ocn_tend_surface_correction(tendPool, statePool, forcingPool, meshPool)
 
             block => block % next
          end do
          call mpas_timer_stop('se tracer tend')
+! mrp added to correct tracers end
+
          ! update halo for tracer tendencies
          call mpas_timer_start("se halo tracers")
          call mpas_pool_get_subpool(domain % blocklist % structs, 'tend', tendPool)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1440,30 +1440,24 @@ module ocn_time_integration_split
 
          call mpas_threading_barrier()
 
-! mrp added to correct tracers
-         ! mrp warning: this mpi sum is within a block loop.  Will not work with
-         ! threading, needs to be moved to outside the block loop for
-         ! production.
+         ! Sum tracer surface heat flux due to exchange of volume with other
+         ! components
+! mrp: need to add if here, on any of the three config flags for this fix, so
+! this is not always done.
          call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
          call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
-print *, 'surfaceHeatFluxSums 3: ',surfaceHeatFluxSums
          call mpas_dmpar_sum_real_array(dminfo,3,surfaceHeatFluxSums,tempArray3)
          surfaceHeatFluxSums = tempArray3
-print *, 'surfaceHeatFluxSums 4: ',surfaceHeatFluxSums
-! mrp added to correct tracers
-         call mpas_timer_start('se tracer tend', .false.)
+         call mpas_timer_start('se sum surface heat fluxes', .false.)
          block => domain % blocklist
          do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-print *, 'call ocn_tend_surface_correction'
             call ocn_tend_surface_correction(tendPool, statePool, forcingPool, meshPool)
-
             block => block % next
          end do
-         call mpas_timer_stop('se tracer tend')
-! mrp added to correct tracers end
+         call mpas_timer_stop('se sum surface heat fluxes')
 
          ! update halo for tracer tendencies
          call mpas_timer_start("se halo tracers")

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1439,6 +1439,26 @@ module ocn_time_integration_split
 
          call mpas_threading_barrier()
 
+! mrp added to correct tracers
+         ! mrp warning: this mpi sum is within a block loop.  Will not work with
+         ! threading, needs to be moved to outside the block loop for
+         ! production.
+         sums(1) = surfaceHeatFluxSums
+         call mpas_dmpar_sum_real_array(dminfo,3,surfaceHeatFluxSums,surfaceHeatFluxSumsAll)
+
+! mrp added to correct tracers
+         call mpas_timer_start('se tracer tend', .false.)
+         block => domain % blocklist
+         do while (associated(block))
+            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
+            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
+            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+            call ocn_correct_surface_heat_flux_tend(tracersTendPool, forcingPool, meshPool)
+
+            block => block % next
+         end do
+         call mpas_timer_stop('se tracer tend')
          ! update halo for tracer tendencies
          call mpas_timer_start("se halo tracers")
          call mpas_pool_get_subpool(domain % blocklist % structs, 'tend', tendPool)

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -400,7 +400,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
-      real (kind=RKIND) :: requiredSalt, allowedSalt
+      real (kind=RKIND) :: requiredSalt, allowedSalt, fluxTerm
 
       err = 0
 
@@ -469,18 +469,18 @@ contains
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature
-           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
-                      + (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
-           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
-                      * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
+           fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
+           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = fluxTerm
 
            ! Accumulate fluxes that use the freezing point
-           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
-               + seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
+           fluxTerm = seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
                                                                          pressure=0.0_RKIND, &
                                                                          inLandIceCavity=.false.) / rho_sw
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
 
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -401,9 +401,8 @@ contains
                                                   seaIceHeatFlux, evaporationFlux, riverRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
-      real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux, areaCell
+      real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux, areaCell, surfaceHeatFluxSums
       real (kind=RKIND) :: requiredSalt, allowedSalt, fluxTerm
-      real (kind=RKIND) :: surfaceHeatFluxSumRainEvap, surfaceHeatFluxSumRunoff, surfaceHeatFluxSumSeaIce
 
       err = 0
 
@@ -435,8 +434,10 @@ contains
       call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
 
       nCells = nCellsArray( 2 )
+      surfaceHeatFluxSums = 0.0_RKIND
 
       ! Build surface fluxes at cell centers
       !$omp do schedule(runtime) private(allowedSalt, requiredSalt)
@@ -468,35 +469,32 @@ contains
       !$omp end do
       ! assume that snow comes in at 0 C
 
-      surfaceHeatFluxSumRainEvap = 0.0_RKIND
-      surfaceHeatFluxSumRunoff = 0.0_RKIND
-      surfaceHeatFluxSumSeaIce = 0.0_RKIND
-
       ! Surface fluxes of water have an associated heat content, but the coupled system does not account for this
       ! Assume surface fluxes of water have a temperature dependent on the incoming mass flux.
       ! Assume surface fluxes of water have zero salinity. So the RHS forcing is zero for salinity.
       ! Only include this heat forcing when bulk thickness is turned on
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (bulkThicknessFluxOn) then
+print *, 'surfaceHeatFluxSums 0: ',surfaceHeatFluxSums
          !$omp do schedule(runtime)
          do iCell = 1, nCellsSolve
 
            ! Accumulate fluxes that use the surface temperature
            fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
-           surfaceHeatFluxSumRainEvap = surfaceHeatFluxSumRainEvap + fluxTerm * areaCell(iCell)
+           surfaceHeatFluxSums(1)= surfaceHeatFluxSums(1) + fluxTerm * areaCell(iCell)
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
            tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = fluxTerm
-           surfaceHeatFluxSumRunoff = surfaceHeatFluxSumRunoff + fluxTerm * areaCell(iCell)
+           surfaceHeatFluxSums(2) = surfaceHeatFluxSums(2) + fluxTerm * areaCell(iCell)
 
            ! Accumulate fluxes that use the freezing point
            fluxTerm = seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
                                                                          pressure=0.0_RKIND, &
                                                                          inLandIceCavity=.false.) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
-           surfaceHeatFluxSumSeaIce = surfaceHeatFluxSumSeaIce + fluxTerm * areaCell(iCell)
+           surfaceHeatFluxSums(3) = surfaceHeatFluxSums(3) + fluxTerm * areaCell(iCell)
 
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux
@@ -504,6 +502,7 @@ contains
 
          end do
 
+print *, 'surfaceHeatFluxSums 1: ',surfaceHeatFluxSums
          ! This loop is split because the correction sums are only collected
          ! for active cells, not halo cells.
          ! mrp: I need to know whether to add !$omp do schedule(runtime) here.
@@ -529,27 +528,6 @@ contains
 
          end do
          !$omp end do
-
-         ! mrp warning: this mpi sum is within a block loop.  Will not work with
-         ! threading, needs to be moved to outside the block loop for
-         ! production.
-         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumRainEvap, reductions)
-         surfaceHeatFluxSumRainEvap = reductions/areaCellGlobal 
-         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumRunoff, reductions)
-         surfaceHeatFluxSumRunoff = reductions/areaCellGlobal 
-         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumSeaIce, reductions)
-         surfaceHeatFluxSumSeaIce = reductions/areaCellGlobal 
-
-         if (config_correct_surfaceHeatFlux_RainEvap) then
-            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumRainEvap
-         endif
-         if (config_correct_surfaceHeatFlux_Runoff) then
-            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumRunoff
-         endif
-         if (config_correct_surfaceHeatFlux_SeaIce) then
-            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumSeaIce
-         endif
-
 
       endif ! bulkThicknessFluxOn
 

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -399,7 +399,7 @@ contains
                                                   seaIceHeatFlux, evaporationFlux, riverRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
-      real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
+      real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux, areaCell
       real (kind=RKIND) :: requiredSalt, allowedSalt, fluxTerm
       real (kind=RKIND) :: surfaceHeatFluxSumRainEvap, surfaceHeatFluxSumRunoff, surfaceHeatFluxSumSeaIce
 
@@ -413,6 +413,7 @@ contains
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', index_temperature_flux)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', index_salinity_flux)
 
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(forcingPool, 'latentHeatFlux', latentHeatFlux)
       call mpas_pool_get_array(forcingPool, 'sensibleHeatFlux', sensibleHeatFlux)
       call mpas_pool_get_array(forcingPool, 'longWaveHeatFluxUp', longWaveHeatFluxUp)
@@ -477,16 +478,19 @@ contains
            ! Accumulate fluxes that use the surface temperature
            fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
+           surfaceHeatFluxSumRainEvap = surfaceHeatFluxSumRainEvap + fluxTerm * areaCell(iCell)
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
            tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = fluxTerm
+           surfaceHeatFluxSumRunoff = surfaceHeatFluxSumRunoff + fluxTerm * areaCell(iCell)
 
            ! Accumulate fluxes that use the freezing point
            fluxTerm = seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
                                                                          pressure=0.0_RKIND, &
                                                                          inLandIceCavity=.false.) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
+           surfaceHeatFluxSumSeaIce = surfaceHeatFluxSumSeaIce + fluxTerm * areaCell(iCell)
 
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -390,7 +390,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, nCells
-      integer, pointer :: index_temperature_flux, index_salinity_flux
+      integer, pointer :: index_temperature_flux, index_salinity_flux, nCellsSolve
       integer, dimension(:), pointer :: nCellsArray
 
       type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
@@ -401,6 +401,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
       real (kind=RKIND) :: requiredSalt, allowedSalt, fluxTerm
+      real (kind=RKIND) :: surfaceHeatFluxSumRainEvap, surfaceHeatFluxSumRunoff, surfaceHeatFluxSumSeaIce
 
       err = 0
 
@@ -408,6 +409,7 @@ contains
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
 
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', index_temperature_flux)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', index_salinity_flux)
 
@@ -459,6 +461,10 @@ contains
       !$omp end do
       ! assume that snow comes in at 0 C
 
+      surfaceHeatFluxSumRainEvap = 0.0_RKIND
+      surfaceHeatFluxSumRunoff = 0.0_RKIND
+      surfaceHeatFluxSumSeaIce = 0.0_RKIND
+
       ! Surface fluxes of water have an associated heat content, but the coupled system does not account for this
       ! Assume surface fluxes of water have a temperature dependent on the incoming mass flux.
       ! Assume surface fluxes of water have zero salinity. So the RHS forcing is zero for salinity.
@@ -466,7 +472,32 @@ contains
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (bulkThicknessFluxOn) then
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsSolve
+
+           ! Accumulate fluxes that use the surface temperature
+           fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
+
+           ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
+           fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
+           tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = fluxTerm
+
+           ! Accumulate fluxes that use the freezing point
+           fluxTerm = seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
+                                                                         pressure=0.0_RKIND, &
+                                                                         inLandIceCavity=.false.) / rho_sw
+           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
+
+           ! Fields with zero temperature are not accumulated. These include:
+           !    snowFlux
+           !    iceRunoffFlux
+
+         end do
+
+         ! This loop is split because the correction sums are only collected
+         ! for active cells, not halo cells.
+         ! mrp: I need to know whether to add !$omp do schedule(runtime) here.
+         do iCell = nCellsSolve+1,nCells
 
            ! Accumulate fluxes that use the surface temperature
            fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -482,7 +482,8 @@ print *, 'surfaceHeatFluxSums 0: ',surfaceHeatFluxSums
            ! Accumulate fluxes that use the surface temperature
            fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
-           surfaceHeatFluxSums(1)= surfaceHeatFluxSums(1) + fluxTerm * areaCell(iCell)
+           surfaceHeatFluxSums(1) = surfaceHeatFluxSums(1) + fluxTerm * areaCell(iCell)
+print *,'loop:',iCell, fluxTerm, surfaceHeatFluxSums(1)
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -475,7 +475,6 @@ contains
       ! Only include this heat forcing when bulk thickness is turned on
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (bulkThicknessFluxOn) then
-print *, 'surfaceHeatFluxSums 0: ',surfaceHeatFluxSums
          !$omp do schedule(runtime)
          do iCell = 1, nCellsSolve
 
@@ -483,7 +482,6 @@ print *, 'surfaceHeatFluxSums 0: ',surfaceHeatFluxSums
            fluxTerm = (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) + fluxTerm
            surfaceHeatFluxSums(1) = surfaceHeatFluxSums(1) + fluxTerm * areaCell(iCell)
-print *,'loop:',iCell, fluxTerm, surfaceHeatFluxSums(1)
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            fluxTerm = riverRunoffFlux(iCell) * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
@@ -503,10 +501,9 @@ print *,'loop:',iCell, fluxTerm, surfaceHeatFluxSums(1)
 
          end do
 
-print *, 'surfaceHeatFluxSums 1: ',surfaceHeatFluxSums
          ! This loop is split because the correction sums are only collected
          ! for active cells, not halo cells.
-         ! mrp: I need to know whether to add !$omp do schedule(runtime) here.
+! mrp: I need to know whether to add !$omp do schedule(runtime) here.
          do iCell = nCellsSolve+1,nCells
 
            ! Accumulate fluxes that use the surface temperature

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -389,6 +389,8 @@ contains
       !
       !-----------------------------------------------------------------
 
+      logical, pointer :: config_correct_surfaceHeatFlux_RainEvap, config_correct_surfaceHeatFlux_Runoff, config_correct_surfaceHeatFlux_SeaIce
+
       integer :: iCell, nCells
       integer, pointer :: index_temperature_flux, index_salinity_flux, nCellsSolve
       integer, dimension(:), pointer :: nCellsArray
@@ -404,6 +406,10 @@ contains
       real (kind=RKIND) :: surfaceHeatFluxSumRainEvap, surfaceHeatFluxSumRunoff, surfaceHeatFluxSumSeaIce
 
       err = 0
+
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_RainEvap',config_correct_surfaceHeatFlux_RainEvap)
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_Runoff',config_correct_surfaceHeatFlux_Runoff)
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_SeaIce',config_correct_surfaceHeatFlux_SeaIce)
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
@@ -523,6 +529,28 @@ contains
 
          end do
          !$omp end do
+
+         ! mrp warning: this mpi sum is within a block loop.  Will not work with
+         ! threading, needs to be moved to outside the block loop for
+         ! production.
+         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumRainEvap, reductions)
+         surfaceHeatFluxSumRainEvap = reductions/areaCellGlobal 
+         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumRunoff, reductions)
+         surfaceHeatFluxSumRunoff = reductions/areaCellGlobal 
+         call mpas_dmpar_sum_real_array(dminfo, nSums, surfaceHeatFluxSumSeaIce, reductions)
+         surfaceHeatFluxSumSeaIce = reductions/areaCellGlobal 
+
+         if (config_correct_surfaceHeatFlux_RainEvap) then
+            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumRainEvap
+         endif
+         if (config_correct_surfaceHeatFlux_Runoff) then
+            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumRunoff
+         endif
+         if (config_correct_surfaceHeatFlux_SeaIce) then
+            tracersSurfaceFlux(index_temperature_flux, :) = tracersSurfaceFlux(index_temperature_flux, :) - surfaceHeatFluxSumSeaIce
+         endif
+
+
       endif ! bulkThicknessFluxOn
 
       ! convert short wave heat flux to a temperature flux

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -78,6 +78,7 @@ module ocn_tendency
              ocn_tend_vel, &
              ocn_tend_tracer, &
              ocn_tend_freq_filtered_thickness, &
+             ocn_tend_surface_correction, &
              ocn_tendency_init
 
    !--------------------------------------------------------------------
@@ -805,6 +806,157 @@ contains
       call mpas_timer_stop("ocn_tend_tracer")
 
    end subroutine ocn_tend_tracer!}}}
+
+!***********************************************************************
+!
+!  routine ocn_tend_surface_correction
+!
+!> \brief   Computes tracer tendency
+!> \author  Mark Petersen
+!> \date    March 2017
+!> \details
+!>  This routine corrects the tracer tendancy for heat conservation
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_tend_surface_correction(tendPool, statePool, forcingPool, meshPool) !{{{
+      implicit none
+
+      !
+      ! intent in/out
+      !
+      type (mpas_pool_type), intent(in)    :: statePool       !< Input: State information
+      type (mpas_pool_type), intent(inout) :: tendPool        !< Input/Output: Tendency structure
+      type (mpas_pool_type), intent(inout) :: forcingPool     !< Input: Forcing information
+      type (mpas_pool_type), intent(inout)    :: meshPool     !< Input: Mesh information
+
+      !
+      ! additional pools
+      !
+      type (mpas_pool_type), pointer :: tracersPool, tracersTendPool            ! tracers and their tendency
+      type (mpas_pool_type), pointer :: tracersSurfaceFluxPool                  ! surface fluxes
+      type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool       ! surface restoring
+      type (mpas_pool_type), pointer :: tracersInteriorRestoringFieldsPool      ! interior restoring
+      type (mpas_pool_type), pointer :: tracersExponentialDecayFieldsPool       ! exponential decay
+      type (mpas_pool_type), pointer :: tracersIdealAgeFieldsPool               ! ideal age
+      type (mpas_pool_type), pointer :: tracersTTDFieldsPool                    ! transit time distribution
+
+      ! scalar pointers
+      integer :: nTracerGroup
+      integer, pointer :: nVertLevels, nEdges, nCells, nCellsSolve, indexTemperature, indexSalinity
+      logical, pointer :: config_disable_tr_all_tend, config_use_cvmix_kpp
+      logical, pointer :: config_use_tracerGroup, config_use_tracerGroup_surface_bulk_forcing, &
+                          config_use_tracerGroup_surface_restoring, config_use_tracerGroup_interior_restoring, &
+                          config_use_tracerGroup_exponential_decay, config_use_tracerGroup_idealAge_forcing, &
+                          config_use_tracerGroup_ttd_forcing, config_use_surface_salinity_monthly_restoring
+
+      ! iterator for tracer categories
+      type (mpas_pool_iterator_type) :: groupItr
+      character (len=StrKIND) :: modifiedGroupName
+      character (len=StrKIND) :: modifiedConfigName
+      !
+      ! one dimensional pointers
+      !
+      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL
+      real (kind=RKIND), dimension(:), pointer :: tracerGroupExponentialDecayRate
+      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), dimension(:), pointer :: surfaceHeatFluxSums
+
+      !
+      ! two dimensional pointers
+      !
+      real (kind=RKIND), dimension(:,:), pointer :: tracerGroupPistonVelocity, tracerGroupSurfaceRestoringValue, &
+                                                    tracerGroupIdealAgeMask, tracerGroupTTDMask
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+        normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
+        tend_layerThickness, normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed, zMid, relativeSlopeTopOfEdge, &
+        relativeSlopeTapering, relativeSlopeTaperingCell, fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
+        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux
+
+      !
+      ! three dimensional pointers
+      !
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+        tracerGroup, tracerGroupTend, vertNonLocalFlux
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+        activeTracers, &  !  need T, S for ecosys
+        ecosysTracers     !  need ecosys for DMS and MacroMolecules
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: tracerGroupInteriorRestoringRate, tracerGroupInteriorRestoringValue
+
+      !
+      ! Field pointers
+      !
+      type (field2DReal), pointer :: normalThicknessFluxField
+
+      !
+      ! local integers/reals/logicals
+      !
+      integer :: err, iCell, iEdge, k, timeLevel, nTracersEcosys
+
+      !
+      ! get tracers pools
+      !
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+      call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
+
+      !
+      ! get dimensions
+      !
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
+
+      !
+      ! get configure options
+      !
+      !call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_all_tend', config_disable_tr_all_tend)
+
+      !
+      ! get arrays
+      !
+      call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
+
+      if(config_disable_tr_all_tend) return
+
+      call mpas_timer_start("ocn_tend_surface_correction")
+
+      call mpas_threading_barrier()
+
+      !
+      ! begin iterate over tracer categories
+      !
+      call mpas_pool_begin_iteration(tracersPool)
+      do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
+         if ( groupItr % memberType == MPAS_POOL_FIELD ) then
+
+            ! only active tracers
+            if (trim(groupItr % memberName) == 'activeTracers') then
+
+               ! Get Tendency array
+               modifiedGroupName = trim(groupItr % memberName) // "Tend"
+               call mpas_pool_get_array(tracersTendPool, trim(modifiedGroupName), tracerGroupTend)
+
+               modifiedGroupName = trim(groupItr % memberName) // "SurfaceFluxRunoff"
+               call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFluxRunoff)
+
+               !
+               ! convert the surface tracer flux into a tracer tendency by distributing the flux across some number
+               ! of surface layers
+               !
+               call ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness, &
+                                                 tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff,  &
+                                                 indexTemperature, surfaceHeatFluxSums, tracerGroupTend, err)
+
+            end if
+         end if
+      end do
+
+      call mpas_threading_barrier()
+
+      call mpas_timer_stop("ocn_tend_surface_correction")
+
+   end subroutine ocn_tend_surface_correction!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -918,13 +918,11 @@ contains
       call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
 
-print *,'config_disable_tr_all_tend',config_disable_tr_all_tend
       if(config_disable_tr_all_tend) return
 
       call mpas_timer_start("ocn_tend_surface_correction")
 
       call mpas_threading_barrier()
-print *,'before tracer loop '
       !
       ! begin iterate over tracer categories
       !
@@ -932,11 +930,9 @@ print *,'before tracer loop '
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
 
-print *,'in tracer loop '
             ! only active tracers
             if (trim(groupItr % memberName) == 'activeTracers') then
 
-print *,'in active tracer loop '
                ! Get Tendency array
                modifiedGroupName = trim(groupItr % memberName) // "Tend"
                call mpas_pool_get_array(tracersTendPool, trim(modifiedGroupName), tracerGroupTend)

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -870,7 +870,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: &
         normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
         tend_layerThickness, normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed, zMid, relativeSlopeTopOfEdge, &
-        relativeSlopeTapering, relativeSlopeTaperingCell, fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
+        relativeSlopeTapering, relativeSlopeTaperingCell, tracerGroupSurfaceFluxRunoff, &
         tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux
 
       !
@@ -910,19 +910,21 @@ contains
       !
       ! get configure options
       !
-      !call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_all_tend', config_disable_tr_all_tend)
+      call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_all_tend', config_disable_tr_all_tend)
 
       !
       ! get arrays
       !
       call mpas_pool_get_array(forcingPool, 'surfaceHeatFluxSums', surfaceHeatFluxSums)
+      call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
 
+print *,'config_disable_tr_all_tend',config_disable_tr_all_tend
       if(config_disable_tr_all_tend) return
 
       call mpas_timer_start("ocn_tend_surface_correction")
 
       call mpas_threading_barrier()
-
+print *,'before tracer loop '
       !
       ! begin iterate over tracer categories
       !
@@ -930,9 +932,11 @@ contains
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
 
+print *,'in tracer loop '
             ! only active tracers
             if (trim(groupItr % memberName) == 'activeTracers') then
 
+print *,'in active tracer loop '
                ! Get Tendency array
                modifiedGroupName = trim(groupItr % memberName) // "Tend"
                call mpas_pool_get_array(tracersTendPool, trim(modifiedGroupName), tracerGroupTend)
@@ -944,9 +948,9 @@ contains
                ! convert the surface tracer flux into a tracer tendency by distributing the flux across some number
                ! of surface layers
                !
-               call ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness, &
-                                                 tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff,  &
-                                                 indexTemperature, surfaceHeatFluxSums, tracerGroupTend, err)
+               call ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, layerThickness, &
+                    tracerGroupSurfaceFlux,  &
+                    indexTemperature, surfaceHeatFluxSums, tracerGroupTend, err)
 
             end if
          end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -44,6 +44,7 @@ module ocn_tracer_surface_flux_to_tend
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_surface_flux_tend, &
+             ocn_correct_surface_heat_flux_tend, &
              ocn_tracer_surface_flux_init
 
    !--------------------------------------------------------------------
@@ -53,6 +54,9 @@ module ocn_tracer_surface_flux_to_tend
    !--------------------------------------------------------------------
 
    logical :: surfaceTracerFluxOn
+   logical :: correct_surfaceHeatFlux_RainEvap
+   logical :: correct_surfaceHeatFlux_Runoff
+   logical :: correct_surfaceHeatFlux_SeaIce
 
 !***********************************************************************
 
@@ -198,6 +202,145 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_correct_surface_heat_flux_tend
+!
+!> \brief   Computes tendency term for surface fluxes
+!> \author  Mark Petersen
+!> \date    March 16 2017
+!> \details
+!>  This routine removes the average heat flux from all cells due to rain, evap,
+!>  runoff, and sea ice.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness,  &
+      surfaceTracerFlux, surfaceTracerFluxRunoff, tend, err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThickness !< Input: Layer thickness
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        surfaceTracerFlux !< Input: surface tracer fluxes
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        fractionAbsorbed !< Input: Coefficients for the application of surface fluxes
+
+      real (kind=RKIND), dimension(:,:), intent(in), pointer :: &
+        surfaceTracerFluxRunoff !< Input: surface tracer fluxes from river runoff
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        fractionAbsorbedRunoff !< Input: Coefficients for the application of surface fluxes due to river runoff
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, iTracer, nTracers, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+      integer, dimension(:), pointer :: maxLevelCell
+
+      real (kind=RKIND) :: remainingFlux
+
+      err = 0
+
+      if (.not. surfaceTracerFluxOn) return
+
+      call mpas_timer_start("surface_tracer_flux")
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      nTracers = size(tend, dim=1)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+      nCells = nCellsArray( 1 )
+
+      !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
+      do iCell = 1, nCells
+        remainingFlux = 1.0_RKIND
+        do k = 1, maxLevelCell(iCell)
+          remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
+
+          do iTracer = 1, nTracers
+            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + surfaceTracerFlux(iTracer, iCell) * fractionAbsorbed(k, iCell)
+          end do
+        end do
+
+        if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+          do iTracer = 1, nTracers
+            tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
+                                                      + surfaceTracerFlux(iTracer, iCell) * remainingFlux
+          end do
+        end if
+      end do
+      !$omp end do
+
+      call mpas_timer_stop("surface_tracer_flux")
+
+      ! now do runoff component
+
+      if (associated(surfaceTracerFluxRunoff)) then
+        call mpas_timer_start("surface_tracer_runoff_flux")
+
+        !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
+        do iCell = 1, nCells
+          remainingFlux = 1.0_RKIND
+          do k = 1, maxLevelCell(iCell)
+            remainingFlux = remainingFlux - fractionAbsorbedRunoff(k, iCell)
+
+            do iTracer = 1, nTracers
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) +  &
+                 surfaceTracerFluxRunoff(iTracer, iCell) * fractionAbsorbedRunoff(k, iCell)
+            end do
+          end do
+
+          if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+            do iTracer = 1, nTracers
+              tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
+                                                        + surfaceTracerFluxRunoff(iTracer, iCell) * remainingFlux
+            end do
+          end if
+        end do
+        !$omp end do
+
+        call mpas_timer_stop("surface_tracer_runoff_flux")
+      end if
+
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_correct_surface_heat_flux_tend!}}}
+
+!***********************************************************************
+!
 !  routine ocn_tracer_surface_flux_init
 !
 !> \brief   Initializes ocean tracer surface flux quantities
@@ -215,15 +358,28 @@ contains
       integer, intent(out) :: err !< Output: error flag
 
       logical, pointer :: config_disable_tr_sflux
+      logical, pointer :: config_correct_surfaceHeatFlux_RainEvap
+      logical, pointer :: config_correct_surfaceHeatFlux_Runoff
+      logical, pointer :: config_correct_surfaceHeatFlux_SeaIce
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_sflux', config_disable_tr_sflux)
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_RainEvap',config_correct_surfaceHeatFlux_RainEvap)
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_Runoff',config_correct_surfaceHeatFlux_Runoff)
+      call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_SeaIce',config_correct_surfaceHeatFlux_SeaIce)
 
       surfaceTracerFluxOn = .true.
+      correct_surfaceHeatFlux_RainEvap = .true.
+      correct_surfaceHeatFlux_Runoff = .true.
+      correct_surfaceHeatFlux_SeaIce = .true.
+
 
       if (config_disable_tr_sflux) then
          surfaceTracerFluxOn = .false.
+         correct_surfaceHeatFlux_RainEvap = .false.
+         correct_surfaceHeatFlux_Runoff = .false.
+         correct_surfaceHeatFlux_SeaIce = .false.
       end if
 
    end subroutine ocn_tracer_surface_flux_init!}}}

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -214,7 +214,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness,  &
-      surfaceTracerFlux, surfaceTracerFluxRunoff, tend, err)!{{{
+      surfaceTracerFlux, surfaceTracerFluxRunoff, indexTemperature, surfaceHeatFluxSums, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -223,6 +223,9 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information
+
+      type (mpas_pool_type), pointer :: tracersPool, tracersTendPool
+! tracers and their tendency
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
         layerThickness !< Input: Layer thickness
@@ -238,6 +241,10 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
         fractionAbsorbedRunoff !< Input: Coefficients for the application of surface fluxes due to river runoff
+
+      integer, intent(in) :: indexTemperature
+
+      real (kind=RKIND), dimension(:), intent(in) :: surfaceHeatFluxSums
 
       !-----------------------------------------------------------------
       !
@@ -266,22 +273,42 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
       integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), pointer :: areaCellTotal
 
-      real (kind=RKIND) :: remainingFlux
+      real (kind=RKIND) :: remainingFlux, surfaceHeatFluxCorrection
 
       err = 0
 
       if (.not. surfaceTracerFluxOn) return
 
-      call mpas_timer_start("surface_tracer_flux")
+      call mpas_timer_start("correct_surface_heat_flux_tend")
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_array(meshPool,'areaCellTotal',areaCellTotal)
       nTracers = size(tend, dim=1)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       nCells = nCellsArray( 1 )
+
+      iTracer = indexTemperature !mrp do this!!!
+
+      surfaceHeatFluxCorrection = 0.0_RKIND
+
+      if (correct_surfaceHeatFlux_RainEvap) then
+         surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(1)/areaCellTotal
+      endif
+      if (correct_surfaceHeatFlux_Runoff) then
+         surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(2)/areaCellTotal
+      endif
+      if (correct_surfaceHeatFlux_SeaIce) then
+         surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(3)/areaCellTotal
+      endif
+
+print *, 'surfaceHeatFluxSums 2: ',surfaceHeatFluxSums
+print *, 'areaCellTotal 2: ', areaCellTotal
+print *, 'surfaceHeatFluxCorrection 2:',surfaceHeatFluxCorrection
 
       !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
       do iCell = 1, nCells
@@ -289,51 +316,17 @@ contains
         do k = 1, maxLevelCell(iCell)
           remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
 
-          do iTracer = 1, nTracers
-            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + surfaceTracerFlux(iTracer, iCell) * fractionAbsorbed(k, iCell)
-          end do
+            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - surfaceHeatFluxCorrection * fractionAbsorbed(k, iCell)
         end do
 
         if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
-          do iTracer = 1, nTracers
             tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
-                                                      + surfaceTracerFlux(iTracer, iCell) * remainingFlux
-          end do
+                                                      - surfaceHeatFluxCorrection * remainingFlux
         end if
       end do
       !$omp end do
 
-      call mpas_timer_stop("surface_tracer_flux")
-
-      ! now do runoff component
-
-      if (associated(surfaceTracerFluxRunoff)) then
-        call mpas_timer_start("surface_tracer_runoff_flux")
-
-        !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
-        do iCell = 1, nCells
-          remainingFlux = 1.0_RKIND
-          do k = 1, maxLevelCell(iCell)
-            remainingFlux = remainingFlux - fractionAbsorbedRunoff(k, iCell)
-
-            do iTracer = 1, nTracers
-              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) +  &
-                 surfaceTracerFluxRunoff(iTracer, iCell) * fractionAbsorbedRunoff(k, iCell)
-            end do
-          end do
-
-          if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
-            do iTracer = 1, nTracers
-              tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
-                                                        + surfaceTracerFluxRunoff(iTracer, iCell) * remainingFlux
-            end do
-          end if
-        end do
-        !$omp end do
-
-        call mpas_timer_stop("surface_tracer_runoff_flux")
-      end if
-
+      call mpas_timer_stop("correct_surface_heat_flux_tend")
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -272,7 +272,6 @@ contains
       real (kind=RKIND) :: remainingFlux, surfaceHeatFluxCorrection
 
       err = 0
-print *, 'surfaceTracerFluxOn 5:',surfaceTracerFluxOn
       if (.not. surfaceTracerFluxOn) return
 
       call mpas_timer_start("correct_surface_heat_flux_tend")
@@ -283,15 +282,9 @@ print *, 'surfaceTracerFluxOn 5:',surfaceTracerFluxOn
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       nTracers = size(tend, dim=1)
 
-print *, 'areaCellTotal 5:',areaCellTotal
-print *, 'surfaceHeatFluxSums 5:',surfaceHeatFluxSums
       nCells = nCellsArray( 1 )
-Print *, 'nCells 5:',nCells
       iTracer = indexTemperature 
-print *, 'iTracer',iTracer
       surfaceHeatFluxCorrection = 0.0_RKIND
-print *, 'surfaceHeatFluxCorrection',surfaceHeatFluxCorrection
-print *, '666:correct_surfaceHeatFlux_RainEvap',correct_surfaceHeatFlux_RainEvap
       if (correct_surfaceHeatFlux_RainEvap) then
          surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(1)/areaCellTotal
       endif
@@ -302,14 +295,12 @@ print *, '666:correct_surfaceHeatFlux_RainEvap',correct_surfaceHeatFlux_RainEvap
          surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(3)/areaCellTotal
       endif
 
-print *, 'surfaceHeatFluxSums 6: ',surfaceHeatFluxSums
-print *, 'areaCellTotal 6: ', areaCellTotal
-print *, 'surfaceHeatFluxCorrection 5:',surfaceHeatFluxCorrection
-
       !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
-print *, 'tend 7:',tend(iTracer, 1, 1:10)
       do iCell = 1, nCells
 
+! mrp Right now I am applying correction to the top layer only.  Need to think
+! about if the commented lines below are better.  It distributes the heat on the
+! top many layers, but is more computation (all the way down to maxLevelCell)
          tend(iTracer, 1, iCell) = tend(iTracer, 1, iCell) - surfaceHeatFluxCorrection
 
 
@@ -325,7 +316,6 @@ print *, 'tend 7:',tend(iTracer, 1, 1:10)
 !                                                      - surfaceHeatFluxCorrection * remainingFlux
 !        end if
       end do
-print *, 'tend 8:',tend(iTracer, 1, 1:10)
       !$omp end do
 
       call mpas_timer_stop("correct_surface_heat_flux_tend")

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -213,8 +213,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, fractionAbsorbedRunoff, layerThickness,  &
-      surfaceTracerFlux, surfaceTracerFluxRunoff, indexTemperature, surfaceHeatFluxSums, tend, err)!{{{
+   subroutine ocn_correct_surface_heat_flux_tend(meshPool, fractionAbsorbed, layerThickness,  &
+      surfaceTracerFlux, indexTemperature, surfaceHeatFluxSums, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -235,12 +235,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
         fractionAbsorbed !< Input: Coefficients for the application of surface fluxes
-
-      real (kind=RKIND), dimension(:,:), intent(in), pointer :: &
-        surfaceTracerFluxRunoff !< Input: surface tracer fluxes from river runoff
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-        fractionAbsorbedRunoff !< Input: Coefficients for the application of surface fluxes due to river runoff
 
       integer, intent(in) :: indexTemperature
 
@@ -278,7 +272,7 @@ contains
       real (kind=RKIND) :: remainingFlux, surfaceHeatFluxCorrection
 
       err = 0
-
+print *, 'surfaceTracerFluxOn 5:',surfaceTracerFluxOn
       if (.not. surfaceTracerFluxOn) return
 
       call mpas_timer_start("correct_surface_heat_flux_tend")
@@ -286,16 +280,18 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_array(meshPool,'areaCellTotal',areaCellTotal)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       nTracers = size(tend, dim=1)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
+print *, 'areaCellTotal 5:',areaCellTotal
+print *, 'surfaceHeatFluxSums 5:',surfaceHeatFluxSums
       nCells = nCellsArray( 1 )
-
-      iTracer = indexTemperature !mrp do this!!!
-
+Print *, 'nCells 5:',nCells
+      iTracer = indexTemperature 
+print *, 'iTracer',iTracer
       surfaceHeatFluxCorrection = 0.0_RKIND
-
+print *, 'surfaceHeatFluxCorrection',surfaceHeatFluxCorrection
+print *, '666:correct_surfaceHeatFlux_RainEvap',correct_surfaceHeatFlux_RainEvap
       if (correct_surfaceHeatFlux_RainEvap) then
          surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(1)/areaCellTotal
       endif
@@ -306,24 +302,30 @@ contains
          surfaceHeatFluxCorrection = surfaceHeatFluxCorrection + surfaceHeatFluxSums(3)/areaCellTotal
       endif
 
-print *, 'surfaceHeatFluxSums 2: ',surfaceHeatFluxSums
-print *, 'areaCellTotal 2: ', areaCellTotal
-print *, 'surfaceHeatFluxCorrection 2:',surfaceHeatFluxCorrection
+print *, 'surfaceHeatFluxSums 6: ',surfaceHeatFluxSums
+print *, 'areaCellTotal 6: ', areaCellTotal
+print *, 'surfaceHeatFluxCorrection 5:',surfaceHeatFluxCorrection
 
       !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
+print *, 'tend 7:',tend(iTracer, 1, 1:10)
       do iCell = 1, nCells
-        remainingFlux = 1.0_RKIND
-        do k = 1, maxLevelCell(iCell)
-          remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
 
-            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - surfaceHeatFluxCorrection * fractionAbsorbed(k, iCell)
-        end do
+         tend(iTracer, 1, iCell) = tend(iTracer, 1, iCell) - surfaceHeatFluxCorrection
 
-        if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
-            tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
-                                                      - surfaceHeatFluxCorrection * remainingFlux
-        end if
+
+!        remainingFlux = 1.0_RKIND
+!        do k = 1, maxLevelCell(iCell)
+!          remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
+!
+!            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - surfaceHeatFluxCorrection * fractionAbsorbed(k, iCell)
+!        end do
+!
+!        if(maxLevelCell(iCell) > 0 .and. remainingFlux > 0.0_RKIND) then
+!            tend(iTracer, maxLevelCell(iCell), iCell) = tend(iTracer, maxLevelCell(iCell), iCell) &
+!                                                      - surfaceHeatFluxCorrection * remainingFlux
+!        end if
       end do
+print *, 'tend 8:',tend(iTracer, 1, 1:10)
       !$omp end do
 
       call mpas_timer_stop("correct_surface_heat_flux_tend")
@@ -363,10 +365,9 @@ print *, 'surfaceHeatFluxCorrection 2:',surfaceHeatFluxCorrection
       call mpas_pool_get_config(ocnConfigs,'config_correct_surfaceHeatFlux_SeaIce',config_correct_surfaceHeatFlux_SeaIce)
 
       surfaceTracerFluxOn = .true.
-      correct_surfaceHeatFlux_RainEvap = .true.
-      correct_surfaceHeatFlux_Runoff = .true.
-      correct_surfaceHeatFlux_SeaIce = .true.
-
+      correct_surfaceHeatFlux_RainEvap = config_correct_surfaceHeatFlux_RainEvap
+      correct_surfaceHeatFlux_Runoff = config_correct_surfaceHeatFlux_Runoff
+      correct_surfaceHeatFlux_SeaIce = config_correct_surfaceHeatFlux_SeaIce
 
       if (config_disable_tr_sflux) then
          surfaceTracerFluxOn = .false.

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -39,6 +39,18 @@
 			description="maximum allowable difference between surface salinity and climatology"
 			possible_values="any non-negative number"
 		/>
+		<nml_option name="config_correct_surfaceHeatFlux_RainEvap" type="logical" default_value=".false." units="unitless"
+			description="if true, apply a uniform global correction for temperature flux from rain and evaporation" 
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_correct_surfaceHeatFlux_Runoff" type="logical" default_value=".false." units="unitless"
+			description="if true, apply a uniform global correction for temperature flux from runoff"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_correct_surfaceHeatFlux_SeaIce" type="logical" default_value=".false." units="unitless"
+			description="if true, apply a uniform global correction for temperature flux from sea ice"
+			possible_values=".true. or .false."
+		/>
 	</nml_record>
 
 	<packages>


### PR DESCRIPTION
This PR would give MPAS-O the ability to make a global correction for heat fluxes that come with fluxes of water from other ACME components, but where there is no explicit corresponding transfer of heat through the coupler.