### PR TITLE
Bug fix to update_radiation_diagnostics not being called if buckets are not used

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -238,15 +238,13 @@
 !$OMP END PARALLEL DO
     endif
 
-    !call to accumulate long- and short-wave diagnostics if needed:
-     if(config_bucket_update /= 'none' .and. config_bucket_radt .gt. 0._RKIND) then
+    !call to accumulate long- and short-wave diagnostics:
 !$OMP PARALLEL DO
-       do thread=1,nThreads
-          call update_radiation_diagnostics(block%configs,mesh,diag_physics, &
-                                            cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
-       end do
+    do thread=1,nThreads
+       call update_radiation_diagnostics(block%configs,mesh,diag_physics, &
+                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+    end do
 !$OMP END PARALLEL DO
-     endif
 
     !deallocate all radiation arrays:
     if(config_radt_sw_scheme.ne.'off' .or. config_radt_lw_scheme.ne.'off') &


### PR DESCRIPTION
Previously, the routine update_radiation_diagnostics to update the accumulated
radiation variables (acswdnb etc) was only called if "config_bucket_update /= 'none'"
and "config_bucket_radt .gt. 0._RKIND". Inside the routine, the current values of
the (temporary) fields (swdnb etc) are multiplied by dt_dyn and added to the
accumulated (permanent) fields. Only after that, another test of config_bucket_update
and config_bucket_radt is done and the overflow values transferred to the buckets,
if requested. If config_bucket_update is set to none, the information stored in
the temporary fields (swdnb etc) is lost at the end of the time step and the
accumulated fields remain zero for the entire integration (i.e. the entire information
on accumulated radiation fields is lost). This is not the intended method, as users
may wish to get the information on accumulated radiation also for shorter runs,
for which the buckets may not be needed.

