### PR TITLE
Added missing deallocate statement for nEdgesOnCellField

### DIFF
--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -392,8 +392,9 @@ module mpas_bootstrapping
       call mpas_deallocate_field(indexToCellIDField)
       call mpas_deallocate_field(indexToEdgeIDField)
       call mpas_deallocate_field(indexToVertexIDField)
-      call mpas_deallocate_field(cellsOnCellField)
 
+      call mpas_deallocate_field(nEdgesOnCellField)
+      call mpas_deallocate_field(cellsOnCellField)
       call mpas_deallocate_field(edgesOnCellField)
       call mpas_deallocate_field(verticesOnCellField)
       call mpas_deallocate_field(cellsOnEdgeField)


### PR DESCRIPTION
The field "nEdgesOnCellField" is not deallocated at the end of mpas_bootstrap_framework_phase1. It should be deallocated like all other fields cellsOnCellField etc.

The deallocate statements are slightly regrouped following the logic of the code.