### PR TITLE
Remove reference to mpas_constants from LI core

### DIFF
--- a/src/core_landice/mode_forward/mpas_li_advection.F
+++ b/src/core_landice/mode_forward/mpas_li_advection.F
@@ -22,7 +22,6 @@ module li_advection
 
    use mpas_derived_types
    use mpas_pool_routines
-   use mpas_constants
    use mpas_log
 
    use li_setup

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -23,7 +23,6 @@ module li_calving
 
    use mpas_derived_types
    use mpas_pool_routines
-   use mpas_constants
    use mpas_dmpar
    use mpas_log
 

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -10,11 +10,12 @@ module li_core_interface
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_dmpar
-   use mpas_constants
    use mpas_attlist
    use mpas_log
+
    use li_core
    use li_analysis_driver
+   use li_constants
 
    public
 

--- a/src/core_landice/mode_forward/mpas_li_diagnostic_vars.F
+++ b/src/core_landice/mode_forward/mpas_li_diagnostic_vars.F
@@ -370,8 +370,6 @@ contains
 !>  All options are adjusted by the enhancement factor (which defaults to 1.0).
 !-----------------------------------------------------------------------
    subroutine li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err)
-      use mpas_constants, only: gravity
-      use li_constants, only: idealGasConstant
 
       !-----------------------------------------------------------------
       !

--- a/src/core_landice/mode_forward/mpas_li_sia.F
+++ b/src/core_landice/mode_forward/mpas_li_sia.F
@@ -227,11 +227,11 @@ contains
 !-----------------------------------------------------------------------
    subroutine li_sia_solve(meshPool, geometryPool, thermalPool, velocityPool, err)
 
-      use mpas_constants, only: gravity
       use mpas_vector_operations, only: mpas_tangential_vector_1d
       use mpas_geometry_utils, only: mpas_cells_to_points_using_baryweights
 
       use li_setup, only: li_cells_to_vertices_1dfield_using_kiteAreas
+      use li_constants, only: gravity
       use li_thermal
       use li_diagnostic_vars
 

--- a/src/core_landice/mode_forward/mpas_li_statistics.F
+++ b/src/core_landice/mode_forward/mpas_li_statistics.F
@@ -23,7 +23,6 @@
 module li_statistics
 
    use mpas_derived_types
-   use mpas_constants
    use mpas_dmpar
    use mpas_timer
    use mpas_log

--- a/src/core_landice/mode_forward/mpas_li_time_integration.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration.F
@@ -23,7 +23,6 @@ module li_time_integration
 
    use mpas_derived_types
    use mpas_pool_routines
-   use mpas_constants
    use mpas_timekeeping
    use mpas_log
 

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -23,7 +23,6 @@ module li_time_integration_fe
 
    use mpas_derived_types
    use mpas_pool_routines
-   use mpas_constants
    use mpas_dmpar
    use mpas_timer
    use mpas_vector_reconstruction
@@ -34,6 +33,7 @@ module li_time_integration_fe
    use li_thermal, only: li_thermal_solver, li_basal_melt_floating_ice
    use li_diagnostic_vars
    use li_setup
+   use li_constants
 
    implicit none
    private

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -24,7 +24,6 @@ module li_velocity_external
 
    use li_setup
    use, intrinsic :: iso_c_binding
-   use mpas_constants, only: gravity
    use li_constants
 
    implicit none


### PR DESCRIPTION
All references have been replaced with use statements for the
li_constants module.

This is to allow the framework mpas_constants module to eventually be removed.