### PR TITLE
Bug fix to character kind in argument to column warnings subroutine

### DIFF
--- a/src/core_cice/column/REVISION
+++ b/src/core_cice/column/REVISION
@@ -1,1 +1,2 @@
 r1179
+Includes bug fix that will need to be put back in CICE repository

--- a/src/core_cice/column/ice_colpkg.F90
+++ b/src/core_cice/column/ice_colpkg.F90
@@ -5623,7 +5623,7 @@
              get_number_warnings, &
              get_warning
 
-        character(len=*), dimension(:), allocatable, intent(out) :: &
+        character(len=char_len_long), dimension(:), allocatable, intent(out) :: &
              warningsOut
 
         integer :: &


### PR DESCRIPTION

Bug fix to character kind in argument to column warnings subroutine