### PR TITLE
Required changes for threaded vector reconstruction

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -650,7 +650,6 @@ module ocn_time_integration_rk4
          ! End: Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
 
-         !$omp master
          call mpas_reconstruct(meshPool,  normalVelocityNew, &
                           velocityX, velocityY, velocityZ,   &
                           velocityZonal, velocityMeridional, &
@@ -660,7 +659,6 @@ module ocn_time_integration_rk4
                           gradSSHX, gradSSHY, gradSSHZ,    &
                           gradSSHZonal, gradSSHMeridional, &
                           includeHalos = .true.)
-         !$omp end master
          call mpas_threading_barrier()
 
          !$omp do schedule(runtime)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1805,7 +1805,7 @@ module ocn_time_integration_split
 
          call mpas_timer_start('se final mpas reconstruct', .false.)
          call mpas_threading_barrier()
-         !$omp master
+
          call mpas_reconstruct(meshPool, normalVelocityNew,  &
                           velocityX, velocityY, velocityZ,   &
                           velocityZonal, velocityMeridional, &
@@ -1815,7 +1815,7 @@ module ocn_time_integration_split
                           gradSSHX, gradSSHY, gradSSHZ,    &
                           gradSSHZonal, gradSSHMeridional, &
                           includeHalos = .true.)
-         !$omp end master
+
          call mpas_threading_barrier()
          call mpas_timer_stop('se final mpas reconstruct')
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1888,8 +1888,6 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
       call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
 
-      !$omp sections
-      !$omp section
       call mpas_reconstruct(meshPool, normalTransportVelocity,          &
                        transportVelocityX,            &
                        transportVelocityY,            &
@@ -1898,7 +1896,6 @@ contains
                        transportVelocityMeridional    &
                       )
 
-      !$omp section
       call mpas_reconstruct(meshPool, normalGMBolusVelocity,          &
                        GMBolusVelocityX,            &
                        GMBolusVelocityY,            &
@@ -1907,7 +1904,6 @@ contains
                        GMBolusVelocityMeridional    &
                       )
 
-      !$omp section
       call mpas_reconstruct(meshPool, relativeSlopeTopOfEdge,          &
                       relativeSlopeTopOfCellX,            &
                       relativeSlopeTopOfCellY,            &
@@ -1916,7 +1912,6 @@ contains
                       relativeSlopeTopOfCellMeridional    &
                      )
 
-      !$omp section
       call mpas_reconstruct(meshPool, gmStreamFuncTopOfEdge,          &
                       GMStreamFuncX,            &
                       GMStreamFuncY,            &
@@ -1924,7 +1919,6 @@ contains
                       GMStreamFuncZonal,        &
                       GMStreamFuncMeridional    &
                      )
-      !$omp end sections
 
       call mpas_timer_stop('reconstruct gm vecs')
 


### PR DESCRIPTION
With the addition of a new threaded reconstruction routine in #1237, openMP directives surrounding calls to this routine in the ocean core needed to be removed for consistency.