### PR TITLE
Send Albany output to log.albany.nnnn.out file

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -739,6 +739,9 @@ is the value of that variable from the *previous* time level!
                 <var name="daysSinceStart" type="real" dimensions="Time" units="days"
                      description="Time since simulationStartTime in days, for plotting"
                 />
+                <var name="timestepNumber" type="integer" dimensions="Time" units="none"
+                     description="time step number.  initial time is 0."
+                />
 	</var_struct>
 
 <!-- ================ -->

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -31,6 +31,9 @@
 #include <mpi.h>
 #include <list>
 #include <iostream>
+#include <fstream>
+#include <unistd.h>
+#include <fcntl.h>
 #include <limits>
 #include <cmath>
 #include <map>
@@ -51,6 +54,9 @@
 #define velocity_solver_export_2d_data velocity_solver_export_2d_data_
 #define velocity_solver_export_fo_velocity velocity_solver_export_fo_velocity_
 #define velocity_solver_estimate_SS_SMB velocity_solver_estimate_ss_smb_
+#define interface_init_log interface_init_log_
+#define interface_redirect_stdout interface_redirect_stdout_
+#define interface_reset_stdout interface_reset_stdout_
 #endif
 
 //#include <lifev/core/algorithm/PreconditionerIfpack.hpp>
@@ -130,6 +136,11 @@ void velocity_solver_export_fo_velocity();
 
 //void velocity_solver_estimate_SS_SMB (const double* u_normal_F, double* sfcMassBal);
 
+void interface_init_log();
+
+void interface_redirect_stdout(int const* iTimestep);
+
+void interface_reset_stdout();
 }
 
 extern void velocity_solver_finalize__();

--- a/src/core_landice/mode_forward/mpas_li_core.F
+++ b/src/core_landice/mode_forward/mpas_li_core.F
@@ -303,9 +303,9 @@ module li_core
       ! local variables
       !
       !-----------------------------------------------------------------
-      integer :: itimestep
+      integer, pointer :: timestepNumber
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: geometryPool, meshPool
       integer, pointer :: config_stats_interval   !< interval (number of timesteps) for writing stats
       character(len=StrKIND), pointer :: config_restart_timestamp_name
       character(len=StrKIND), pointer :: config_velocity_solver
@@ -328,24 +328,38 @@ module li_core
 
       call mpas_timer_start("land ice core run")
 
+      ! initialize time step number.  initial time is 0
+      block => domain % blocklist
+      do while(associated(block))
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_array(meshPool, 'timestepNumber', timestepNumber)
+         timestepNumber = 0
+         block => block % next
+      end do
+
       ! ===
       ! Solve initial state before beginning time stepping
       ! ===
       err_tmp = li_core_initial_solve(domain)
       err = ior(err,err_tmp)  ! li_core_finalize would abort if there was an error, but being safe.
 
-
       ! During integration, time level 1 stores the model state at the beginning of the
       !   time step, and time level 2 stores the state advanced dt in time by timestep(...)
-      itimestep = 0
       ! ===
       ! === Time step loop
       ! ===
       do while (.not. mpas_is_clock_stop_time(domain % clock))
 
-         itimestep = itimestep + 1
-         call mpas_log_write('Starting timestep number $i', intArgs=(/iTimeStep/), flushNow=.true.)
+         ! Update time step number
+         block => domain % blocklist
+         do while(associated(block))
+            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+            call mpas_pool_get_array(meshPool, 'timestepNumber', timestepNumber)
+            timestepNumber = timestepNumber + 1
+            block => block % next
+         end do
 
+         call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
 
          ! ===
          ! === Perform Timestep
@@ -357,9 +371,9 @@ module li_core
 
          ! Write statistics at designated interval
          if (config_stats_interval > 0) then
-            if (mod(itimestep, config_stats_interval) == 0) then
+            if (mod(timestepNumber, config_stats_interval) == 0) then
                call mpas_timer_start("compute_statistics")
-               call li_compute_statistics(domain, itimestep)
+               call li_compute_statistics(domain, timestepNumber)
                call mpas_timer_stop("compute_statistics")
             end if
          end if
@@ -652,7 +666,6 @@ module li_core
       ! local variables
       !
       !-----------------------------------------------------------------
-      integer :: itimestep
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool
       logical, pointer :: config_do_restart, config_write_output_on_startup, config_write_stats_on_startup
@@ -710,7 +723,6 @@ module li_core
       if (config_write_stats_on_startup) then
          call mpas_timer_start("compute_statistics")
          call li_compute_statistics(domain, 0)     ! itimestep = 0
-                                                   ! (itimestep is initialized below)
          call mpas_timer_stop("compute_statistics")
       endif
 

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -160,6 +160,9 @@ contains
       call mpas_log_write("Initializing external velocity solver.", flushNow=.true.)
 
       call velocity_solver_init_mpi(domain % dminfo % comm)
+
+      call interface_init_log()!domain % logInfo % outputLog % isActive, trim(domain % logInfo % outputLog % fileName) // CHAR(0))
+
 #else
       err = 1
       call mpas_log_write("To run with an external velocity solver you must compile MPAS with one.", MPAS_LOG_ERR)
@@ -305,6 +308,8 @@ contains
       call mpas_timer_start("velocity_solver_set_grid_data")
       call mpas_log_write("Initializing external velocity solver grid data.", flushNow=.true.)
 
+      call interface_redirect_stdout(-1) ! time level of -1 prevents message of what time level this is
+
       call velocity_solver_set_grid_data(nCells, nEdges, nVertices, nVertInterfaces, &
               nCellsSolve, nEdgesSolve, nVerticesSolve, maxNEdgesOnCell, radius, &
               cellsOnEdge, cellsOnVertex, verticesOnCell, verticesOnEdge, edgesOnCell, &
@@ -339,6 +344,8 @@ contains
       call velocity_solver_set_parameters(gravity, config_ice_density, config_ocean_density, config_sea_level, &
          config_default_flowParamA, config_enhancementFactor, &
          config_flowLawExponent, config_dynamic_thickness, li_mask_ValueAlbanyActive, li_mask_ValueIce)
+
+      call interface_reset_stdout()
 #endif
 
 
@@ -425,6 +432,7 @@ contains
       integer, pointer :: anyDynamicVertexMaskChanged
       integer, pointer :: dirichletMaskChanged
       integer, pointer :: nEdges
+      integer, pointer :: timestepNumber
       type (field2dReal), pointer :: dissipationVertexField
       real (kind=RKIND), dimension(:,:), pointer :: heatDissipation  ! on cells
       integer :: iEdge
@@ -443,6 +451,7 @@ contains
       ! Mesh variables
       call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
+      call mpas_pool_get_array(meshPool, 'timestepNumber', timestepNumber)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
       ! Geometry variables
@@ -470,6 +479,10 @@ contains
       call mpas_pool_get_array(velocityPool, 'dirichletVelocityMask', dirichletVelocityMask, timeLevel = 1)
       call mpas_pool_get_array(velocityPool, 'floatingEdges', floatingEdges)
 
+#if defined(USE_EXTERNAL_L1L2) || defined(USE_EXTERNAL_FIRSTORDER) || defined(USE_EXTERNAL_STOKES)
+      ! Capture Albany output
+      call interface_redirect_stdout(timestepNumber)
+#endif
 
       ! ==================================================================
       ! External dycore calls to be made only when vertex mask changes
@@ -582,6 +595,9 @@ contains
          if (.not. li_mask_is_dynamic_ice(edgeMask(iEdge)) ) normalVelocity(:,iEdge) = 0.0e0_RKIND
       end do
 
+#if defined(USE_EXTERNAL_L1L2) || defined(USE_EXTERNAL_FIRSTORDER) || defined(USE_EXTERNAL_STOKES)
+      call interface_reset_stdout()
+#endif
 
    !--------------------------------------------------------------------
    end subroutine li_velocity_external_solve

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -364,7 +364,7 @@ module mpas_log
       ! Open file if it was determined to be active
       if (activeFile .and. .not. alreadyOpen) then
          ! Open the file
-         open (unit = unitNumber, file = fileName, action="WRITE", status="REPLACE", IOSTAT=err_tmp)
+         open (unit = unitNumber, file = fileName, action="WRITE", status="REPLACE", access="APPEND", IOSTAT=err_tmp)
          if ( err_tmp /= 0 ) then
             call mpas_dmpar_global_abort('ERROR: Opening of log file failed for filename: ' // logFileInfo % fileName)
          endif


### PR DESCRIPTION
After the new log system was added, stdout and stderr from the Albany
external velocity solver is dumped to the terminal.

This commit redirects it to a file called log.albany.0000.out file.  As
implemented now, only the master task ever writes this file, and the
other tasks are redirected to /dev/null instead.

Note: it did not appear possible to redirect Albany output to the MPAS
log file without first closing the MPAS log file before Albany took over
and then reopening it afterwards.  This seemed cumbersome and
potentially problematic, and, given the verbosity of Albany output,
putting it a separate file had advantages anyway.

The redirection to this new log file is applied to both stdout and stderr.
It is activated before each call to the Albany routines.  stdout and
sterr are then reset back to their original locations between Albany
solves so that if the code is running in ACME, stdout and stderr are not
hijacked during the rest of the model when other components or the ACME
driver might be expecting them to point elsewhere.

In order to make the new albany log file easier to follow, I insert the
timestep number in the file before each solve.  (I could not write the
model time because that is not known yet during the velocity solve when
using the adaptive timestepper.)  To allow writing the timestep number,
I added a new MPAS model variable to the mesh pool called
'timestepNumber' that is updated on each time step.