### PR TITLE
correct del2 scaling from dx^3 to dx

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -354,7 +354,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             meshScalingDel2(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                   / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
+                                   / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
             meshScalingDel4(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
                                    / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
             meshScaling(iEdge)     = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &


### PR DESCRIPTION
Previously, the momentum del2 operator did not work, and would fail at normal time steps.  The scaling on mesh size was copied from the del4 operator, and was incorrect. Simulations with this fix can run with del2 values of up to 1e4 with normal time steps, on an EC60to30 mesh.

Fixes #1371
