### PR TITLE
Note in description of config_len_disp that it is also used by 3-d div damping

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -141,7 +141,7 @@
 
                 <nml_option name="config_len_disp" type="real" default_value="120000.0"
                      units="m"
-                     description="Horizontal length scale for Smagorinsky formulation of horizontal diffusion"
+                     description="Horizontal length scale, used by the Smagorinsky formulation of horizontal diffusion and by 3-d divergence damping"
                      possible_values="Positive real values"/>
 
                 <nml_option name="config_visc4_2dsmag" type="real" default_value="0.05"


### PR DESCRIPTION
This merge updates the description of the 'config_len_disp' option in MPAS-Atmosphere to
note that the value specified by this option is also used by the 3-d divergence damping
mechanism beginning with the changes merged in 80a1fa0.