### PR TITLE
Make log manager flush messages by default

### DIFF
--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -504,7 +504,7 @@ module mpas_log
 
       ierr = 0
 
-      flushLog = .false.
+      flushLog = .true.
 
       if (present(messageType)) then
          messageTypeHere = messageType


### PR DESCRIPTION
Currently, messages from the log module are buffered by default and a
flush is only forced if the flushNow optional argument is true.  In
practice, it has been found that the buffered output leads to confusion
during debugging or interpreting model output, because the log contents 
cannot be relied to be current (or complete if the model dies).

This merge makes the flushNow argument true by default (which
reproduces the flush behavior of the old log.*.err files).  This
behavior can still be overridden to suppress flushing by setting the
optional argument to false.  (For example if a large set of messages are
to be written at once.)