### PR TITLE
Initialize garbage elements for ke_edge and ke_vertex in atm_mpas_init_block

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -342,7 +342,9 @@ module atm_core
       call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
 
       allocate(ke_vertex(nVertLevels,nVertices+1))  ! ke_vertex is a module variable defined in mpas_atm_time_integration.F
+      ke_vertex(:,nVertices+1) = 0.0_RKIND
       allocate(ke_edge(nVertLevels,nEdges+1))       ! ke_edge is a module variable defined in mpas_atm_time_integration.F
+      ke_edge(:,nEdges+1) = 0.0_RKIND
 
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 


### PR DESCRIPTION
This merge adds initialization of the garbage element for ke_edge and ke_vertex
after their allocation in atm_mpas_init_block.

The arrays ke_edge and ke_vertex must be allocated outside the threaded calls
to the routine atm_compute_solve_diagnostics. The garbage elements of these
arrays are initialized to zero when the arrays are allocated in atm_srk3, but
the atm_compute_solve_diagnostics routine is also called from
atm_mpas_init_block, where these arrays are also allocated and the garbage
elements are not initialized; this can cause an otherwise harmless FPE.