### PR TITLE
Bug in mpas_io_streams.F: real3dField is queried for a real4dField

### DIFF
--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -3074,7 +3074,7 @@ module mpas_io_streams
 
                else
    
-                  if (field_cursor % real3dField % isVarArray) then
+                  if (field_cursor % real4dField % isVarArray) then
                      call mpas_dmpar_bcast_reals( mpas_io_handle_dminfo(stream % fileHandle), size(real3d_temp), real3d_temp(:,1,1))
                      field_4dreal_ptr => field_cursor % real4dField
                      do while (associated(field_4dreal_ptr))


### PR DESCRIPTION
In mpas_io_streams.F, field_cursor % real3dField % isVarArray is queried in one place for a 4d real field. The correct behaviour would be to query field_cursor % real4dField % isVarArray.

Apparently, we do not meet the section of the code at present, hence this error never came up. The code should probably crash if we did.
