### PR TITLE
Add gitignore file for python compiled modules in sea ice testing

### DIFF
--- a/testing_and_setup/seaice/testing/.gitignore
+++ b/testing_and_setup/seaice/testing/.gitignore
@@ -1,0 +1,2 @@
+# python compiled modules
+*.pyc


### PR DESCRIPTION
Add gitignore file for python compiled modules (.pyc) in sea ice testing

