### PR TITLE
Rayleigh damping in bottom layer

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -423,15 +423,19 @@
 	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
 		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false." units="unitless"
-					description="If true, Rayleigh friction is included in the momentum equation."
+					description="If true, Rayleigh friction is included in the momentum equation at every depth level."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_Rayleigh_friction_bottom_only" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_Rayleigh_damping_coeff" type="real" default_value="1.0e-4" units="s^{-1}"
+					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_Rayleigh_bottom_friction" type="logical" default_value=".false." units="unitless"
 					description="If true, Rayleigh friction is only applied to the bottom"
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_Rayleigh_damping_coeff" type="real" default_value="0.0" units="s^{-1}"
-					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$."
+		<nml_option name="config_Rayleigh_bottom_damping_coeff" type="real" default_value="1.0e-4" units="s^{-1}"
+					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, only applied at the bottom."
 					possible_values="Any positive real value."
 		/>
 	</nml_record>

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_rayleigh.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_rayleigh.F
@@ -50,8 +50,8 @@ module ocn_vel_forcing_rayleigh
    !
    !--------------------------------------------------------------------
 
-   logical :: rayleighFrictionOn, rayleighFrictionBottomOnly
-   real (kind=RKIND) :: rayleighDampingCoef
+   logical :: rayleighFrictionOn, rayleighBottomFrictionOn
+   real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef
 
 
 !***********************************************************************
@@ -131,23 +131,25 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
-      if ( rayleighFrictionBottomOnly ) then
+      if ( rayleighFrictionOn ) then
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1, nEdges
+           do k = 1, maxLevelEdgeTop(iEdge)
+
+              tend(k,iEdge) = tend(k,iEdge) - rayleighDampingCoef * normalVelocity(k,iEdge)
+
+           enddo
+         enddo
+         !$omp end do
+      endif
+
+      if ( rayleighBottomFrictionOn ) then
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
 
            k = maxLevelEdgeTop(iEdge)
            tend(k,iEdge) = tend(k,iEdge) - rayleighDampingCoef * normalVelocity(k,iEdge)
 
-         enddo
-         !$omp end do
-      else ! not rayleighFrictionBottomOnly
-         !$omp do schedule(runtime) private(k)
-         do iEdge = 1, nEdges
-           do k = 1, maxLevelEdgeTop(iEdge)
-   
-              tend(k,iEdge) = tend(k,iEdge) - rayleighDampingCoef * normalVelocity(k,iEdge)
-   
-           enddo
          enddo
          !$omp end do
       endif
@@ -183,21 +185,28 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
-      logical, pointer :: config_Rayleigh_friction, config_Rayleigh_friction_bottom_only
-      real (kind=RKIND), pointer :: config_Rayleigh_damping_coeff
+      logical, pointer :: config_Rayleigh_friction, config_Rayleigh_bottom_friction
+      real (kind=RKIND), pointer :: config_Rayleigh_damping_coeff, config_Rayleigh_bottom_damping_coeff
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_friction', config_Rayleigh_friction)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_bottom_friction', config_Rayleigh_bottom_friction)
       call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_damping_coeff', config_Rayleigh_damping_coeff)
-      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_friction_bottom_only', config_Rayleigh_friction_bottom_only)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_bottom_damping_coeff', config_Rayleigh_bottom_damping_coeff)
 
       rayleighDampingCoef = 0.0_RKIND
 
       if (config_Rayleigh_friction) then
           rayleighFrictionOn = .true.
-          rayleighFrictionBottomOnly = config_Rayleigh_friction_bottom_only
           rayleighDampingCoef = config_Rayleigh_damping_coeff
+      endif
+
+      rayleighBottomDampingCoef = 0.0_RKIND
+
+      if (config_Rayleigh_bottom_friction) then
+          rayleighBottomFrictionOn = .true.
+          rayleighBottomDampingCoef = config_Rayleigh_bottom_damping_coeff
       endif
 
    !--------------------------------------------------------------------


### PR DESCRIPTION
Add option to apply Rayleigh damping in just the bottom layer.  This is not an option we plan to use regularly, and it is off by default.  It was added because it proved useful for testing ideas about the bottom drag implementation, so may be used in future testing.
