### PR TITLE
Initialize horizontal fluxes for ghost-cell faces in monotonic transport

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3568,7 +3568,7 @@ module atm_time_integration
 
             if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve) then  ! only for owned cells
   
-               ! speclal treatment of calculations involving edges between hexagonal cells
+               ! special treatment of calculations involving edges between hexagonal cells
                ! original code retained in select "default" case
                ! be sure to see additional declarations near top of subroutine
                select case(nAdvCellsForEdge(iEdge))
@@ -3602,6 +3602,8 @@ module atm_time_integration
                   end do
                end select
 
+            else
+               flux_arr(:,iEdge) = 0.0_RKIND
             end if
 
          end do


### PR DESCRIPTION
In the atm_advance_scalars_mono_work( ) routine, the flux_arr field holds
the horizontal fluxes through cell faces. This array was previously only
set for edges that bordered owned cells, leaving the fluxes between ghost
cells uninitialized. Later in the routine, however, values from the flux_arr
field are used for all edges, and this can lead to floating-point exceptions.

The fix in this commit simply sets the flux_arr field to zero for edges that
separate two ghost cells in the loop over edges.