### PR TITLE
Bug fix to add initialization of variable in precompute AM driver

### DIFF
--- a/src/core_cice/analysis_members/mpas_cice_analysis_driver.F
+++ b/src/core_cice/analysis_members/mpas_cice_analysis_driver.F
@@ -1218,6 +1218,8 @@ contains
 
       iErr = 0
 
+      err_tmp = 0 ! needed since time series stats is commented out
+
       nameLength = len_trim(analysisMemberName)
 
       if ( analysisMemberName(1:nameLength) == 'highFrequencyOutput' ) then


### PR DESCRIPTION
This is needed since the precompute subroutines are commented out so that we can use as closely as possible the ocean time series stats code. This means though that err_tmp is not initialized in this case.

