### PR TITLE
Fix thread race condition corrupting output of mpas native timer

### DIFF
--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -123,6 +123,7 @@
 #endif
 
 #ifdef MPAS_NATIVE_TIMERS
+             call mpas_threading_barrier()
              if ( threadNum == 0 ) then
                 setup_timer = .false.
    


### PR DESCRIPTION
This is about the second issue mentioned by @mark-petersen in #1289

I noticed around 6 months ago that when running with 2+ threads, certain timer phases in the timer report have obviously incorrect results. Max/total/Average times orders of magnitudes larger than the actual run time, or often overflowing the format and just ***********'s for output. I took a quick look, didn't see an obvious problem, and moved on because the timers are just a convenience.

I returned to this problem recently while I wait for my more important PR's to worm through the sausage factory.

It's not a problem with the reduction; the corruption happens when a very large time value is added, and only the first call to start/stop('noun') has the corrupt value. The master thread is always correct, other threads may have the problem. Running 30to10 with 8k ranks, ranks will randomly have the corruption with a probability of ~0.02.

It's fixed by adding a thread barrier before the start timer master-only code block that looks for timer tree nodes and creates new ones if not found. I can't explicitly explain why. It's related to the master thread falling behind the others such as two timer calls being separated by only a block of master only code, which explains why only certain report lines can have the problem. 

Non-master threads call for wtime for start_time(:) and somehow the master thread setup_timer conditional then overwrites it to zero. Because times are relative to an epoc, 1.5 billion - 0 = 1.5 billion and that's where the absurd value comes from. I was able to confirm that the setup_timer(noun) correctly triggers once for each noun.

This problem itself is still only convenience, but it suggests there could be similar threading problems lurking in other systems that are just as difficult to analyze but without obvious ******* warning flags. A cell field incorrectly being initilized to 0 when it should be 0.048 at the first time step is not going to be obvious when looking at the outcome.

Another concern is, much as surrounding code impacts a race in the timers, the thread barriers inside timer calls could be necessary for correct behavior in surrounding code. Running with timers turned off could expose new race conditions.

This is only a bug fix. It will perform a tiny bit slower because there's one more thread barrier per start_timer call.