### PR TITLE
core LI: Minor updates to Registry and velocity interface header

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -478,6 +478,7 @@
 			<var name="cellMask"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>
+			<var name="floatingBasalMassBal"/>
 			<!-- normalVelocity is needed for advection on the next timestep -->
 			<var name="normalVelocity"/>
 			<!-- uReconstructX/Y are only needed for exact restarts of HO iterative solvers -->

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -27,6 +27,7 @@
 //! Includes
 // ===================================================
 //#include <boost/program_options.hpp>
+#include <cstring>
 #include <vector>
 #include <mpi.h>
 #include <list>


### PR DESCRIPTION
This PR adds:

- the 'floatingBasalMassBal' field to the restart stream in Registry.xml

- one missing include statement to the header file for the interface to the velocity solver

