### PR TITLE
Change totalVolumeChange from ==0 to <= 1e-12

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -1327,7 +1327,7 @@ contains
 
       ! calculate fresh water conservation check quantities
       absoluteFreshWaterConservation = totalVolumeChange - netFreshwaterInput
-      if (totalVolumeChange == 0.0_RKIND) then
+      if (abs(totalVolumeChange) < 1e-12_RKIND) then
          relativeFreshWaterConservation = 0.0_RKIND
       else
          relativeFreshWaterConservation = (totalVolumeChange - netFreshwaterInput)/totalVolumeChange


### PR DESCRIPTION
This fixes a floating invalid error that occurs on cori-knl intel.  The
totalVolumeChange may be a very small value, i.e. 1e-100, because it is
computed as a difference:
  `totalVolumeChange = currentVolume - sums(variableIndex)`
In the current code, it does not equal zero exactly, but still
produces a floating invalid when dividing.
